### PR TITLE
Drop class name analogies favoring technical names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,5 +130,8 @@ dmypy.json
 
 .DS_Store
 
-# Specific to this project
+## Specific to this project
 bin/cns
+# ignore generated data of the examples
+examples/recipes/scoring/step_1
+examples/recipes/scoring/topology

--- a/bin/haddock3.py
+++ b/bin/haddock3.py
@@ -5,7 +5,7 @@ import logging
 import sys
 from haddock.version import CURRENT_VERSION
 from haddock.cli import greeting, adieu
-from haddock.cooking import Chef
+from haddock.workflow import WorkflowManager
 from haddock.error import HaddockError
 
 
@@ -30,7 +30,8 @@ def main(args=None):
                         help="The input recipe file name")
     # Version
     parser.add_argument("-V", "-v", "--version", help="show version",
-                        action="version", version="%s %s" % (parser.prog, CURRENT_VERSION))
+                        action="version",
+                        version="%s %s" % (parser.prog, CURRENT_VERSION))
 
     # Special case only using print instead of logging
     options = parser.parse_args()
@@ -39,15 +40,17 @@ def main(args=None):
 
     # Configuring logging
     logging.basicConfig(level=options.log_level,
-                        format="[%(asctime)s] %(levelname)s - %(name)s: %(message)s",
+                        format=("[%(asctime)s] %(levelname)s - "
+                                "%(name)s: %(message)s"),
                         datefmt="%d/%m/%Y %H:%M:%S")
 
     try:
         # Let the chef work
-        chef = Chef(recipe_path=options.recipe.name, start=options.restart)
+        workflow = WorkflowManager(recipe_path=options.recipe.name,
+                                   start=options.restart)
 
         # Main loop of execution
-        chef.cook()
+        workflow.run()
 
     except HaddockError as he:
         logging.error(he)

--- a/examples/recipes/scoring/scoring.toml
+++ b/examples/recipes/scoring/scoring.toml
@@ -8,7 +8,7 @@ order = ["topology", "scoring"]
 
 #####################################################################-1
 [stage.topology]
-flavour = "default"
+mode = "default"
 autohis = true
 
 # Definition of the input molecules:
@@ -18,5 +18,5 @@ file = "T161-rescoring-5.pdb"
 
 #####################################################################-2
 [stage.scoring]
-flavour = ""
+mode = ""
 

--- a/haddock/cns/engine.py
+++ b/haddock/cns/engine.py
@@ -1,13 +1,14 @@
 """Running CNS scripts"""
 import subprocess
 from haddock.error import CNSRunningError
-from haddock.parallel import CaptainHaddock
+from haddock.parallel import Scheduler
 from haddock.defaults import CNS_EXE, NUM_CORES
 
 
 class CNSJob:
     """A CNS job script"""
-    def __init__(self, input_file, output_file, cns_folder='.', cns_exec=CNS_EXE):
+    def __init__(self, input_file, output_file, cns_folder='.',
+                 cns_exec=CNS_EXE):
         """
         :param input_file: input CNS script
         :param output_file: CNS output
@@ -24,7 +25,11 @@ class CNSJob:
         with open(self.input_file) as inp:
             with open(self.output_file, 'w+') as outf:
                 env = {'RUN': self.cns_folder}
-                p = subprocess.Popen(self.cns_exec, stdin=inp, stdout=outf, close_fds=True, env=env)
+                p = subprocess.Popen(self.cns_exec,
+                                     stdin=inp,
+                                     stdout=outf,
+                                     close_fds=True,
+                                     env=env)
                 out, error = p.communicate()
                 p.kill()
                 if error:
@@ -45,5 +50,5 @@ class CNSEngine:
 
     def run(self):
         """Run all provided jobs"""
-        captain = CaptainHaddock(self.jobs, self.num_cores)
-        captain.drink()
+        scheduler = Scheduler(self.jobs, self.num_cores)
+        scheduler.execute()

--- a/haddock/cns/topology.py
+++ b/haddock/cns/topology.py
@@ -16,24 +16,31 @@ def get_topology_header(protonation=None):
     axis = load_axis(Default.AXIS)
     water_box = load_waterbox(Default.WATER_BOX['boxtyp20'])
 
-    return param, top, link, topology_protonation, trans_vec, tensor, scatter, axis, water_box
+    return (param, top, link, topology_protonation, trans_vec, tensor, scatter,
+            axis, water_box)
 
 
-def generate_topology(input_pdb, course_path, recipe_str, defaults, protonation=None):
+def generate_topology(input_pdb, course_path, recipe_str, defaults,
+                      protonation=None):
     """Generate a HADDOCK topology file from input_pdb"""
     general_param = load_recipe_params(defaults)
 
-    param, top, link, topology_protonation, trans_vec, tensor, scatter, axis, water_box = get_topology_header(protonation)
+    param, top, link, topology_protonation, \
+        trans_vec, tensor, scatter, \
+        axis, water_box = get_topology_header(protonation)
 
     abs_path = input_pdb.resolve().parent.absolute()
-    output_pdb_filename = abs_path / f'{input_pdb.stem}_haddock{input_pdb.suffix}'
-    output_psf_filename = abs_path / f'{input_pdb.stem}_haddock.{Format.TOPOLOGY}'
+    output_pdb_filename = abs_path / (f'{input_pdb.stem}_'
+                                      f'haddock{input_pdb.suffix}')
+    output_psf_filename = abs_path / (f'{input_pdb.stem}_'
+                                      f'haddock.{Format.TOPOLOGY}')
     output = prepare_output(output_psf_filename, output_pdb_filename)
 
     input_str = prepare_input(str(input_pdb.resolve().absolute()), course_path)
 
-    inp = general_param + param + top + input_str + output + link + topology_protonation \
-        + trans_vec + tensor + scatter + axis + water_box + recipe_str
+    inp = general_param + param + top + input_str + output + link \
+        + topology_protonation + trans_vec + tensor + scatter + axis \
+        + water_box + recipe_str
 
     output_inp_filename = abs_path / f'{input_pdb.stem}.{Format.CNS_INPUT}'
     with open(output_inp_filename, 'w') as output_handler:
@@ -45,8 +52,10 @@ def generate_topology(input_pdb, course_path, recipe_str, defaults, protonation=
 def prepare_output(output_psf_filename, output_pdb_filename):
     """Output of the CNS file"""
     output = f'{linesep}! Output structure{linesep}'
-    output += f"eval ($output_psf_filename= \"{output_psf_filename}\"){linesep}"
-    output += f"eval ($output_pdb_filename= \"{output_pdb_filename}\"){linesep}"
+    output += ("eval ($output_psf_filename="
+               f" \"{output_psf_filename}\"){linesep}")
+    output += ("eval ($output_pdb_filename="
+               f" \"{output_pdb_filename}\"){linesep}")
     return output
 
 
@@ -72,10 +81,12 @@ def load_protonation_state(protononation):
 
             hise_str = ''
             for e in [(i + 1, c + 1, r) for c, r in enumerate(hise_l)]:
-                hise_str += f'eval ($toppar.hise_resid_{e[0]}_{e[1]} = {e[2]}){linesep}'
+                hise_str += (f'eval ($toppar.hise_resid_{e[0]}_{e[1]}'
+                             f' = {e[2]}){linesep}')
             hisd_str = ''
             for e in [(i + 1, c + 1, r) for c, r in enumerate(hisd_l)]:
-                hisd_str += f'eval ($toppar.hisd_resid_{e[0]}_{e[1]} = {e[2]}){linesep}'
+                hisd_str += (f'eval ($toppar.hisd_resid_{e[0]}_{e[1]}'
+                             f' = {e[2]}){linesep}')
 
             protonation_header += hise_str
             protonation_header += hisd_str

--- a/haddock/defaults.py
+++ b/haddock/defaults.py
@@ -38,108 +38,11 @@ class Default:
     LINK_FILE = data_path / "toppar/protein-allhdg5-4-noter.link"
 
     TRANSLATION_VECTORS = {
-        "trans_vector_0": (data_path /
-                           "toppar/initial_positions/trans_vector_0"),
-        "trans_vector_1": (data_path /
-                           "toppar/initial_positions/trans_vector_1"),
-        "trans_vector_2": (data_path /
-                           "toppar/initial_positions/trans_vector_2"),
-        "trans_vector_3": (data_path /
-                           "toppar/initial_positions/trans_vector_3"),
-        "trans_vector_4": (data_path /
-                           "toppar/initial_positions/trans_vector_4"),
-        "trans_vector_5": (data_path /
-                           "toppar/initial_positions/trans_vector_5"),
-        "trans_vector_6": (data_path /
-                           "toppar/initial_positions/trans_vector_6"),
-        "trans_vector_7": (data_path /
-                           "toppar/initial_positions/trans_vector_7"),
-        "trans_vector_8": (data_path /
-                           "toppar/initial_positions/trans_vector_8"),
-        "trans_vector_9": (data_path /
-                           "toppar/initial_positions/trans_vector_9"),
-        "trans_vector_10": (data_path /
-                            "toppar/initial_positions/trans_vector_10"),
-        "trans_vector_11": (data_path /
-                            "toppar/initial_positions/trans_vector_11"),
-        "trans_vector_12": (data_path /
-                            "toppar/initial_positions/trans_vector_12"),
-        "trans_vector_13": (data_path /
-                            "toppar/initial_positions/trans_vector_13"),
-        "trans_vector_14": (data_path /
-                            "toppar/initial_positions/trans_vector_14"),
-        "trans_vector_15": (data_path /
-                            "toppar/initial_positions/trans_vector_15"),
-        "trans_vector_16": (data_path /
-                            "toppar/initial_positions/trans_vector_16"),
-        "trans_vector_17": (data_path /
-                            "toppar/initial_positions/trans_vector_17"),
-        "trans_vector_18": (data_path /
-                            "toppar/initial_positions/trans_vector_18"),
-        "trans_vector_19": (data_path /
-                            "toppar/initial_positions/trans_vector_19"),
-        "trans_vector_20": (data_path /
-                            "toppar/initial_positions/trans_vector_20"),
-        "trans_vector_21": (data_path /
-                            "toppar/initial_positions/trans_vector_21"),
-        "trans_vector_22": (data_path /
-                            "toppar/initial_positions/trans_vector_22"),
-        "trans_vector_23": (data_path /
-                            "toppar/initial_positions/trans_vector_23"),
-        "trans_vector_24": (data_path /
-                            "toppar/initial_positions/trans_vector_24"),
-        "trans_vector_25": (data_path /
-                            "toppar/initial_positions/trans_vector_25"),
-        "trans_vector_26": (data_path /
-                            "toppar/initial_positions/trans_vector_26"),
-        "trans_vector_27": (data_path /
-                            "toppar/initial_positions/trans_vector_27"),
-        "trans_vector_28": (data_path /
-                            "toppar/initial_positions/trans_vector_28"),
-        "trans_vector_29": (data_path /
-                            "toppar/initial_positions/trans_vector_29"),
-        "trans_vector_30": (data_path /
-                            "toppar/initial_positions/trans_vector_30"),
-        "trans_vector_31": (data_path /
-                            "toppar/initial_positions/trans_vector_31"),
-        "trans_vector_32": (data_path /
-                            "toppar/initial_positions/trans_vector_32"),
-        "trans_vector_33": (data_path /
-                            "toppar/initial_positions/trans_vector_33"),
-        "trans_vector_34": (data_path /
-                            "toppar/initial_positions/trans_vector_34"),
-        "trans_vector_35": (data_path /
-                            "toppar/initial_positions/trans_vector_35"),
-        "trans_vector_36": (data_path /
-                            "toppar/initial_positions/trans_vector_36"),
-        "trans_vector_37": (data_path /
-                            "toppar/initial_positions/trans_vector_37"),
-        "trans_vector_38": (data_path /
-                            "toppar/initial_positions/trans_vector_38"),
-        "trans_vector_39": (data_path /
-                            "toppar/initial_positions/trans_vector_39"),
-        "trans_vector_40": (data_path /
-                            "toppar/initial_positions/trans_vector_40"),
-        "trans_vector_41": (data_path /
-                            "toppar/initial_positions/trans_vector_41"),
-        "trans_vector_42": (data_path /
-                            "toppar/initial_positions/trans_vector_42"),
-        "trans_vector_43": (data_path /
-                            "toppar/initial_positions/trans_vector_43"),
-        "trans_vector_44": (data_path /
-                            "toppar/initial_positions/trans_vector_44"),
-        "trans_vector_45": (data_path /
-                            "toppar/initial_positions/trans_vector_45"),
-        "trans_vector_46": (data_path /
-                            "toppar/initial_positions/trans_vector_46"),
-        "trans_vector_47": (data_path /
-                            "toppar/initial_positions/trans_vector_47"),
-        "trans_vector_48": (data_path /
-                            "toppar/initial_positions/trans_vector_48"),
-        "trans_vector_49": (data_path /
-                            "toppar/initial_positions/trans_vector_49"),
-        "trans_vector_50": (data_path /
-                            "toppar/initial_positions/trans_vector_50")
+        f"trans_vector_{i}": Path(data_path,
+                                  'toppar',
+                                  'initial_positions',
+                                  f'trans_vector_{i}')
+        for i in range(51)
     }
 
     TENSORS = {

--- a/haddock/defaults.py
+++ b/haddock/defaults.py
@@ -13,7 +13,8 @@ if not CNS_EXE:
 # Number of cores to use
 NUM_CORES = int(os.getenv("HADDOCK3_NUM_CORES", multiprocessing.cpu_count()))
 
-# Module input and generated data will be stored in folder starting by this prefix
+# Module input and generated data will be stored in folder starting by
+#  this prefix
 MODULE_PATH_NAME = "step_"
 
 # Default name for exchange module information file
@@ -37,57 +38,108 @@ class Default:
     LINK_FILE = data_path / "toppar/protein-allhdg5-4-noter.link"
 
     TRANSLATION_VECTORS = {
-        "trans_vector_0": data_path / "toppar/initial_positions/trans_vector_0",
-        "trans_vector_1": data_path / "toppar/initial_positions/trans_vector_1",
-        "trans_vector_2": data_path / "toppar/initial_positions/trans_vector_2",
-        "trans_vector_3": data_path / "toppar/initial_positions/trans_vector_3",
-        "trans_vector_4": data_path / "toppar/initial_positions/trans_vector_4",
-        "trans_vector_5": data_path / "toppar/initial_positions/trans_vector_5",
-        "trans_vector_6": data_path / "toppar/initial_positions/trans_vector_6",
-        "trans_vector_7": data_path / "toppar/initial_positions/trans_vector_7",
-        "trans_vector_8": data_path / "toppar/initial_positions/trans_vector_8",
-        "trans_vector_9": data_path / "toppar/initial_positions/trans_vector_9",
-        "trans_vector_10": data_path / "toppar/initial_positions/trans_vector_10",
-        "trans_vector_11": data_path / "toppar/initial_positions/trans_vector_11",
-        "trans_vector_12": data_path / "toppar/initial_positions/trans_vector_12",
-        "trans_vector_13": data_path / "toppar/initial_positions/trans_vector_13",
-        "trans_vector_14": data_path / "toppar/initial_positions/trans_vector_14",
-        "trans_vector_15": data_path / "toppar/initial_positions/trans_vector_15",
-        "trans_vector_16": data_path / "toppar/initial_positions/trans_vector_16",
-        "trans_vector_17": data_path / "toppar/initial_positions/trans_vector_17",
-        "trans_vector_18": data_path / "toppar/initial_positions/trans_vector_18",
-        "trans_vector_19": data_path / "toppar/initial_positions/trans_vector_19",
-        "trans_vector_20": data_path / "toppar/initial_positions/trans_vector_20",
-        "trans_vector_21": data_path / "toppar/initial_positions/trans_vector_21",
-        "trans_vector_22": data_path / "toppar/initial_positions/trans_vector_22",
-        "trans_vector_23": data_path / "toppar/initial_positions/trans_vector_23",
-        "trans_vector_24": data_path / "toppar/initial_positions/trans_vector_24",
-        "trans_vector_25": data_path / "toppar/initial_positions/trans_vector_25",
-        "trans_vector_26": data_path / "toppar/initial_positions/trans_vector_26",
-        "trans_vector_27": data_path / "toppar/initial_positions/trans_vector_27",
-        "trans_vector_28": data_path / "toppar/initial_positions/trans_vector_28",
-        "trans_vector_29": data_path / "toppar/initial_positions/trans_vector_29",
-        "trans_vector_30": data_path / "toppar/initial_positions/trans_vector_30",
-        "trans_vector_31": data_path / "toppar/initial_positions/trans_vector_31",
-        "trans_vector_32": data_path / "toppar/initial_positions/trans_vector_32",
-        "trans_vector_33": data_path / "toppar/initial_positions/trans_vector_33",
-        "trans_vector_34": data_path / "toppar/initial_positions/trans_vector_34",
-        "trans_vector_35": data_path / "toppar/initial_positions/trans_vector_35",
-        "trans_vector_36": data_path / "toppar/initial_positions/trans_vector_36",
-        "trans_vector_37": data_path / "toppar/initial_positions/trans_vector_37",
-        "trans_vector_38": data_path / "toppar/initial_positions/trans_vector_38",
-        "trans_vector_39": data_path / "toppar/initial_positions/trans_vector_39",
-        "trans_vector_40": data_path / "toppar/initial_positions/trans_vector_40",
-        "trans_vector_41": data_path / "toppar/initial_positions/trans_vector_41",
-        "trans_vector_42": data_path / "toppar/initial_positions/trans_vector_42",
-        "trans_vector_43": data_path / "toppar/initial_positions/trans_vector_43",
-        "trans_vector_44": data_path / "toppar/initial_positions/trans_vector_44",
-        "trans_vector_45": data_path / "toppar/initial_positions/trans_vector_45",
-        "trans_vector_46": data_path / "toppar/initial_positions/trans_vector_46",
-        "trans_vector_47": data_path / "toppar/initial_positions/trans_vector_47",
-        "trans_vector_48": data_path / "toppar/initial_positions/trans_vector_48",
-        "trans_vector_49": data_path / "toppar/initial_positions/trans_vector_49",
-        "trans_vector_50": data_path / "toppar/initial_positions/trans_vector_50"
+        "trans_vector_0": (data_path /
+                           "toppar/initial_positions/trans_vector_0"),
+        "trans_vector_1": (data_path /
+                           "toppar/initial_positions/trans_vector_1"),
+        "trans_vector_2": (data_path /
+                           "toppar/initial_positions/trans_vector_2"),
+        "trans_vector_3": (data_path /
+                           "toppar/initial_positions/trans_vector_3"),
+        "trans_vector_4": (data_path /
+                           "toppar/initial_positions/trans_vector_4"),
+        "trans_vector_5": (data_path /
+                           "toppar/initial_positions/trans_vector_5"),
+        "trans_vector_6": (data_path /
+                           "toppar/initial_positions/trans_vector_6"),
+        "trans_vector_7": (data_path /
+                           "toppar/initial_positions/trans_vector_7"),
+        "trans_vector_8": (data_path /
+                           "toppar/initial_positions/trans_vector_8"),
+        "trans_vector_9": (data_path /
+                           "toppar/initial_positions/trans_vector_9"),
+        "trans_vector_10": (data_path /
+                            "toppar/initial_positions/trans_vector_10"),
+        "trans_vector_11": (data_path /
+                            "toppar/initial_positions/trans_vector_11"),
+        "trans_vector_12": (data_path /
+                            "toppar/initial_positions/trans_vector_12"),
+        "trans_vector_13": (data_path /
+                            "toppar/initial_positions/trans_vector_13"),
+        "trans_vector_14": (data_path /
+                            "toppar/initial_positions/trans_vector_14"),
+        "trans_vector_15": (data_path /
+                            "toppar/initial_positions/trans_vector_15"),
+        "trans_vector_16": (data_path /
+                            "toppar/initial_positions/trans_vector_16"),
+        "trans_vector_17": (data_path /
+                            "toppar/initial_positions/trans_vector_17"),
+        "trans_vector_18": (data_path /
+                            "toppar/initial_positions/trans_vector_18"),
+        "trans_vector_19": (data_path /
+                            "toppar/initial_positions/trans_vector_19"),
+        "trans_vector_20": (data_path /
+                            "toppar/initial_positions/trans_vector_20"),
+        "trans_vector_21": (data_path /
+                            "toppar/initial_positions/trans_vector_21"),
+        "trans_vector_22": (data_path /
+                            "toppar/initial_positions/trans_vector_22"),
+        "trans_vector_23": (data_path /
+                            "toppar/initial_positions/trans_vector_23"),
+        "trans_vector_24": (data_path /
+                            "toppar/initial_positions/trans_vector_24"),
+        "trans_vector_25": (data_path /
+                            "toppar/initial_positions/trans_vector_25"),
+        "trans_vector_26": (data_path /
+                            "toppar/initial_positions/trans_vector_26"),
+        "trans_vector_27": (data_path /
+                            "toppar/initial_positions/trans_vector_27"),
+        "trans_vector_28": (data_path /
+                            "toppar/initial_positions/trans_vector_28"),
+        "trans_vector_29": (data_path /
+                            "toppar/initial_positions/trans_vector_29"),
+        "trans_vector_30": (data_path /
+                            "toppar/initial_positions/trans_vector_30"),
+        "trans_vector_31": (data_path /
+                            "toppar/initial_positions/trans_vector_31"),
+        "trans_vector_32": (data_path /
+                            "toppar/initial_positions/trans_vector_32"),
+        "trans_vector_33": (data_path /
+                            "toppar/initial_positions/trans_vector_33"),
+        "trans_vector_34": (data_path /
+                            "toppar/initial_positions/trans_vector_34"),
+        "trans_vector_35": (data_path /
+                            "toppar/initial_positions/trans_vector_35"),
+        "trans_vector_36": (data_path /
+                            "toppar/initial_positions/trans_vector_36"),
+        "trans_vector_37": (data_path /
+                            "toppar/initial_positions/trans_vector_37"),
+        "trans_vector_38": (data_path /
+                            "toppar/initial_positions/trans_vector_38"),
+        "trans_vector_39": (data_path /
+                            "toppar/initial_positions/trans_vector_39"),
+        "trans_vector_40": (data_path /
+                            "toppar/initial_positions/trans_vector_40"),
+        "trans_vector_41": (data_path /
+                            "toppar/initial_positions/trans_vector_41"),
+        "trans_vector_42": (data_path /
+                            "toppar/initial_positions/trans_vector_42"),
+        "trans_vector_43": (data_path /
+                            "toppar/initial_positions/trans_vector_43"),
+        "trans_vector_44": (data_path /
+                            "toppar/initial_positions/trans_vector_44"),
+        "trans_vector_45": (data_path /
+                            "toppar/initial_positions/trans_vector_45"),
+        "trans_vector_46": (data_path /
+                            "toppar/initial_positions/trans_vector_46"),
+        "trans_vector_47": (data_path /
+                            "toppar/initial_positions/trans_vector_47"),
+        "trans_vector_48": (data_path /
+                            "toppar/initial_positions/trans_vector_48"),
+        "trans_vector_49": (data_path /
+                            "toppar/initial_positions/trans_vector_49"),
+        "trans_vector_50": (data_path /
+                            "toppar/initial_positions/trans_vector_50")
     }
 
     TENSORS = {

--- a/haddock/modules/sampling/lightdock.py
+++ b/haddock/modules/sampling/lightdock.py
@@ -27,34 +27,43 @@ class HaddockModule(BaseHaddockModule):
         self.patch_defaults(module_information)
 
         # Get the models generated in previous step
-        models_to_score = [p for p in self.previous_io.output if p.file_type == Format.PDB]
+        models_to_score = []
+        for p in self.previous_io.output:
+            if p.file_type == Format.PDB:
+                models_to_score.append(p)
 
         # Check if multiple models are provided
         if len(models_to_score) > 1:
-            self.finish_with_error("Only one model allowed in LightDock sampling module")
+            self.finish_with_error("Only one model allowed in LightDock"
+                                   " sampling module")
 
         model = models_to_score[0]
         # Check if chain IDs are present
-        segids, chains = PDBFactory.identify_chainseg(Path(model.path) / model.file_name)
+        segids, chains = PDBFactory.identify_chainseg(Path(model.path) /
+                                                      model.file_name)
         if set(segids) != set(chains):
             logger.info("No chain IDs found, using segid information")
             PDBFactory.swap_segid_chain(Path(model.path) / model.file_name,
-                self.path / model.file_name)
+                                        self.path / model.file_name)
         else:
             # Copy original model to this working path
-            shutil.copyfile(Path(model.path) / model.file_name, self.path / model.file_name)
+            shutil.copyfile(Path(model.path) / model.file_name, self.path /
+                            model.file_name)
 
         model_with_chains = self.path / model.file_name
         # Split by chain
         new_models = PDBFactory.split_by_chain(model_with_chains)
         if model_with_chains in new_models:
-            self.finish_with_error(f"Input {model_with_chains} cannot be split by chain")
+            self.finish_with_error(f"Input {model_with_chains} cannot be"
+                                   " split by chain")
 
         # Receptor and ligand PDB structures
         rec_chain = self.defaults["params"]["receptor_chains"][0]
         lig_chain = self.defaults["params"]["ligand_chains"][0]
-        receptor_pdb_file = f"{Path(model.file_name).stem}_{rec_chain}.{Format.PDB}"
-        ligand_pdb_file = f"{Path(model.file_name).stem}_{lig_chain}.{Format.PDB}"
+        receptor_pdb_file = (f"{Path(model.file_name).stem}_"
+                             f"{rec_chain}.{Format.PDB}")
+        ligand_pdb_file = (f"{Path(model.file_name).stem}_"
+                           f"{lig_chain}.{Format.PDB}")
 
         # Setup
         logger.info("Running LightDock setup")
@@ -63,7 +72,8 @@ class HaddockModule(BaseHaddockModule):
             glowworms = self.defaults["params"]["glowworms"]
             noxt = self.defaults["params"]["noxt"]
             noh = self.defaults["params"]["noh"]
-            cmd = f"lightdock3_setup.py {receptor_pdb_file} {ligand_pdb_file} -s {swarms} -g {glowworms}"
+            cmd = (f"lightdock3_setup.py {receptor_pdb_file}"
+                   f" {ligand_pdb_file} -s {swarms} -g {glowworms}")
             if noxt:
                 cmd += " --noxt"
             if noh:
@@ -89,18 +99,24 @@ class HaddockModule(BaseHaddockModule):
             cmd = f"lgd_rank.py {swarms} {steps}"
             subprocess.call(cmd, shell=True)
 
-        # Generate top, requires a hack to use original structures (H, OXT, etc.)
+        # Generate top, requires a hack to use original structures (H, OXT,
+        #  etc.)
         logger.info("Generating top structures")
         with working_directory(self.path):
             # Save structures, needs error control
-            shutil.copyfile(self.path / receptor_pdb_file, self.path / f"tmp_{receptor_pdb_file}")
-            shutil.copyfile(self.path / ligand_pdb_file, self.path / f"tmp_{ligand_pdb_file}")
-            shutil.copy(self.path / receptor_pdb_file, self.path / f"lightdock_{receptor_pdb_file}")
-            shutil.copy(self.path / ligand_pdb_file, self.path / f"lightdock_{ligand_pdb_file}")
+            shutil.copyfile(self.path / receptor_pdb_file, self.path /
+                            f"tmp_{receptor_pdb_file}")
+            shutil.copyfile(self.path / ligand_pdb_file, self.path /
+                            f"tmp_{ligand_pdb_file}")
+            shutil.copy(self.path / receptor_pdb_file, self.path /
+                        f"lightdock_{receptor_pdb_file}")
+            shutil.copy(self.path / ligand_pdb_file, self.path /
+                        f"lightdock_{ligand_pdb_file}")
             # Create top
             steps = self.defaults["params"]["steps"]
             top = self.defaults["params"]["top"]
-            cmd = f"lgd_top.py {receptor_pdb_file} {ligand_pdb_file} rank_by_scoring.list {top}"
+            cmd = (f"lgd_top.py {receptor_pdb_file} {ligand_pdb_file}"
+                   f" rank_by_scoring.list {top}")
             subprocess.call(cmd, shell=True)
 
         # Tidy top files
@@ -110,7 +126,9 @@ class HaddockModule(BaseHaddockModule):
             file_name = f"top_{i+1}.{Format.PDB}"
             tidy_file_name = f"haddock_top_{i+1}.{Format.PDB}"
             PDBFactory.tidy(self.path / file_name, self.path / tidy_file_name)
-            expected.append(PDBFile(tidy_file_name, topology=model.topology, path=(self.path / tidy_file_name)))
+            expected.append(PDBFile(tidy_file_name,
+                                    topology=model.topology,
+                                    path=(self.path / tidy_file_name)))
 
         # Save module information
         io = ModuleIO()

--- a/haddock/modules/sampling/lightdock.py
+++ b/haddock/modules/sampling/lightdock.py
@@ -27,20 +27,17 @@ class HaddockModule(BaseHaddockModule):
         self.patch_defaults(module_information)
 
         # Get the models generated in previous step
-        models_to_score = []
-        for p in self.previous_io.output:
-            if p.file_type == Format.PDB:
-                models_to_score.append(p)
+        models_to_score = [p for p in self.previous_io.output if p.file_type == Format.PDB]
 
         # Check if multiple models are provided
         if len(models_to_score) > 1:
-            self.finish_with_error("Only one model allowed in LightDock"
-                                   " sampling module")
+            _msg = "Only one model allowed in LightDock sampling module"
+            self.finish_with_error(_msg)
 
         model = models_to_score[0]
         # Check if chain IDs are present
-        segids, chains = PDBFactory.identify_chainseg(Path(model.path) /
-                                                      model.file_name)
+        _path = Path(model.path, model.file_name)
+        segids, chains = PDBFactory.identify_chainseg(_path)
         if set(segids) != set(chains):
             logger.info("No chain IDs found, using segid information")
             PDBFactory.swap_segid_chain(Path(model.path) / model.file_name,

--- a/haddock/modules/scoring/default.py
+++ b/haddock/modules/scoring/default.py
@@ -56,10 +56,7 @@ class HaddockModule(BaseHaddockModule):
         jobs = []
 
         # Get the models generated in previous step
-        models_to_score = []
-        for p in self.previous_io.output:
-            if p.file_type == Format.PDB:
-                models_to_score.append(p)
+        models_to_score = [p for p in self.previous_io.output if p.file_type == Format.PDB]
 
         for model in models_to_score:
             scoring_filename = generate_scoring(model,

--- a/haddock/modules/scoring/default.py
+++ b/haddock/modules/scoring/default.py
@@ -20,16 +20,21 @@ def generate_scoring(model, course_path, recipe_str, defaults):
     output_pdb_filename = course_path / Path(model.file_name)
     input_abs_path = Path(model.path).resolve().absolute()
     input_pdb_filename = input_abs_path / model.file_name
-    input_psf_filename = Path(model.topology.path) / Path(model.topology.file_name)
+    input_psf_filename = (Path(model.topology.path) /
+                          Path(model.topology.file_name))
     output = f"{linesep}! Output structure{linesep}"
-    output += f"eval ($input_psf_filename= \"{input_psf_filename}\"){linesep}"
-    output += f"eval ($output_pdb_filename= \"{output_pdb_filename}\"){linesep}"
+    output += (f"eval ($input_psf_filename="
+               f" \"{input_psf_filename}\"){linesep}")
+    output += (f"eval ($output_pdb_filename="
+               f" \"{output_pdb_filename}\"){linesep}")
 
     input_str = prepare_input(str(input_pdb_filename), input_abs_path)
 
-    inp = general_param + param + top + input_str + output + topology_protonation + recipe_str
+    inp = general_param + param + top + input_str + output \
+        + topology_protonation + recipe_str
 
-    output_inp_filename = course_path / f"{Path(model.file_name).stem}.{Format.CNS_INPUT}"
+    output_inp_filename = (course_path /
+                           f"{Path(model.file_name).stem}.{Format.CNS_INPUT}")
     with open(output_inp_filename, "w") as output_handler:
         output_handler.write(inp)
 
@@ -51,11 +56,21 @@ class HaddockModule(BaseHaddockModule):
         jobs = []
 
         # Get the models generated in previous step
-        models_to_score = [p for p in self.previous_io.output if p.file_type == Format.PDB]
+        models_to_score = []
+        for p in self.previous_io.output:
+            if p.file_type == Format.PDB:
+                models_to_score.append(p)
+
         for model in models_to_score:
-            scoring_filename = generate_scoring(model, self.path, self.recipe_str, self.defaults)
-            output_filename = self.path / f"{Path(model.file_name).stem}_scoring.out"
-            jobs.append(CNSJob(scoring_filename, output_filename, cns_folder=self.cns_folder_path))
+            scoring_filename = generate_scoring(model,
+                                                self.path,
+                                                self.recipe_str,
+                                                self.defaults)
+            output_filename = (self.path /
+                               f"{Path(model.file_name).stem}_scoring.out")
+            jobs.append(CNSJob(scoring_filename,
+                               output_filename,
+                               cns_folder=self.cns_folder_path))
 
         # Run CNS engine
         logger.info(f"Running CNS engine with {len(jobs)} jobs")
@@ -70,9 +85,12 @@ class HaddockModule(BaseHaddockModule):
             abs_path = self.path / model.file_name
             if not abs_path.is_file():
                 not_found.append(model.file_name)
-            expected.append(PDBFile(model.file_name, topology=model.topology, path=abs_path))
+            expected.append(PDBFile(model.file_name,
+                                    topology=model.topology,
+                                    path=abs_path))
         if not_found:
-            self.finish_with_error(f"Several files were not generated: {not_found}")
+            self.finish_with_error("Several files were not generated:"
+                                   f" {not_found}")
 
         # Save module information
         io = ModuleIO()

--- a/haddock/modules/topology/default.py
+++ b/haddock/modules/topology/default.py
@@ -56,12 +56,19 @@ class HaddockModule(BaseHaddockModule):
                 PDBFactory.sanitize(model, overwrite=True)
 
                 # Prepare generation of topologies jobs
-                topology_filename = generate_topology(model, self.path, self.recipe_str, self.defaults)
-                logger.info(f"Topology CNS input created in {topology_filename}")
+                topology_filename = generate_topology(model,
+                                                      self.path,
+                                                      self.recipe_str,
+                                                      self.defaults)
+                logger.info("Topology CNS input created in"
+                            f" {topology_filename}")
 
                 # Add new job to the pool
-                output_filename = model.resolve().parent.absolute() / f"{model.stem}.{Format.CNS_OUTPUT}"
-                jobs.append(CNSJob(topology_filename, output_filename, cns_folder=self.cns_folder_path))
+                output_filename = (model.resolve().parent.absolute()
+                                   / f"{model.stem}.{Format.CNS_OUTPUT}")
+                jobs.append(CNSJob(topology_filename,
+                                   output_filename,
+                                   cns_folder=self.cns_folder_path))
 
             # Run CNS engine
             logger.info(f"Running CNS engine with {len(jobs)} jobs")
@@ -69,20 +76,30 @@ class HaddockModule(BaseHaddockModule):
             engine.run()
             logger.info("CNS engine has finished")
 
-            # Check for generated output, fail it not all expected files are found
+            # Check for generated output, fail it not all expected files
+            #  are found
             expected = []
             not_found = []
             for model in models:
                 model_name = model.stem
-                if not (processed_pdb := self.path / f"{model_name}_haddock.{Format.PDB}").is_file():
+                processed_pdb = (self.path /
+                                 f"{model_name}_haddock.{Format.PDB}")
+                if not processed_pdb.is_file():
                     not_found.append(processed_pdb.name)
-                if not (processed_topology := self.path / f"{model_name}_haddock.{Format.TOPOLOGY}").is_file():
+                processed_topology = (self.path /
+                                      f"{model_name}_haddock"
+                                      f".{Format.TOPOLOGY}")
+                if not processed_topology.is_file():
                     not_found.append(processed_topology.name)
-                topology = TopologyFile(processed_topology, path=(self.path / TOPOLOGY_PATH))
+                topology = TopologyFile(processed_topology,
+                                        path=(self.path / TOPOLOGY_PATH))
                 expected.append(topology)
-                expected.append(PDBFile(processed_pdb, topology, path=(self.path / TOPOLOGY_PATH)))
+                expected.append(PDBFile(processed_pdb,
+                                        topology,
+                                        path=(self.path / TOPOLOGY_PATH)))
             if not_found:
-                self.finish_with_error(f"Several files were not generated: {not_found}")
+                self.finish_with_error("Several files were not generated:"
+                                       f" {not_found}")
 
             # Save module information
             io = ModuleIO()

--- a/haddock/ontology.py
+++ b/haddock/ontology.py
@@ -1,4 +1,5 @@
-"""This module describes the Haddock3 ontology used for communicating between modules"""
+"""This module describes the Haddock3 ontology used for communicating between
+modules"""
 
 import datetime
 from os import linesep
@@ -29,7 +30,9 @@ class Persistent:
         self.path = str(Path(path).parent.absolute())
 
     def __repr__(self):
-        return f"[{self.file_type}|{self.created}] {Path(self.path) / self.file_name}"
+        rep = (f"[{self.file_type}|{self.created}] "
+               f"{Path(self.path) / self.file_name}")
+        return rep
 
 
 class PDBFile(Persistent):

--- a/haddock/parallel.py
+++ b/haddock/parallel.py
@@ -6,31 +6,36 @@ from multiprocessing import Process, cpu_count
 logger = logging.getLogger(__name__)
 
 
-class Sailor(Process):
-    """What is a captain without sailors?"""
+class Worker(Process):
+
     def __init__(self, tasks):
-        super(Sailor, self).__init__()
+        super(Worker, self).__init__()
         self.tasks = tasks
-        logger.info(f"Sailor ready with {len(self.tasks)} tasks")
+        logger.info(f"Worker ready with {len(self.tasks)} tasks")
 
     def run(self):
         for task in self.tasks:
             task.run()
-        logger.info(f"Sailor {self.name} says: Aye, Captain!")
+        logger.info(f"{self.name} executed")
 
 
-class CaptainHaddock():
-    """Aye, Captain"""
+class Scheduler():
+
     def __init__(self, tasks, num_cores=0):
         try:
             self.num_processes = int(num_cores)
+
             if self.num_processes < 1:
                 raise ValueError()
+
             if self.num_processes > cpu_count():
-                logger.warning(f"Number of cores ({self.num_processes}) larger than available.")
+                logger.warning(f"Number of cores ({self.num_processes}) larger"
+                               " than available.")
                 raise ValueError()
+
         except (ValueError, TypeError):
-            logger.warning("Number of cores has not been specified or is incorrect. Using available cores.")
+            logger.warning("Number of cores has not been specified or is"
+                           " incorrect. Using available cores.")
             self.num_processes = cpu_count()
 
         self.tasks = tasks
@@ -38,34 +43,38 @@ class CaptainHaddock():
         # Do not waste resources
         if self.num_tasks < self.num_processes:
             self.num_processes = self.num_tasks
-        logger.info(f"Captain commands {self.num_processes} sailors (cpu cores)")
+        logger.info(f"Running with {self.num_processes} cpu cores")
 
-        self.crew = []
-        crew_tasks = [tasks[i::self.num_processes] for i in range(self.num_processes)]
+        self.task_list = []
+        job_list = []
+        for i in range(self.num_processes):
+            job_list.append(tasks[i::self.num_processes])
 
         for i in range(self.num_processes):
-            sailor = Sailor(crew_tasks[i])
-            self.crew.append(sailor)
+            task = Worker(job_list[i])
+            self.task_list.append(task)
 
         logger.info(f"{self.num_tasks} tasks ready")
 
-    def drink(self):
-        """Drink up me "earties, yo ho"""
-        logger.info("Oh Captain, my Captain!")
-        try:
-            for sailor in self.crew:
-                sailor.start()
+    def execute(self):
 
-            for sailor in self.crew:
-                sailor.join()
+        try:
+            for task in self.task_list:
+                task.start()
+
+            for task in self.task_list:
+                task.join()
 
             logger.info(f"{self.num_tasks} tasks finished")
-        except KeyboardInterrupt:
-            self.mutiny()
 
-    def mutiny(self):
-        """There is a mutiny in the ship, anyone interrupted?"""
-        logger.warning("Mutiny in the ship")
-        for sailor in self.crew:
-            sailor.terminate()
-        logger.warning("The crew has stopped working")
+        except KeyboardInterrupt:
+            # Q: why have a keyboard interrupt here?
+            self.terminate()
+
+    def terminate(self):
+
+        logger.warning("Something went wrong")
+        for task in self.task_list:
+            task.terminate()
+
+        logger.warning("The workers have stopped")

--- a/haddock/pdbutil.py
+++ b/haddock/pdbutil.py
@@ -19,7 +19,10 @@ class PDBFactory:
 
     @staticmethod
     def split_ensemble(pdb_file_path):
-        """"Split a PDB file into multiple structures if different models are found"""
+        """"
+        Split a PDB file into multiple structures if different models
+            are found
+        """
         new_models = []
         abs_path = Path(pdb_file_path).resolve().parent.absolute()
         with open(pdb_file_path) as input_handler:

--- a/haddock/structure.py
+++ b/haddock/structure.py
@@ -1,7 +1,8 @@
 """Molecular data structures"""
 
+
 class Molecule:
-    """Input molecule, usually a PDB file"""
+    """Input molecule, usually a PDB file."""
     def __init__(self, file_name, segid):
         self.file_name = file_name
         self.segid = segid

--- a/haddock/version.py
+++ b/haddock/version.py
@@ -2,7 +2,7 @@
 
 MAJOR = "3"
 MINOR = "0"
-PATCH = "0"
-RELEASE = "reboot"
+PATCH = "beta"
+RELEASE = "unreleased"
 
 CURRENT_VERSION = f"{MAJOR}.{MINOR}.{PATCH}-{RELEASE}"

--- a/haddock/workflow.py
+++ b/haddock/workflow.py
@@ -65,6 +65,7 @@ class Recipe:
 
 
 class Step:
+    """Represents a step to be executed in the workflow."""
 
     def __init__(self, module_name, order, course_information, working_path):
         self.module = module_name

--- a/haddock/workflow.py
+++ b/haddock/workflow.py
@@ -1,0 +1,98 @@
+"""HADDOCK3 workflow logic"""
+import logging
+import importlib
+import shutil
+from pathlib import Path
+import toml
+from haddock.error import HaddockError, RecipeError
+from haddock.defaults import MODULE_PATH_NAME, TOPOLOGY_PATH
+
+
+logger = logging.getLogger(__name__)
+
+
+class WorkflowManager:
+    """The WorkflowManager reads the recipes and executes them."""
+    def __init__(self, recipe_path, start=0):
+        path = Path(recipe_path)
+        if not path.exists():
+            raise HaddockError(f"Recipe {recipe_path} does not exist or cannot"
+                               " be opened")
+        self.start = start
+        # Save current working path
+        self.workspace = path.parent.absolute()
+        # Create a recipe from a TOML file
+        self.recipe = Recipe(path)
+
+    def run(self):
+        """High level workflow composer"""
+        for step in self.recipe.steps[self.start:]:
+            step.execute()
+
+
+class Recipe:
+    """Represents a set of stages to be executed by HADDOCK"""
+    def __init__(self, recipe_path):
+        content = toml.load(recipe_path)
+        # Check if the order has been set
+        if 'order' not in content:
+            raise RecipeError("This recipe does not specify the order"
+                              " of execution")
+
+        logger.info(f"Recipe [{recipe_path}] contains {len(content['order'])}"
+                    " steps")
+
+        # Create the list of courses contained in this recipe
+        self.steps = []
+        for num_stage, stage in enumerate(content["order"]):
+            try:
+                logger.info(f"Reading instructions of [{stage}] step")
+                is_substage = (len(stage.split('.')) == 2)
+                if is_substage:
+                    sub_stage, sub_id = stage.split('.')
+                    self.steps.append(Step(sub_stage,
+                                           num_stage,
+                                           content["stage"][sub_stage][sub_id],
+                                           recipe_path.parent))
+                else:
+                    self.steps.append(Step(stage,
+                                           num_stage,
+                                           content["stage"][stage],
+                                           recipe_path.parent))
+            except RecipeError as re:
+                logger.error(f"Error found while parsing course {stage}")
+                raise HaddockError from re
+
+
+class Step:
+
+    def __init__(self, module_name, order, course_information, working_path):
+        self.module = module_name
+        self.order = order
+        self.raw_information = course_information
+        self.working_path = working_path
+        if "mode" in self.raw_information and self.raw_information["mode"]:
+            self.mode = self.raw_information["mode"]
+        else:
+            self.mode = "default"
+
+    def execute(self):
+        # Create course path structure
+        if self.module == "topology":
+            p = self.working_path / Path(TOPOLOGY_PATH)
+        else:
+            p = self.working_path / Path(f"{MODULE_PATH_NAME}{self.order}")
+        if p.exists():
+            logger.warning(f"Found previous run ({p}), removed")
+            shutil.rmtree(p)
+        p.absolute().mkdir(parents=True, exist_ok=False)
+
+        # Import the module given by the mode or default
+        module_name = f"haddock.modules.{self.module}.{self.mode}"
+        module_lib = importlib.import_module(module_name)
+        module = module_lib.HaddockModule(order=self.order, path=p.absolute())
+        # Remove mode information as it is already used and won't be mapped
+        self.raw_information.pop("mode", None)
+
+        # Run module
+        module.run(self.raw_information)


### PR DESCRIPTION
This is a boring PR to make the code more accessible.

I do believe analogy is a great technique to match unrelated objects in order facilitate understanding and it is seen in many large projects out there in the wild. However me and @joaomcteixeira are getting lost in the ones that were present here since they were often actually quite metaphoric. 

Additionally, since we aim the project to have a wide reach, we need to also consider code accessibility and making it more boring can increase its readability. There will still be plenty of room for creative expression later on :)

With this PR I also linted to code to comply with [E501](https://www.flake8rules.com/rules/E501.html).
In this branch there are no tests yet, so I tested it by running the examples and checking if things were working.