### PR TITLE
data_path not being found

### DIFF
--- a/haddock/defaults.py
+++ b/haddock/defaults.py
@@ -36,7 +36,6 @@ class Default:
     TOPOLOGY_FILE = data_path / "toppar/haddock.top"
 
     LINK_FILE = data_path / "toppar/protein-allhdg5-4-noter.link"
-    print(Path(data_path))
 
     TRANSLATION_VECTORS = {}
     for i in range(51):

--- a/haddock/defaults.py
+++ b/haddock/defaults.py
@@ -36,14 +36,13 @@ class Default:
     TOPOLOGY_FILE = data_path / "toppar/haddock.top"
 
     LINK_FILE = data_path / "toppar/protein-allhdg5-4-noter.link"
+    print(Path(data_path))
 
-    TRANSLATION_VECTORS = {
-        f"trans_vector_{i}": Path(data_path,
-                                  'toppar',
-                                  'initial_positions',
-                                  f'trans_vector_{i}')
-        for i in range(51)
-    }
+    TRANSLATION_VECTORS = {}
+    for i in range(51):
+        _s = f'trans_vector_{i}'
+        _p = Path(data_path, 'toppar', 'initial_positions', _s)
+        TRANSLATION_VECTORS[_s] = _p
 
     TENSORS = {
         "tensor_psf": data_path / "toppar/tensor.psf",


### PR DESCRIPTION
After #21 I got this error when running `defaults.py`.

`data_path` was not being found within dictionary comprehension in `defaults.py`.

```bash
File "/home/joao/github/haddock3/haddock/defaults.py", line 42, in <dictcomp>
    f"trans_vector_{i}": Path(data_path, 'toppar', 'initial_positions', f'trans_vector_{i}')
    NameError: name 'data_path' is not defined
```

reverting to a for-loop solves the issue. But I am really puzzled by this issue. I don't understand why `data_path` was not being found inside the dictionary comprehension. Any ideas?