### PR TITLE
renames flavour to mode missing files

### DIFF
--- a/examples/recipes/double_scoring/scoring.toml
+++ b/examples/recipes/double_scoring/scoring.toml
@@ -8,7 +8,7 @@ order = ["topology", "scoring.1", "scoring.2"]
 
 #####################################################################-1
 [stage.topology]
-flavour = "default"
+mode = "default"
 autohis = true
 
 # Definition of the input molecules:
@@ -18,10 +18,10 @@ file = "structure.pdb"
 
 #####################################################################-2
 [stage.scoring.1]
-flavour = ""
+mode = ""
 steps = 50
 
 #####################################################################-3
 [stage.scoring.2]
-flavour = ""
+mode = ""
 steps = 100

--- a/examples/recipes/full_scoring/scoring.toml
+++ b/examples/recipes/full_scoring/scoring.toml
@@ -8,7 +8,7 @@ order = ["topology", "scoring", "clustering", "analysis"]
 
 #####################################################################-1
 [stage.topology]
-flavour = "default"
+mode = "default"
 autohis = true
 
 # Definition of the input molecules:
@@ -19,7 +19,7 @@ segid = ""
 
 #####################################################################-2
 [stage.scoring]
-flavour = ""
+mode = ""
 
 #####################################################################-3
 [stage.clustering]

--- a/examples/recipes/sampling/lightdock.toml
+++ b/examples/recipes/sampling/lightdock.toml
@@ -8,7 +8,7 @@ order = ["topology", "sampling", "scoring"]
 
 #####################################################################-1
 [stage.topology]
-flavour = "default"
+mode = "default"
 autohis = true
 
 # Definition of the input molecules:
@@ -18,7 +18,7 @@ file = "2oob.pdb"
 
 #####################################################################-2
 [stage.sampling]
-flavour = "lightdock"
+mode = "lightdock"
 receptor_chains = "A"
 ligand_chains = "B"
 scoring = "fastdfire"
@@ -32,4 +32,4 @@ noh = true
 
 #####################################################################-3
 [stage.scoring]
-flavour = ""
+mode = ""


### PR DESCRIPTION
Some names `flavour` remained after #21. This broke any runs where flavour was not the `default`, for example in `lightdock`.