### PR TITLE
Correct `ln` command typo and updates `CNS_EXE` path to `bin/cns`

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ python setup.py develop --no-deps
 ### 1.3 Copy CNS binary to the expected path:
 
 ```bash
-mkdir -p bin/cns
+mkdir -p bin/
 
 # on mac
-ls -s bin/cns /PATH/TO/cns_solve-1.31-UU-MacIntel.exe
+ls -s /PATH/TO/cns_solve-1.31-UU-MacIntel.exe bin/cns 
 
 # on linux
-ls -s bin/cns /PATH/TO/CNS_FOLDER/intel-x86_64bit-linux/source/cns_solve-2002171359.exe
+ls -s /PATH/TO/CNS_FOLDER/intel-x86_64bit-linux/source/cns_solve-2002171359.exe bin/cns 
 ```
 
 ### 1.4 Activate environment variables

--- a/src/haddock/defaults.py
+++ b/src/haddock/defaults.py
@@ -1,14 +1,20 @@
 """All default parameters used by the framework"""
 import os
+import sys
 import multiprocessing
+import logging
 from pathlib import Path
-
+logger = logging.getLogger(__name__)
 
 # Locate the CNS binary
 CNS_EXE = os.getenv("HADDOCK3_CNS_EXE")
 if not CNS_EXE:
-    bin_path = Path(__file__).resolve().parent.parent.absolute()
-    CNS_EXE = bin_path / "bin/cns/cns_solve-1.31-UU-MacIntel.exe"
+    bin_path = Path(__file__).resolve().parent.parent.parent.absolute()
+    CNS_EXE = bin_path / "bin/cn"
+    if not CNS_EXE.exists():
+        logger.error('HADDOCK3_CNS_EXE not defined and bin/cns not found')
+        sys.exit()
+
 
 # Number of cores to use
 NUM_CORES = int(os.getenv("HADDOCK3_NUM_CORES", multiprocessing.cpu_count()))

--- a/src/haddock/defaults.py
+++ b/src/haddock/defaults.py
@@ -10,11 +10,10 @@ logger = logging.getLogger(__name__)
 CNS_EXE = os.getenv("HADDOCK3_CNS_EXE")
 if not CNS_EXE:
     bin_path = Path(__file__).resolve().parent.parent.parent.absolute()
-    CNS_EXE = bin_path / "bin/cn"
+    CNS_EXE = bin_path / "bin" / "cns"
     if not CNS_EXE.exists():
         logger.error('HADDOCK3_CNS_EXE not defined and bin/cns not found')
         sys.exit()
-
 
 # Number of cores to use
 NUM_CORES = int(os.getenv("HADDOCK3_NUM_CORES", multiprocessing.cpu_count()))


### PR DESCRIPTION
This updates the install instructions and change the code to look for `bin/cns` instead of `bin/cns/cns`