### PR TITLE
Add `seletop` module

### DIFF
--- a/examples/docking/docking.toml
+++ b/examples/docking/docking.toml
@@ -4,10 +4,10 @@
 # in which order the steps must be executed?
 order = ["topoaa",
          "rigidbody",
-         "clustfcc",
-         "seletopclusts",
+         "seletop",
          "flexref",
-         "mdref"]
+         "mdref",
+         "clustfcc",]
 
 # directory in which the scoring will be done
 run_dir = "run1"
@@ -31,14 +31,8 @@ autohis = true
 ambig = '../data/1a2k_ti.tbl'
 sampling = 20
 
-[clustfcc]
-contact_distance_cutoff = 5.0
-fraction_cutoff = 0.6
-threshold = 4
-
-[seletopclusts]
-top_cluster = [1, 2, 3, 4] # will select the best one
-top_models = 4 # will select the top4 models inside the cluster
+[seletop]
+select = 5
 
 [flexref]
 ambig = '../data/1a2k_ti.tbl'
@@ -47,6 +41,11 @@ cool1_steps = 500
 [mdref]
 ambig = '../data/1a2k_ti.tbl'
 cool1_steps = 10
+
+[clustfcc]
+contact_distance_cutoff = 5.0
+fraction_cutoff = 0.6
+threshold = 4
 
 # ====================================================================
 

--- a/src/haddock/modules/analysis/seletop/seletop.toml
+++ b/src/haddock/modules/analysis/seletop/seletop.toml
@@ -1,2 +1,2 @@
 [params]
-select = 400
+select = 200

--- a/src/haddock/modules/analysis/seletop/seletop.toml
+++ b/src/haddock/modules/analysis/seletop/seletop.toml
@@ -1,0 +1,2 @@
+[params]
+select = 400


### PR DESCRIPTION
For haddock to work in the **classical** way we also need a model to select the top X models from a previous stage. In the production version the rigid-body generates 1000 models, then the top 200 are selected to the next stage.

This can be done in haddock3 with the `seletop` module; it gets all the models from the previous_io and ranks them according to their score and outputs a subset equal to `select`

I also changed the docking example to reflect the default haddock protocol.