### PR TITLE
Inspect dependencies are installed for thirdparty libraries

### DIFF
--- a/install-thirdparty.md
+++ b/install-thirdparty.md
@@ -1,8 +1,18 @@
-# How to install the dependencies of the third-party modules
+HADDOCK3 is able to integrate third-party software in its workflows.
+However, we are not responsible to the proper installation of such
+packages, but we do help you to install them. In this document you will
+find a list of all third-party packages HADDOCK3 can use and guidelines
+on how to install them.
+
+
+# Installing third-party packages
 
 ## `lightdock`
 
-_pending_
+To install to [lightdock](https://github.com/lightdock/lightdock) follow
+the instructions in the project's website. Remember to install it under
+the same Python environment you created for HADDOCK3. If you have any
+doubts, please let us know.
 
 * * *
 
@@ -25,6 +35,8 @@ pip install deap scipy mgzip biopython
 export GDOCK_PATH=some-folder
 ```
 
-**Important**: These are not the full install instructions as here only the model generation is used. Please check the [repository page](https://github.com/rvhonorato/gdock) for more information.
+**Important**: These are not the full install instructions as here only
+the model generation is used. Please check the [repository
+page](https://github.com/rvhonorato/gdock) for more information.
 
 * * *

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ toml==0.10.0
 pdb-tools==2.1.0
 jsonpickle==2.0.0
 numpy==1.20.2
-lightdock==0.9.0a2

--- a/requirements.yml
+++ b/requirements.yml
@@ -10,4 +10,3 @@ dependencies:
     - jsonpickle
     - pip:
         - pdb-tools
-        - lightdock

--- a/src/haddock/__init__.py
+++ b/src/haddock/__init__.py
@@ -17,3 +17,4 @@ v_patch = "beta"
 v_release = "unreleased"
 
 current_version = f"{v_major}.{v_minor}.{v_patch}-{v_release}"
+contact_us = 'https://github.com/haddocking/haddock3/issues'

--- a/src/haddock/clis/cli.py
+++ b/src/haddock/clis/cli.py
@@ -105,9 +105,9 @@ def main(
     try:
         params, other_params = setup_run(recipe, restart_from=restart)
 
-    except ConfigurationError as err:
+    except HaddockError as err:
         logging.error(err)
-        sys.exit()
+        raise err
 
     if not setup_only:
         try:
@@ -121,6 +121,7 @@ def main(
             workflow.run()
 
         except HaddockError as err:
+            raise err
             logging.error(err)
 
     # Finish

--- a/src/haddock/core/exceptions.py
+++ b/src/haddock/core/exceptions.py
@@ -9,6 +9,10 @@ class ConfigurationError(HaddockError):
     pass
 
 
+class ModuleError(HaddockError):
+    pass
+
+
 class StepError(HaddockError):
     pass
 

--- a/src/haddock/gear/prepare_run.py
+++ b/src/haddock/gear/prepare_run.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import toml
 
-from haddock import haddock3_source_path
+from haddock import contact_us, haddock3_source_path
 from haddock.modules import modules_category
 from haddock.core.exceptions import ConfigurationError, ModuleError
 from haddock.gear.parameters import config_mandatory_general_parameters
@@ -192,8 +192,12 @@ def validate_installed_modules(params):
             module_lib.HaddockModule.confirm_installation()
         except Exception as err:
             _msg = (
-                f'There\'s a problem with module {module_name!r} '
-                'likely it is not installed.'
+                'A problem occurred when we tried to confirm if module '
+                f'{module_name!r} is installed in your system. Have you '
+                'installed the packages required to run this module? If '
+                f'yes write us at {contact_us!r} describing your system '
+                'and the problems you are facing. If not, please install '
+                'them.'
                 )
             raise ModuleError(_msg) from err
 

--- a/src/haddock/gear/prepare_run.py
+++ b/src/haddock/gear/prepare_run.py
@@ -1,4 +1,5 @@
 """Logic pertraining to preparing the run files and folders."""
+import importlib
 import logging
 import shutil
 from contextlib import contextmanager
@@ -9,7 +10,7 @@ import toml
 
 from haddock import haddock3_source_path
 from haddock.modules import modules_category
-from haddock.core.exceptions import ConfigurationError
+from haddock.core.exceptions import ConfigurationError, ModuleError
 from haddock.gear.parameters import config_mandatory_general_parameters
 from haddock.gear.restart_run import remove_folders_after_number
 from haddock.libs.libutil import (
@@ -86,6 +87,7 @@ def setup_run(workflow_path, restart_from=None):
         config_mandatory_general_parameters,
         )
     validate_modules_params(modules_params)
+    validate_installed_modules(modules_params)
 
     if restart_from is None:
         # prepares the run folders
@@ -174,6 +176,26 @@ def validate_modules_params(params):
                 f'parameters for module {module_name!r}: {diff}.'
                 )
             raise ConfigurationError(_msg)
+
+
+def validate_installed_modules(params):
+    """Validate if third party-libraries are installed"""
+    for module_name in params.keys():
+        module_import_name = '.'.join([
+            'haddock',
+            'modules',
+            modules_category[module_name],
+            module_name,
+            ])
+        module_lib = importlib.import_module(module_import_name)
+        try:
+            module_lib.HaddockModule.confirm_installation()
+        except Exception as err:
+            _msg = (
+                f'There\'s a problem with module {module_name!r} '
+                'likely it is not installed.'
+                )
+            raise ModuleError(_msg) from err
 
 
 def convert_params_to_path(params):

--- a/src/haddock/libs/libutil.py
+++ b/src/haddock/libs/libutil.py
@@ -1,7 +1,9 @@
 """General utilities."""
 import logging
 import shutil
+import subprocess
 from copy import deepcopy
+from functools import partial
 from operator import ge
 from os import cpu_count
 from pathlib import Path
@@ -10,6 +12,14 @@ from haddock.core.exceptions import SetupError
 
 
 logger = logging.getLogger(__name__)
+
+
+check_subprocess = partial(
+    subprocess.run,
+    shell=True,
+    check=True,
+    stdout=subprocess.DEVNULL,
+    )
 
 
 def get_result_or_same_in_list(function, value):

--- a/src/haddock/modules/__init__.py
+++ b/src/haddock/modules/__init__.py
@@ -83,6 +83,16 @@ class BaseHaddockModule(ABC):
     def run(self, params):
         self.update_params(**params)
 
+    @classmethod
+    @abstractmethod
+    def confirm_installation(self):
+        """
+        Confirm the third-party software needed for the module is installed.
+
+        HADDOCK3's own modules should just return.
+        """
+        return
+
     def finish_with_error(self, message=""):
         if not message:
             message = "Module has failed"

--- a/src/haddock/modules/analysis/clustfcc/__init__.py
+++ b/src/haddock/modules/analysis/clustfcc/__init__.py
@@ -3,6 +3,8 @@ import logging
 import os
 from pathlib import Path
 
+import toml
+
 from fcc.scripts import calc_fcc_matrix, cluster_fcc
 
 from haddock import FCC_path
@@ -23,6 +25,19 @@ class HaddockModule(BaseHaddockModule):
     def __init__(self, order, path, initial_params=DEFAULT_CONFIG):
         cns_script = False
         super().__init__(order, path, initial_params, cns_script)
+
+    @classmethod
+    def confirm_installation(cls):
+        dcfg = toml.load(DEFAULT_CONFIG)
+        exec_path = Path(FCC_path, dcfg['executable'])
+
+        if not os.access(exec_path, mode=os.F_OK):
+            raise Exception(f'Required {str(exec_path)} file does not exist.')
+
+        if not os.access(exec_path, mode=os.X_OK):
+            raise Exception(f'Required {str(exec_path)} file is not executable')
+
+        return
 
     def run(self, **params):
         logger.info("Running [clustfcc] module")

--- a/src/haddock/modules/analysis/seletop/__init__.py
+++ b/src/haddock/modules/analysis/seletop/__init__.py
@@ -21,6 +21,10 @@ class HaddockModule(BaseHaddockModule):
             **everything):
         super().__init__(order, path, init_params)
 
+    @classmethod
+    def confirm_installation(cls):
+        return
+
     def run(self, **params):
         logger.info("Running [seletop] module")
 

--- a/src/haddock/modules/analysis/seletopclusts/__init__.py
+++ b/src/haddock/modules/analysis/seletopclusts/__init__.py
@@ -21,6 +21,10 @@ class HaddockModule(BaseHaddockModule):
             **everything):
         super().__init__(order, path, init_params)
 
+    @classmethod
+    def confirm_installation(cls):
+        return
+
     def run(self, **params):
         logger.info("Running [seletopclusts] module")
 

--- a/src/haddock/modules/refinement/emref/__init__.py
+++ b/src/haddock/modules/refinement/emref/__init__.py
@@ -65,6 +65,10 @@ class HaddockModule(BaseHaddockModule):
         cns_script = RECIPE_PATH / "cns" / "emref.cns"
         super().__init__(order, path, initial_params, cns_script)
 
+    @classmethod
+    def confirm_installation(cls):
+        return
+
     def run(self, **params):
         logger.info("Running [emref] module")
 

--- a/src/haddock/modules/refinement/flexref/__init__.py
+++ b/src/haddock/modules/refinement/flexref/__init__.py
@@ -63,6 +63,10 @@ class HaddockModule(BaseHaddockModule):
         cns_script = RECIPE_PATH / "cns" / "flexref.cns"
         super().__init__(order, path, initial_params, cns_script)
 
+    @classmethod
+    def confirm_installation(cls):
+        return
+
     def run(self, **params):
         logger.info("Running [flexref] module")
 

--- a/src/haddock/modules/refinement/mdref/__init__.py
+++ b/src/haddock/modules/refinement/mdref/__init__.py
@@ -61,6 +61,10 @@ class HaddockModule(BaseHaddockModule):
         cns_script = RECIPE_PATH / "cns" / "mdref.cns"
         super().__init__(order, path, initial_params, cns_script)
 
+    @classmethod
+    def confirm_installation(cls):
+        return
+
     def run(self, **params):
         logger.info("Running [mdref] module")
 

--- a/src/haddock/modules/sampling/gdock/__init__.py
+++ b/src/haddock/modules/sampling/gdock/__init__.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from haddock.core.defaults import NUM_CORES
 from haddock.libs import libpdb
 from haddock.libs.libontology import Format, ModuleIO, PDBFile
+from haddock.libs.libutil import check_subprocess
 from haddock.modules import BaseHaddockModule, working_directory
 
 
@@ -18,6 +19,8 @@ logger = logging.getLogger(__name__)
 
 RECIPE_PATH = Path(__file__).resolve().parent
 DEFAULT_CONFIG = Path(RECIPE_PATH, "defaults.toml")
+
+
 
 
 def ambig2dic(ambig_f):
@@ -41,6 +44,13 @@ class HaddockModule(BaseHaddockModule):
 
     def __init__(self, order, path, initial_params=DEFAULT_CONFIG):
         super().__init__(order, path, initial_params)
+
+    @classmethod
+    def confirm_installation(cls):
+        """Confirm this module is installed."""
+        gdock_path = os.environ['GDOCK_PATH']
+        gdock_exec = Path(gdock_path, 'gdock.py')
+        check_subprocess(f'{sys.executable} {gdock_exec}')
 
     def run(self, **params):
         logger.info("Running [gdock] module")

--- a/src/haddock/modules/sampling/lightdock/__init__.py
+++ b/src/haddock/modules/sampling/lightdock/__init__.py
@@ -7,8 +7,9 @@ from pathlib import Path
 
 from haddock.core.defaults import NUM_CORES
 from haddock.libs import libpdb
-from haddock.modules import BaseHaddockModule, working_directory
 from haddock.libs.libontology import Format, ModuleIO, PDBFile
+from haddock.libs.libutil import check_subprocess
+from haddock.modules import BaseHaddockModule, working_directory
 
 
 logger = logging.getLogger(__name__)
@@ -28,6 +29,11 @@ class HaddockModule(BaseHaddockModule):
             **everything,
             ):
         super().__init__(order, path, initial_params)
+
+    @classmethod
+    def confirm_installation(cls):
+        """Confirm this module is installed."""
+        check_subprocess('lightdock3.py -h')
 
     def run(self, **params):
         logger.info("Running [sampling-lightdock] module")

--- a/src/haddock/modules/sampling/rigidbody/__init__.py
+++ b/src/haddock/modules/sampling/rigidbody/__init__.py
@@ -63,6 +63,10 @@ class HaddockModule(BaseHaddockModule):
         cns_script = RECIPE_PATH / "cns" / "rigidbody.cns"
         super().__init__(order, path, initial_params, cns_script)
 
+    @classmethod
+    def confirm_installation(cls):
+        return
+
     def run(self, **params):
         logger.info("Running [rigidbody] module")
 
@@ -114,7 +118,7 @@ class HaddockModule(BaseHaddockModule):
                 not_found.append(model.name)
 
             haddock_score = HaddockModel(model).calc_haddock_score(**weights)
-            
+
             pdb = PDBFile(model, path=self.path)
             pdb.score = haddock_score
             pdb.topology = topologies

--- a/src/haddock/modules/scoring/emscoring/__init__.py
+++ b/src/haddock/modules/scoring/emscoring/__init__.py
@@ -57,6 +57,10 @@ class HaddockModule(BaseHaddockModule):
         cns_script = RECIPE_PATH / "cns" / "scoring.cns"
         super().__init__(order, path, initial_params, cns_script)
 
+    @classmethod
+    def confirm_installation(cls):
+        return
+
     def run(self, **params):
         logger.info("Running [scoring] module")
 

--- a/src/haddock/modules/topology/topoaa/__init__.py
+++ b/src/haddock/modules/topology/topoaa/__init__.py
@@ -59,6 +59,10 @@ class HaddockModule(BaseHaddockModule):
         cns_script = RECIPE_PATH / "cns" / "generate-topology.cns"
         super().__init__(order, path, initial_params, cns_script)
 
+    @classmethod
+    def confirm_installation(cls):
+        return
+
     def run(self, molecules, **params):
         logger.info("Running [allatom] module")
         logger.info("Generating topologies")


### PR DESCRIPTION
Closes #29 

## concept

HADDOCK3 integrates third-party packages in its workflows. In this PR implements a structured mean to confirm third-party packages are installed before executing the workflow. Hence, HADDOCK3 is not responsible for proper the installation of such packages.

## detailed implementations

The `BaseModuleHaddock` class has now an `@abstractclassmethod` named `confirm_installation` that needs to be implemented on every subclass of `BaseModuleHaddock`. HADDOCK3 own modules should just implement a dummy method with a `return` statement. Third-party modules should implement whatever routines needed to properly check the module is functional. These confirmation steps happen while preparing the run and before executing the workflow. Any error raised `confirm_installation` will be captured and raised as a problem with the installation.

I have implemented confirmation routines for both `lightdock`, `gdock`, and `FCC`, as well as for all other HADDOCK3 modules.

Updated installation instructions and dependencies.

---

I think this implementation is a good example of both the modularity and extensibility of the `prepare_run` FP-based implementation as well as the OOP-based implementation of `BaseModuleHaddock` seeded by @brianjimenez . Taking profit from both realms :wink: