### PR TITLE
Structures the log system

### DIFF
--- a/examples/scoring/scoring.toml
+++ b/examples/scoring/scoring.toml
@@ -18,7 +18,7 @@ molecules = "../data/T161-rescoring-5.pdb"
 autohis = true
 
 ########################
-[emscoring]
+#[emscoring]
 
 ########################
 #[clustering]

--- a/src/haddock/__init__.py
+++ b/src/haddock/__init__.py
@@ -1,5 +1,23 @@
 """HADDOCK3 library."""
+import logging
+from os import get_terminal_size
 from pathlib import Path
+
+from haddock.libs.liblog import add_streamhandler
+
+
+log = logging.getLogger(__name__)
+log.handlers.clear()
+log.setLevel(logging.DEBUG)
+
+try:
+    # runs in clusters likely won't have terminal output
+    get_terminal_size()
+except OSError:
+    has_terminal = False
+else:
+    add_streamhandler(log)
+    has_terminal = True
 
 
 haddock3_source_path = Path(__file__).resolve().parent

--- a/src/haddock/__init__.py
+++ b/src/haddock/__init__.py
@@ -3,7 +3,7 @@ import logging
 from os import get_terminal_size
 from pathlib import Path
 
-from haddock.libs.liblog import add_streamhandler
+from haddock.libs.liblog import add_sysout_handler
 
 
 log = logging.getLogger(__name__)
@@ -16,7 +16,7 @@ try:
 except OSError:
     has_terminal = False
 else:
-    add_streamhandler(log)
+    add_sysout_handler(log)
     has_terminal = True
 
 

--- a/src/haddock/clis/cli.py
+++ b/src/haddock/clis/cli.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
 import argparse
-import logging
 import sys
 from argparse import ArgumentTypeError
 from functools import partial
 
-from haddock import current_version
-from haddock.libs.libutil import file_exists
+from haddock import current_version, has_terminal, log
 from haddock.gear.restart_run import add_restart_arg
+from haddock.libs.liblog import add_loglevel_arg, set_log_level_for_clis
+from haddock.libs.libutil import file_exists
 
 
 # Command line interface parser
@@ -32,12 +32,7 @@ ap.add_argument(
     dest='setup_only',
     )
 
-_log_levels = ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL")
-ap.add_argument(
-    "--log-level",
-    default="INFO",
-    choices=_log_levels,
-    )
+add_loglevel_arg(ap)
 
 ap.add_argument(
     "-v",
@@ -93,20 +88,16 @@ def main(
     from haddock.gear.prepare_run import setup_run
     from haddock.core.exceptions import HaddockError, ConfigurationError
 
-    # Configuring logging
-    logging.basicConfig(
-        level=log_level,
-        format="[%(asctime)s] %(name)s:L%(lineno)d %(levelname)s - %(message)s",
-        )
+    set_log_level_for_clis(log, log_level, add_streamhandler=has_terminal)
 
     # Special case only using print instead of logging
-    logging.info(get_initial_greeting())
+    log.info(get_initial_greeting())
 
     try:
         params, other_params = setup_run(recipe, restart_from=restart)
 
     except ConfigurationError as err:
-        logging.error(err)
+        log.error(err)
         sys.exit()
 
     if not setup_only:
@@ -121,10 +112,10 @@ def main(
             workflow.run()
 
         except HaddockError as err:
-            logging.error(err)
+            log.error(err)
 
     # Finish
-    logging.info(get_adieu())
+    log.info(get_adieu())
 
 
 if __name__ == "__main__":

--- a/src/haddock/clis/cli.py
+++ b/src/haddock/clis/cli.py
@@ -67,7 +67,7 @@ def maincli():
 def manage_config_errors(log_streams, log_names):
     try:
         yield
-    except ConfigurationError as err:
+    except Exception as err:
         _msg = (
             'An error ocurred while reading the configuration file, '
             'hence the log files will be saved in the CWD and not in the '
@@ -87,6 +87,7 @@ def manage_run_errors():
         log.info('Something external to the code halted the execution.')
         log.exception(err)
     except Exception as err:
+        log.info('An error ocurred while running the HADDOCK3 workflow.')
         log.exception(err)
 
 
@@ -94,20 +95,15 @@ def _run_haddock(restart, params, other_params):
 
     # anti-pattern to speed up CLI initiation
     from haddock.libs.libworkflow import WorkflowManager
-    from haddock.core.exceptions import HaddockError, ConfigurationError
 
-    try:
-        workflow = WorkflowManager(
-            workflow_params=params,
-            start=restart,
-            **other_params,
-            )
+    workflow = WorkflowManager(
+        workflow_params=params,
+        start=restart,
+        **other_params,
+        )
 
-        # Main loop of execution
-        workflow.run()
-
-    except HaddockError as err:
-        log.error(err)
+    # Main loop of execution
+    workflow.run()
 
     return
 
@@ -136,7 +132,6 @@ def main(
         The logging level: INFO, DEBUG, ERROR, WARNING, CRITICAL.
     """
     # small antipatterns to improve CLI startup speed
-    from haddock.core.exceptions import ConfigurationError
     from haddock.gear.greetings import get_adieu, get_initial_greeting
     from haddock.gear.prepare_run import setup_run
 

--- a/src/haddock/clis/cli.py
+++ b/src/haddock/clis/cli.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
 import argparse
 import sys
+import shutil
 from argparse import ArgumentTypeError
 from functools import partial
+from pathlib import Path
 
 from haddock import current_version, has_terminal, log
 from haddock.gear.restart_run import add_restart_arg
-from haddock.libs.liblog import add_loglevel_arg, set_log_level_for_clis
+from haddock.libs.liblog import add_loglevel_arg, set_log_level_for_clis, info_name, debug_name
 from haddock.libs.libutil import file_exists
 
 
@@ -82,23 +84,53 @@ def main(
     log_level : str
         The logging level: INFO, DEBUG, ERROR, WARNING, CRITICAL.
     """
-    # anti-pattern to speed up CLI initiation
-    from haddock.libs.libworkflow import WorkflowManager
-    from haddock.gear.greetings import get_adieu, get_initial_greeting
+    # small antipatterns to improve CLI startup speed
     from haddock.gear.prepare_run import setup_run
-    from haddock.core.exceptions import HaddockError, ConfigurationError
+    from haddock.core.exceptions import ConfigurationError
 
-    set_log_level_for_clis(log, log_level, add_streamhandler=has_terminal)
-
-    # Special case only using print instead of logging
-    log.info(get_initial_greeting())
+    log_streams, log_suggested_names = \
+        set_log_level_for_clis(log, log_level, stream_to_stdout=has_terminal)
 
     try:
         params, other_params = setup_run(recipe, restart_from=restart)
 
     except ConfigurationError as err:
         log.error(err)
+        save_streams_to_files(log_streams, log_suggested_names)
         sys.exit()
+
+    try:
+        _run(recipe, restart, setup_only, params, other_params)
+    except BaseException as err:
+        log.exception(err)
+
+    _add_dir_run = lambda x: Path(other_params['run_dir'], Path(x).name)
+    _log_names = list(map(_add_dir_run, log_suggested_names))
+    save_streams_to_files(log_streams, _log_names)
+
+
+
+def save_stream_to_file(stream, file_name):
+    stream.seek(0)
+    with open(file_name, 'w') as fout:
+        shutil.copyfileobj(stream, fout)
+
+
+def save_streams_to_files(streams, file_names):
+    for stream, file_name in zip(streams, file_names):
+        save_stream_to_file(stream, file_name)
+
+
+def _run(recipe, restart, setup_only, params, other_params):
+
+    # anti-pattern to speed up CLI initiation
+    from haddock.libs.libworkflow import WorkflowManager
+    from haddock.gear.greetings import get_adieu, get_initial_greeting
+    from haddock.core.exceptions import HaddockError, ConfigurationError
+
+    # Special case only using print instead of logging
+    log.info(get_initial_greeting())
+
 
     if not setup_only:
         try:
@@ -116,6 +148,7 @@ def main(
 
     # Finish
     log.info(get_adieu())
+    return
 
 
 if __name__ == "__main__":

--- a/src/haddock/clis/cli.py
+++ b/src/haddock/clis/cli.py
@@ -3,13 +3,15 @@ import argparse
 import sys
 import shutil
 from argparse import ArgumentTypeError
+from contextlib import contextmanager
 from functools import partial
 from pathlib import Path
 
 from haddock import current_version, has_terminal, log
 from haddock.gear.restart_run import add_restart_arg
-from haddock.libs.liblog import add_loglevel_arg, set_log_level_for_clis, info_name, debug_name
+from haddock.libs.liblog import add_loglevel_arg, set_log_for_cli
 from haddock.libs.libutil import file_exists
+from haddock.libs.libio import save_stream_to_file, save_streams_to_files
 
 
 # Command line interface parser
@@ -61,6 +63,55 @@ def maincli():
     cli(ap, main)
 
 
+@contextmanager
+def manage_config_errors(log_streams, log_names):
+    try:
+        yield
+    except ConfigurationError as err:
+        _msg = (
+            'An error ocurred while reading the configuration file, '
+            'hence the log files will be saved in the CWD and not in the '
+            'specified run directory.'
+            )
+        log.info(_msg)
+        log.error(err)
+        save_streams_to_files(log_streams, log_names)
+        sys.exit()
+
+
+@contextmanager
+def manage_run_errors():
+    try:
+        yield
+    except (SystemExit, KeyboardInterrupt) as err:
+        log.info('Something external to the code halted the execution.')
+        log.exception(err)
+    except Exception as err:
+        log.exception(err)
+
+
+def _run_haddock(restart, params, other_params):
+
+    # anti-pattern to speed up CLI initiation
+    from haddock.libs.libworkflow import WorkflowManager
+    from haddock.core.exceptions import HaddockError, ConfigurationError
+
+    try:
+        workflow = WorkflowManager(
+            workflow_params=params,
+            start=restart,
+            **other_params,
+            )
+
+        # Main loop of execution
+        workflow.run()
+
+    except HaddockError as err:
+        log.error(err)
+
+    return
+
+
 def main(
         recipe,
         restart=None,
@@ -85,70 +136,28 @@ def main(
         The logging level: INFO, DEBUG, ERROR, WARNING, CRITICAL.
     """
     # small antipatterns to improve CLI startup speed
-    from haddock.gear.prepare_run import setup_run
     from haddock.core.exceptions import ConfigurationError
+    from haddock.gear.greetings import get_adieu, get_initial_greeting
+    from haddock.gear.prepare_run import setup_run
 
     log_streams, log_suggested_names = \
-        set_log_level_for_clis(log, log_level, stream_to_stdout=has_terminal)
+        set_log_for_cli(log, log_level, stream_to_stdout=has_terminal)
 
-    try:
+    log.info(get_initial_greeting())
+
+    with manage_config_errors(log_streams, log_suggested_names):
         params, other_params = setup_run(recipe, restart_from=restart)
 
-    except ConfigurationError as err:
-        log.error(err)
-        save_streams_to_files(log_streams, log_suggested_names)
-        sys.exit()
-
-    try:
-        _run(recipe, restart, setup_only, params, other_params)
-    except BaseException as err:
-        log.exception(err)
+    if not setup_only:
+        with manage_run_errors():
+            _run_haddock(restart, params, other_params)
 
     _add_dir_run = lambda x: Path(other_params['run_dir'], Path(x).name)
     _log_names = list(map(_add_dir_run, log_suggested_names))
     save_streams_to_files(log_streams, _log_names)
 
-
-
-def save_stream_to_file(stream, file_name):
-    stream.seek(0)
-    with open(file_name, 'w') as fout:
-        shutil.copyfileobj(stream, fout)
-
-
-def save_streams_to_files(streams, file_names):
-    for stream, file_name in zip(streams, file_names):
-        save_stream_to_file(stream, file_name)
-
-
-def _run(recipe, restart, setup_only, params, other_params):
-
-    # anti-pattern to speed up CLI initiation
-    from haddock.libs.libworkflow import WorkflowManager
-    from haddock.gear.greetings import get_adieu, get_initial_greeting
-    from haddock.core.exceptions import HaddockError, ConfigurationError
-
-    # Special case only using print instead of logging
-    log.info(get_initial_greeting())
-
-
-    if not setup_only:
-        try:
-            workflow = WorkflowManager(
-                workflow_params=params,
-                start=restart,
-                **other_params,
-                )
-
-            # Main loop of execution
-            workflow.run()
-
-        except HaddockError as err:
-            log.error(err)
-
     # Finish
     log.info(get_adieu())
-    return
 
 
 if __name__ == "__main__":

--- a/src/haddock/libs/libio.py
+++ b/src/haddock/libs/libio.py
@@ -1,0 +1,13 @@
+"""General Input/Output routines."""
+import shutil
+
+
+def save_stream_to_file(stream, file_name):
+    stream.seek(0)
+    with open(file_name, 'w') as fout:
+        shutil.copyfileobj(stream, fout)
+
+
+def save_streams_to_files(streams, file_names):
+    for stream, file_name in zip(streams, file_names):
+        save_stream_to_file(stream, file_name)

--- a/src/haddock/libs/liblog.py
+++ b/src/haddock/libs/liblog.py
@@ -1,0 +1,80 @@
+import logging
+
+
+info_formatter = '[%(asctime)s]%(message)s'
+debug_formatter = \
+    "[%(asctime)s]%(filename)s:%(name)s:%(funcName)s:%(lineno)d: %(message)s"
+
+log_levels = {
+    'DEBUG': logging.DEBUG,
+    'INFO': logging.INFO,
+    'WARNING': logging.WARNING,
+    'ERROR': logging.ERROR,
+    'CRITICAL': logging.CRITICAL,
+    }
+
+
+def add_loglevel_arg(parser):
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=tuple(log_levels.keys()),
+        )
+    return
+
+
+def add_streamhandler(
+        log,
+        log_level='INFO',
+        formatter=info_formatter,
+        ):
+    """Add streamhandler to the log object."""
+    ch = logging.StreamHandler()
+    ch.setLevel(log_levels[log_level.upper()])
+    ch.setFormatter(logging.Formatter(formatter))
+    log.addHandler(ch)
+    return
+
+
+def set_log_level_for_clis(log, log_level, add_streamhandler=True):
+    """."""
+    log.setLevel(log_levels[log_level])
+
+    if log_level.upper() in ("INFO", "WARNING", "ERROR", "CRITICAL"):
+        init_info_file(log)
+
+    elif log_level.upper() in ("DEBUG"):
+        log.handlers.clear()
+        if add_streamhandler:
+            add_streamhandler(log, log_level='DEBUG', formatter=debug_formatter)
+        init_log_files(log)
+        init_debug_file(log)
+
+    return
+
+
+def init_debug_file(
+        log,
+        file_name='haddock3.debug',
+        formatter=debug_formatter,
+        ):
+    """."""
+    handler = logging.FileHandler(file_name, mode='w')
+    handler.setLevel(logging.DEBUG)
+    handler.setFormatter(logging.Formatter(formatter))
+    log.addHandler(handler)
+    return
+
+
+def init_info_file(
+        log,
+        file_name='haddock3.log',
+        formatter=info_formatter,
+        ):
+    """
+    """
+    handler = logging.FileHandler(file_name, mode='w')
+    handler.setLevel(logging.INFO)
+    handler.setFormatter(logging.Formatter(formatter))
+    log.addHandler(handler)
+    return

--- a/src/haddock/libs/liblog.py
+++ b/src/haddock/libs/liblog.py
@@ -9,9 +9,12 @@ from pathlib import Path
 info_name = 'haddock3.log'
 debug_name = 'haddock3.debug'
 
-info_formatter = '[%(asctime)s]%(message)s'
-debug_formatter = \
-    "[%(asctime)s]%(filename)s:%(name)s:%(funcName)s:%(lineno)d: %(message)s"
+info_formatter = '[%(asctime)s] %(message)s'
+debug_formatter = (
+    "[%(asctime)s] "
+    "%(filename)s:%(name)s:%(funcName)s:%(lineno)d: "
+    "%(message)s"
+    )
 
 log_levels = {
     'DEBUG': logging.DEBUG,
@@ -47,13 +50,14 @@ def add_streamhandler(
 
 def set_log_for_cli(log, log_level, stream_to_stdout=True):
     """Set the logging streams for HADDOCK3 main client"""
-    log.setLevel(log_levels[log_level])
+    llu = log_level.upper()
+    log.setLevel(log_levels[llu])
 
-    if log_level.upper() in ("INFO", "WARNING", "ERROR", "CRITICAL"):
+    if llu in ("INFO", "WARNING", "ERROR", "CRITICAL"):
         h = add_info_stringio(log)
         return [h.stream], [info_name]
 
-    elif log_level.upper() in ("DEBUG"):
+    elif llu in ("DEBUG"):
         if stream_to_stdout:
             log.handlers.clear()
             add_sysout_handler(log, log_level='DEBUG', formatter=debug_formatter)

--- a/src/haddock/libs/liblog.py
+++ b/src/haddock/libs/liblog.py
@@ -1,5 +1,12 @@
 import logging
+import io
+import os
+import sys
+from pathlib import Path
 
+
+info_name = 'haddock3.log'
+debug_name = 'haddock3.debug'
 
 info_formatter = '[%(asctime)s]%(message)s'
 debug_formatter = \
@@ -29,52 +36,56 @@ def add_streamhandler(
         formatter=info_formatter,
         ):
     """Add streamhandler to the log object."""
-    ch = logging.StreamHandler()
+    ch = logging.StreamHandler(sys.stdout)
     ch.setLevel(log_levels[log_level.upper()])
     ch.setFormatter(logging.Formatter(formatter))
     log.addHandler(ch)
     return
 
 
-def set_log_level_for_clis(log, log_level, add_streamhandler=True):
+def set_log_level_for_clis(log, log_level, stream_to_stdout=True):
     """."""
     log.setLevel(log_levels[log_level])
 
     if log_level.upper() in ("INFO", "WARNING", "ERROR", "CRITICAL"):
-        init_info_file(log)
+        h, n = init_info_file(log)
+        return [h.stream], [n]
 
     elif log_level.upper() in ("DEBUG"):
         log.handlers.clear()
-        if add_streamhandler:
+        if stream_to_stdout:
             add_streamhandler(log, log_level='DEBUG', formatter=debug_formatter)
-        init_log_files(log)
-        init_debug_file(log)
+        h1, n1 = init_info_file(log)
+        h2, n2 = init_debug_file(log)
+        return (h1.stream, h2.stream), (n1, n2)
 
-    return
+    else:
+        raise AssertionError("Execution shouldn't reach this point.")
 
 
 def init_debug_file(
         log,
-        file_name='haddock3.debug',
+        file_name=debug_name,
         formatter=debug_formatter,
         ):
     """."""
-    handler = logging.FileHandler(file_name, mode='w')
+    #handler = logging.FileHandler(file_name, mode='w')
+    handler = logging.StreamHandler(io.StringIO(newline=os.linesep))
     handler.setLevel(logging.DEBUG)
     handler.setFormatter(logging.Formatter(formatter))
     log.addHandler(handler)
-    return
+    return handler, file_name
 
 
 def init_info_file(
         log,
-        file_name='haddock3.log',
+        file_name=info_name,
         formatter=info_formatter,
         ):
     """
     """
-    handler = logging.FileHandler(file_name, mode='w')
+    handler = logging.StreamHandler(io.StringIO(newline=os.linesep))
     handler.setLevel(logging.INFO)
     handler.setFormatter(logging.Formatter(formatter))
     log.addHandler(handler)
-    return
+    return handler, file_name

--- a/tests/test_liblog.py
+++ b/tests/test_liblog.py
@@ -1,0 +1,34 @@
+"""Test liblog"""
+import io
+import logging
+
+import pytest
+
+
+from haddock import log
+from haddock.libs import liblog
+
+
+@pytest.mark.parametrize(
+    'func',
+    [
+        liblog.add_sysout_handler,
+        liblog.add_stringio_handler,
+        liblog.add_info_stringio,
+        liblog.add_debug_stringio,
+        ]
+    )
+def test_add_sysout_handler(func):
+    """."""
+    log.handlers.clear()
+    func(log)
+    assert len(log.handlers) == 1
+
+
+def test_set_log_for_cli():
+    s, n = liblog.set_log_for_cli(log, log_level='info')
+    assert isinstance(s, list)
+    assert isinstance(n, list)
+    assert isinstance(s[0], io.StringIO)
+    assert n[0] == liblog.info_name
+


### PR DESCRIPTION
Enhances the previous logging structure.

Added features:

* two files are now saved: `haddock3.log` and `haddock3.debug`, where the latter is only created if `--log-level debug` is given.
* log only outputs for `sys.stdout` if there is one. For example, some times clusters have no terminal output, for these cases the log prints nothing.
* log files are written **only** at the end of the execution and **not** on every log call. Log is kept in memory and only flushed to files at the end.
* log files are created even if the execution breaks
* in case the an error happens before reading the configuration file, the log files are saved in the `CWD`. If the error happens after reading the config, the log files are saved in the `run dir` folder.