### PR TITLE
Corrects for the rare case of number of CPUs = 0

### DIFF
--- a/src/haddock/libs/libutil.py
+++ b/src/haddock/libs/libutil.py
@@ -109,7 +109,7 @@ def parse_ncores(n=None, njobs=None, max_cpus=None):
     int
         A correct number of cores according to specifications.
     """
-    max_cpus = max_cpus or cpu_count() - 1
+    max_cpus = max_cpus or max(cpu_count() - 1, 1)
 
     if n is None:
         return max_cpus


### PR DESCRIPTION
Thanks, @amjjbonvin for spotting this out. Developing software for GRID/Cloud and 1-CPU cases. This is what I meant by >100% coverage the last time.

I will add tests to the whole codebase after the major PRs are merged.