### PR TITLE
Codecoving

### DIFF
--- a/.github/workflows/py38.yml
+++ b/.github/workflows/py38.yml
@@ -45,9 +45,9 @@ jobs:
       run: tox -e py38
 
     # from https://github.com/codecov/codecov-action
-    #- name: Upload coverage to Codecov
-    #  uses: codecov/codecov-action@v1
-    #  with:
-    #    files: ./coverage.xml
-    #    fail_ci_if_error: true
-    #    verbose: true
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v2
+      with:
+        files: ./coverage.xml
+        fail_ci_if_error: true
+        verbose: true

--- a/.github/workflows/py39.yml
+++ b/.github/workflows/py39.yml
@@ -46,7 +46,7 @@ jobs:
 
     # from https://github.com/codecov/codecov-action
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v2
       with:
         files: ./coverage.xml
         fail_ci_if_error: true

--- a/.github/workflows/py39.yml
+++ b/.github/workflows/py39.yml
@@ -45,9 +45,9 @@ jobs:
       run: tox -e py39
 
     # from https://github.com/codecov/codecov-action
-    #- name: Upload coverage to Codecov
-    #  uses: codecov/codecov-action@v1
-    #  with:
-    #    files: ./coverage.xml
-    #    fail_ci_if_error: true
-    #    verbose: true
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v1
+      with:
+        files: ./coverage.xml
+        fail_ci_if_error: true
+        verbose: true


### PR DESCRIPTION
Since this repository is [already activated in codecov](https://app.codecov.io/gh/haddocking/haddock3/commits?page=1), we can add the codecov report from the github actions. I forgot to check this on #110 .