### PR TITLE
Adds support for global variables for CNS

### DIFF
--- a/src/haddock/gear/prepare_run.py
+++ b/src/haddock/gear/prepare_run.py
@@ -109,6 +109,8 @@ def setup_run(workflow_path, restart_from=None):
     # the workflow, the "other parameters" can be expanded in the future
     # by a function if needed
 
+    general_params['config_path'] = Path(workflow_path).resolve()
+
     return modules_params, general_params
 
 

--- a/src/haddock/libs/libsubprocess.py
+++ b/src/haddock/libs/libsubprocess.py
@@ -3,6 +3,7 @@ import os
 import shlex
 import subprocess
 
+from haddock import toppar_path
 from haddock.core.defaults import cns_exec
 from haddock.core.exceptions import CNSRunningError, JobRunningError
 
@@ -45,20 +46,45 @@ class CNSJob:
             self,
             input_file,
             output_file,
-            cns_folder='.',
+            cns_folder,
+            modpath,
+            config_path,
             cns_exec=None,
             ):
         """
         CNS subprocess.
 
-        :param input_file: input CNS script
-        :param output_file: CNS output
-        :cns_folder: absolute execution path
-        :cns_exec: CNS binary including absolute path
+        Parameters
+        ----------
+        input_file : str or pathlib.Path
+            The path to the .inp CNS file.
+
+        output_file : str or pathlib.Path
+            The path to the .out CNS file, where the standard output
+            will be saved.
+
+        cns_folder : str of pathlib.Path
+            The path where the CNS scripts needed for the module reside.
+            For example, `modules/rigidibody/cns`.
+
+        mod_path : str of pathlib.Path
+            Path where the results of the haddock3 module executing this
+            CNS job will be saved.
+
+        config_path : str of pathlib.Path
+            Path of the haddock3 configuration file. Will be used to
+            manage paths in relative manner.
+
+        cns_exec : str of pathlib.Path, optional
+            The path to the CNS exec. If not provided defaults to the
+            global configuration in HADDOCK3.
         """
         self.input_file = input_file
         self.output_file = output_file
         self.cns_folder = cns_folder
+        self.modpath = modpath
+        self.config_path = config_path
+
         self.cns_exec = cns_exec
 
     @property
@@ -84,7 +110,12 @@ class CNSJob:
         with open(self.input_file) as inp, \
                 open(self.output_file, 'w+') as outf:
 
-            env = {'RUN': self.cns_folder}
+            env = {
+                'MODDIR': self.modpath,
+                'MODULE': self.cns_folder,
+                'RUN': self.config_path,
+                'TOPPAR': toppar_path,
+                }
             p = subprocess.Popen(
                 self.cns_exec,
                 stdin=inp,

--- a/src/haddock/libs/libsubprocess.py
+++ b/src/haddock/libs/libsubprocess.py
@@ -2,6 +2,7 @@
 import os
 import shlex
 import subprocess
+from pathlib import Path
 
 from haddock import toppar_path as global_toppar
 from haddock.core.defaults import cns_exec
@@ -91,7 +92,7 @@ class CNSJob:
         self.output_file = output_file
         self.cns_folder = cns_folder
         self.modpath = modpath
-        self.config_path = config_path
+        self.config_path = Path(config_path).parent
 
         self.toppar = toppar or global_toppar
         self.cns_exec = cns_exec
@@ -120,11 +121,12 @@ class CNSJob:
                 open(self.output_file, 'w+') as outf:
 
             env = {
-                'MODDIR': self.modpath,
-                'MODULE': self.cns_folder,
-                'RUN': self.config_path,
-                'TOPPAR': self.toppar,
+                'MODDIR': str(self.modpath),
+                'MODULE': str(self.cns_folder),
+                'RUN': str(self.config_path),
+                'TOPPAR': str(self.toppar),
                 }
+            print(env)
             p = subprocess.Popen(
                 self.cns_exec,
                 stdin=inp,

--- a/src/haddock/libs/libsubprocess.py
+++ b/src/haddock/libs/libsubprocess.py
@@ -3,7 +3,7 @@ import os
 import shlex
 import subprocess
 
-from haddock import toppar_path
+from haddock import toppar_path as global_toppar
 from haddock.core.defaults import cns_exec
 from haddock.core.exceptions import CNSRunningError, JobRunningError
 
@@ -50,9 +50,12 @@ class CNSJob:
             modpath,
             config_path,
             cns_exec=None,
+            toppar=None,
             ):
         """
         CNS subprocess.
+
+        To execute the job, call the `.run()` method.
 
         Parameters
         ----------
@@ -78,6 +81,11 @@ class CNSJob:
         cns_exec : str of pathlib.Path, optional
             The path to the CNS exec. If not provided defaults to the
             global configuration in HADDOCK3.
+
+        toppar : str of pathlib.Path, optional
+            Path to the folder containing CNS topology parameters.
+            If `None` is given defaults to `cns/toppar` inside HADDOCK3
+            source code.
         """
         self.input_file = input_file
         self.output_file = output_file
@@ -85,6 +93,7 @@ class CNSJob:
         self.modpath = modpath
         self.config_path = config_path
 
+        self.toppar = toppar or global_toppar
         self.cns_exec = cns_exec
 
     @property
@@ -114,7 +123,7 @@ class CNSJob:
                 'MODDIR': self.modpath,
                 'MODULE': self.cns_folder,
                 'RUN': self.config_path,
-                'TOPPAR': toppar_path,
+                'TOPPAR': self.toppar,
                 }
             p = subprocess.Popen(
                 self.cns_exec,

--- a/src/haddock/libs/libworkflow.py
+++ b/src/haddock/libs/libworkflow.py
@@ -28,7 +28,14 @@ class WorkflowManager:
 class Workflow:
     """Represent a set of stages to be executed by HADDOCK."""
 
-    def __init__(self, content, ncores=None, run_dir=None, cns_exec=None, **ig):
+    def __init__(
+            self,
+            content,
+            ncores=None,
+            run_dir=None,
+            cns_exec=None,
+            config_path=None,
+            **ig):
         # Create the list of steps contained in this workflow
         self.steps = []
         for num_stage, (stage_name, params) in enumerate(content.items()):
@@ -38,6 +45,7 @@ class Workflow:
             # hasn't been used
             params.setdefault('ncores', ncores)
             params.setdefault('cns_exec', cns_exec)
+            params.setdefault('config_path', config_path)
 
             try:
                 _ = Step(

--- a/src/haddock/modules/refinement/emref/__init__.py
+++ b/src/haddock/modules/refinement/emref/__init__.py
@@ -119,6 +119,8 @@ class HaddockModule(BaseHaddockModule):
                 inp_file,
                 out_file,
                 cns_folder=self.cns_folder_path,
+                modpath=self.path,
+                config_path=self.params['config_path'],
                 cns_exec=self.params['cns_exec'],
                 )
 

--- a/src/haddock/modules/refinement/flexref/__init__.py
+++ b/src/haddock/modules/refinement/flexref/__init__.py
@@ -119,6 +119,8 @@ class HaddockModule(BaseHaddockModule):
                 inp_file,
                 out_file,
                 cns_folder=self.cns_folder_path,
+                modpath=self.path,
+                config_path=self.params['config_path'],
                 cns_exec=self.params['cns_exec'],
                 )
 

--- a/src/haddock/modules/refinement/mdref/__init__.py
+++ b/src/haddock/modules/refinement/mdref/__init__.py
@@ -114,6 +114,8 @@ class HaddockModule(BaseHaddockModule):
                 inp_file,
                 out_file,
                 cns_folder=self.cns_folder_path,
+                modpath=self.path,
+                config_path=self.params['config_path'],
                 cns_exec=self.params['cns_exec'],
                 )
 

--- a/src/haddock/modules/sampling/rigidbody/__init__.py
+++ b/src/haddock/modules/sampling/rigidbody/__init__.py
@@ -127,6 +127,8 @@ class HaddockModule(BaseHaddockModule):
                 inp_file,
                 out_file,
                 cns_folder=self.cns_folder_path,
+                modpath=self.path,
+                config_path=self.params['config_path'],
                 cns_exec=self.params['cns_exec'],
                 )
 

--- a/src/haddock/modules/scoring/emscoring/__init__.py
+++ b/src/haddock/modules/scoring/emscoring/__init__.py
@@ -94,6 +94,8 @@ class HaddockModule(BaseHaddockModule):
                 scoring_filename,
                 output_filename,
                 cns_folder=self.cns_folder_path,
+                modpath=self.path,
+                config_path=self.params['config_path'],
                 cns_exec=self.params['cns_exec'],
                 )
 

--- a/src/haddock/modules/topology/topoaa/__init__.py
+++ b/src/haddock/modules/topology/topoaa/__init__.py
@@ -110,6 +110,8 @@ class HaddockModule(BaseHaddockModule):
                     topology_filename,
                     output_filename,
                     cns_folder=self.cns_folder_path,
+                    modpath=self.path,
+                    config_path=self.params['config_path'],
                     cns_exec=self.params['cns_exec'],
                     )
 


### PR DESCRIPTION
Adds global variables for CNS runs according to what we discussed.

@amjjbonvin can you read over the documentation of `CNSJob` and see if they agree with expectations? Also, can you test out the examples? With this changes the `rigid-body` example broke. Likely because the `RUN` variable does not point to the same place as before. Should we update the var or the CNS scripts?

**EDIT:** likely the example broke because of #132