### PR TITLE
Solves chainID and segID missing in input molecule

### DIFF
--- a/src/haddock/core/exceptions.py
+++ b/src/haddock/core/exceptions.py
@@ -19,6 +19,12 @@ class ModuleError(HaddockError):
     pass
 
 
+class MoleculeError(HaddockError):
+    """Error in a HADDOCK3 module."""
+
+    pass
+
+
 class StepError(HaddockError):
     """Error in a HADDOCK3 workflow step."""
 

--- a/src/haddock/libs/libpdb.py
+++ b/src/haddock/libs/libpdb.py
@@ -12,6 +12,24 @@ from haddock.libs.libutil import get_result_or_same_in_list
 from haddock.modules import working_directory
 
 
+slc_record = slice(0, 6)
+slc_serial = slice(6, 11)
+slc_name = slice(12, 16)
+slc_altloc = slice(16, 17)
+slc_resname = slice(17, 20)
+slc_chainid = slice(21, 22)
+slc_resseq = slice(22, 26)
+slc_icode = slice(26, 27)
+slc_x = slice(30, 38)
+slc_y = slice(38, 46)
+slc_z = slice(46, 54)
+slc_occ = slice(54, 60)
+slc_temp = slice(60, 66)
+slc_segid = slice(72, 76)
+slc_element = slice(76, 78)
+slc_model = slice(78, 80)
+
+
 def get_supported_residues(haddock_topology):
     """Read the topology file and identify which data is supported."""
     supported = []

--- a/src/haddock/libs/libstructure.py
+++ b/src/haddock/libs/libstructure.py
@@ -3,7 +3,7 @@ import os
 import string
 from pathlib import Path
 
-from pdbtools import pdb_chainxseg, pdb_segxchain, pdb_chain
+from pdbtools import pdb_chainxseg, pdb_segxchain, pdb_chain, pdb_tidy
 
 
 slc_record = slice(0, 6)
@@ -86,14 +86,19 @@ def clean_chainID_segID(molecules):
 
     for mol in molecules:
         if not mol.chainid and mol.segid:
-            mol.lines = list(pdb_segxchain(mol.lines))
+            lines = pdb_segxchain(mol.lines)
 
         elif mol.chainid and not mol.segid:
-            mol.lines = list(pdb_chainxseg(mol.lines))
+            lines = pdb_chainxseg(mol.lines)
 
         elif not mol.chainid and not mol.segid:
             _chains = pdb_chain.run(mol.lines, remaining_chains.pop())
-            mol.lines = list(pdb_chainxseg.run(_chains))
+            lines = pdb_chainxseg.run(_chains)
 
         elif mol.chainid != mol.segid:
             raise ValueError('ChainID differs from segID')
+
+        else:
+            continue
+
+        mol.lines = list(pdb_tidy.run(lines))

--- a/src/haddock/libs/libstructure.py
+++ b/src/haddock/libs/libstructure.py
@@ -1,18 +1,99 @@
 """Molecular data structures."""
+import os
+import string
 from pathlib import Path
+
+from pdbtools import pdb_chainxseg, pdb_segxchain, pdb_chain
+
+
+slc_record = slice(0, 6)
+slc_serial = slice(6, 11)
+slc_name = slice(12, 16)
+slc_altLoc = slice(16, 17)
+slc_resName = slice(17, 20)
+slc_chainID = slice(21, 22)
+slc_resSeq = slice(22, 26)
+slc_iCode = slice(26, 27)
+slc_x = slice(30, 38)
+slc_y = slice(38, 46)
+slc_z = slice(46, 54)
+slc_occ = slice(54, 60)
+slc_temp = slice(60, 66)
+slc_segid = slice(72, 76)
+slc_element = slice(76, 78)
+slc_model = slice(78, 80)
 
 
 class Molecule:
     """Input molecule, usually a PDB file."""
 
-    def __init__(self, file_name, segid=None):
+    def __init__(self, file_path):
         # the rest of the code is too dependent on the Path API
-        assert isinstance(file_name, Path), "`file_name` must be pathlib.Path"
+        assert isinstance(file_path, Path), "`file_name` must be pathlib.Path"
 
-        self.file_name = file_name
-        self.segid = segid
+        self.file_path = file_path
+
+    def read_lines(self):
+        self.lines = self.file_path.read_text().split(os.linesep)
+
+    def read_chain(self):
+        # read the chain ID
+        chainids = set(
+            line[slc_chainID].strip()
+            for line in self.lines
+            if line.startswith(('ATOM', 'HETATM', 'ANISOU'))
+            )
+
+        if len(chainids) > 1:
+            raise ValueError(f'PDB files can have only one chain. {chainids}')
+        self.chainid = chainids.pop()
+
+    def read_segid(self):
+        # read the segid
+        segids = set(
+            line[slc_segid].strip()
+            for line in self.lines
+            if line.startswith(('ATOM', 'HETATM', 'ANISOU'))
+            )
+
+        if len(segids) > 1:
+            raise ValueError('PDB files can have only one segid.')
+        self.segid = segids.pop()
 
 
 def make_molecules(paths):
     """Get input molecules from the data stream."""
     return list(map(Molecule, paths))
+
+
+def clean_chainID_segID(molecules):
+    """Clean molecules chainID and segID."""
+
+    for mol in molecules:
+        mol.read_lines()
+        mol.read_chain()
+        mol.read_segid()
+
+    chainids = list(mol.chainid for mol in molecules)
+    segids = list(mol.segid for mol in molecules)
+
+    if chainids != segids:
+        raise ValueError
+
+    # i don't use sets beause i want to keep order
+    uc = list(string.ascii_uppercase)
+    remaining_chains = [c for c in uc if c not in chainids][::-1]
+
+    for mol in molecules:
+        if not mol.chainid and mol.segid:
+            mol.lines = list(pdb_segxchain(mol.lines))
+
+        elif mol.chainid and not mol.segid:
+            mol.lines = list(pdb_chainxseg(mol.lines))
+
+        elif not mol.chainid and not mol.segid:
+            _chains = pdb_chain.run(mol.lines, remaining_chains.pop())
+            mol.lines = list(pdb_chainxseg.run(_chains))
+
+        elif mol.chainid != mol.segid:
+            raise ValueError('ChainID differs from segID')

--- a/src/haddock/modules/topology/topoaa/__init__.py
+++ b/src/haddock/modules/topology/topoaa/__init__.py
@@ -1,5 +1,4 @@
 """Create and manage CNS all-atom topology."""
-import os
 from pathlib import Path
 
 from haddock import log
@@ -70,6 +69,9 @@ class HaddockModule(BaseHaddockModule):
         super().run(params)
 
         molecules = make_molecules(molecules)
+
+        # corrects errors in the input PDB files
+        # we can use this space to correct any errors nicely with pdb-tools
         clean_chainID_segID(molecules)
 
         # Pool of jobs to be executed by the CNS engine
@@ -81,8 +83,7 @@ class HaddockModule(BaseHaddockModule):
 
             # Copy the molecule to the step folder
             step_molecule_path = Path(self.path, molecule.file_path.name)
-            step_molecule_path.write_text(os.linesep.join(molecule.lines))
-            #shutil.copyfile(molecule.file_name, step_molecule_path)
+            step_molecule_path.write_text(''.join(molecule.lines))
 
             # Split models
             log.info(f"Split models if needed for {step_molecule_path}")

--- a/src/haddock/modules/topology/topoaa/__init__.py
+++ b/src/haddock/modules/topology/topoaa/__init__.py
@@ -12,7 +12,7 @@ from haddock.libs.libcns import (
     )
 from haddock.libs.libontology import Format, ModuleIO, PDBFile, TopologyFile
 from haddock.libs.libparallel import Scheduler
-from haddock.libs.libstructure import make_molecules
+from haddock.libs.libstructure import clean_chainID_segID, make_molecules
 from haddock.libs.libsubprocess import CNSJob
 from haddock.modules import BaseHaddockModule
 
@@ -70,17 +70,19 @@ class HaddockModule(BaseHaddockModule):
         super().run(params)
 
         molecules = make_molecules(molecules)
+        clean_chainID_segID(molecules)
 
         # Pool of jobs to be executed by the CNS engine
         jobs = []
 
         models = []
         for i, molecule in enumerate(molecules, start=1):
-            log.info(f"{i} - {molecule.file_name}")
+            log.info(f"{i} - {molecule.file_path}")
 
             # Copy the molecule to the step folder
-            step_molecule_path = Path(self.path, molecule.file_name.name)
-            shutil.copyfile(molecule.file_name, step_molecule_path)
+            step_molecule_path = Path(self.path, molecule.file_path.name)
+            step_molecule_path.write_text('\n'.join(molecule.lines))
+            #shutil.copyfile(molecule.file_name, step_molecule_path)
 
             # Split models
             log.info(f"Split models if needed for {step_molecule_path}")

--- a/src/haddock/modules/topology/topoaa/__init__.py
+++ b/src/haddock/modules/topology/topoaa/__init__.py
@@ -1,5 +1,5 @@
 """Create and manage CNS all-atom topology."""
-import shutil
+import os
 from pathlib import Path
 
 from haddock import log
@@ -81,7 +81,7 @@ class HaddockModule(BaseHaddockModule):
 
             # Copy the molecule to the step folder
             step_molecule_path = Path(self.path, molecule.file_path.name)
-            step_molecule_path.write_text('\n'.join(molecule.lines))
+            step_molecule_path.write_text(os.linesep.join(molecule.lines))
             #shutil.copyfile(molecule.file_name, step_molecule_path)
 
             # Split models


### PR DESCRIPTION
I am pull requesting this to the `haddock3-emref` branch from #140 .

Closes #138 

* makes nice use of `pdbtools` lib mod from https://github.com/haddocking/pdb-tools/pull/107
* Chain/SegIDs are added by order to the molecules. For example, if there are 3 molecules (`A`, `missing`, `C`). The `missing` will get `B`.

But, if there are 3 molecules (`A`, `missing`, `B`). The missing will get `C`. Is this expected? Should we correct also this and have all molecules `ABC...` in order, or is it something the user must correct?