### PR TITLE
Implement ensemble support for docking in CNS-based modules

### DIFF
--- a/src/haddock/libs/libontology.py
+++ b/src/haddock/libs/libontology.py
@@ -30,11 +30,16 @@ class Persistent:
         self.file_name = Path(file_name).name
         self.file_type = file_type
         self.path = str(Path(path).resolve())
+        self.full_name = str(Path(path, self.file_name))
 
     def __repr__(self):
         rep = (f"[{self.file_type}|{self.created}] "
                f"{Path(self.path) / self.file_name}")
         return rep
+
+    def is_present(self):
+        """Check if the persisent file exists on disk."""
+        return Path(self.path, self.file_name).exists()
 
 
 class PDBFile(Persistent):

--- a/src/haddock/modules/refinement/emref/__init__.py
+++ b/src/haddock/modules/refinement/emref/__init__.py
@@ -99,9 +99,6 @@ class HaddockModule(BaseHaddockModule):
             if p.file_type == Format.PDB
             ]
 
-        first_model = models_to_refine[0]
-        topologies = first_model.topology
-
         refined_structure_list = []
         for idx, model in enumerate(models_to_refine, start=1):
             inp_file = generate_emref(
@@ -115,7 +112,8 @@ class HaddockModule(BaseHaddockModule):
 
             out_file = self.path / f"emref_{idx}.out"
             structure_file = self.path / f"emref_{idx}.pdb"
-            refined_structure_list.append(structure_file)
+            topologies = model.topology
+            refined_structure_list.append((structure_file, topologies))
 
             job = CNSJob(
                 inp_file,
@@ -141,14 +139,15 @@ class HaddockModule(BaseHaddockModule):
 
         expected = []
         not_found = []
-        for model in refined_structure_list:
-            if not model.exists():
-                not_found.append(model.name)
+        for element in refined_structure_list:
+            pdb_fname, topologies = element
+            if not pdb_fname.exists():
+                not_found.append(pdb_fname.name)
 
             haddock_score = \
-                HaddockModel(model).calc_haddock_score(**weights)
+                HaddockModel(pdb_fname).calc_haddock_score(**weights)
 
-            pdb = PDBFile(model, path=self.path)
+            pdb = PDBFile(pdb_fname, path=self.path)
             pdb.score = haddock_score
             pdb.topology = topologies
             expected.append(pdb)
@@ -161,6 +160,5 @@ class HaddockModule(BaseHaddockModule):
 
         # Save module information
         io = ModuleIO()
-        io.add(refined_structure_list)
         io.add(expected, "o")
         io.save(self.path)

--- a/src/haddock/modules/sampling/rigidbody/__init__.py
+++ b/src/haddock/modules/sampling/rigidbody/__init__.py
@@ -23,8 +23,7 @@ DEFAULT_CONFIG = Path(RECIPE_PATH, "defaults.cfg")
 
 def generate_docking(
         identifier,
-        pdb_list,
-        psf_list,
+        input_list,
         step_path,
         recipe_str,
         defaults,
@@ -38,6 +37,14 @@ def generate_docking(
     param, top, link, topology_protonation, \
         trans_vec, tensor, scatter, \
         axis, water_box = generate_default_header()
+
+    pdb_list = []
+    psf_list = []
+    for element in input_list:
+        pdb_fname = element.full_name
+        psf_fname = element.topology.full_name
+        pdb_list.append(pdb_fname)
+        psf_list.append(psf_fname)
 
     input_str = prepare_multiple_input(pdb_list, psf_list)
 
@@ -126,15 +133,10 @@ class HaddockModule(BaseHaddockModule):
         structure_list = []
         for combination in models_to_dock:
 
-            #  generate docking takes a list with file names
-            pdb_fname_list = [e[0].full_name for e in combination]
-            psf_fname_list = [e[1].full_name for e in combination]
-
             for _i in range(sampling_factor):
                 inp_file = generate_docking(
                     idx,
-                    pdb_fname_list,
-                    psf_fname_list,
+                    combination,
                     self.path,
                     self.recipe_str,
                     self.params,
@@ -146,7 +148,7 @@ class HaddockModule(BaseHaddockModule):
 
                 # Create a model for the expected output
                 model = PDBFile(output_pdb_fname, path=self.path)
-                model.topology = [e[1] for e in combination]
+                model.topology = [e.topology for e in combination]
                 structure_list.append(model)
 
                 job = CNSJob(

--- a/src/haddock/modules/sampling/rigidbody/__init__.py
+++ b/src/haddock/modules/sampling/rigidbody/__init__.py
@@ -1,4 +1,5 @@
 """HADDOCK3 rigid-body docking module."""
+from itertools import product
 from os import linesep
 from pathlib import Path
 
@@ -10,7 +11,7 @@ from haddock.libs.libcns import (
     load_workflow_params,
     prepare_multiple_input,
     )
-from haddock.libs.libontology import Format, ModuleIO, PDBFile
+from haddock.libs.libontology import ModuleIO, PDBFile
 from haddock.libs.libparallel import Scheduler
 from haddock.libs.libsubprocess import CNSJob
 from haddock.modules import BaseHaddockModule
@@ -22,7 +23,8 @@ DEFAULT_CONFIG = Path(RECIPE_PATH, "defaults.cfg")
 
 def generate_docking(
         identifier,
-        input_files,
+        pdb_list,
+        psf_list,
         step_path,
         recipe_str,
         defaults,
@@ -36,16 +38,6 @@ def generate_docking(
     param, top, link, topology_protonation, \
         trans_vec, tensor, scatter, \
         axis, water_box = generate_default_header()
-
-    # input_files is the ontology, unwrap it
-    pdb_list = []
-    psf_list = []
-    for element in input_files:
-        pdb = Path(element.path, element.file_name)
-        psf = Path(element.path, element.topology.file_name)
-
-        pdb_list.append(str(pdb))
-        psf_list.append(str(psf))
 
     input_str = prepare_multiple_input(pdb_list, psf_list)
 
@@ -92,47 +84,82 @@ class HaddockModule(BaseHaddockModule):
         jobs = []
 
         # Get the models generated in previous step
-        models_to_dock = [
-            p
-            for p in self.previous_io.output
-            if p.file_type == Format.PDB
-            ]
+        #  The models from topology come in a dictionary
+        input_dic = {}
+        for i, model_dic in enumerate(self.previous_io.output):
+            input_dic[i] = []
+            for key in model_dic:
+                input_dic[i].append(model_dic[key])
 
-        # TODO: Make the topology aquisition generic,
-        # here its expecting this module
-        # to be preceeded by topology
-        topologies = [
-            p
-            for p in self.previous_io.output
-            if p.file_type == Format.TOPOLOGY
-            ]
+        if not self.params['crossdock']:
+            # docking should be paired
+            # A1-B1, A2-B2, A3-B3, etc
 
-        # Sampling
+            # check if all ensembles contain the same number of models
+            sub_lists = iter(input_dic.values())
+            _len = len(next(sub_lists))
+            if not all(len(sub) == _len for sub in sub_lists):
+                _msg = ('With crossdock=false, the number of models inside each'
+                        ' ensemble must be the same')
+                self.finish_with_error(_msg)
+
+            # prepare pairwise combinations
+            models_to_dock = [values for values in zip(*input_dic.values())]
+
+        elif self.params['crossdock']:
+            # All combinations should be sampled
+            # A1-B1, A1-B2, A3-B3, A2-B1, A2-B2, etc
+            # prepare combinations as cartesian product
+            models_to_dock = [values for values in product(*input_dic.values())]
+
+        # How many times each combination should be sampled,
+        #  cannot be smaller than 1
+        sampling_factor = int(params['sampling'] / len(models_to_dock))
+        if sampling_factor < 1:
+            self.finish_with_error('Sampling is smaller than the number'
+                                   ' of model combinations '
+                                   f'#model_combinations={len(models_to_dock)},'
+                                   f' sampling={params["sampling"]}.')
+
+        # Prepare the jobs
+        idx = 1
         structure_list = []
-        for idx in range(1, params['sampling'] + 1):
-            inp_file = generate_docking(
-                idx,
-                models_to_dock,
-                self.path,
-                self.recipe_str,
-                self.params,
-                ambig_fname=self.params['ambig_fname'],
-                )
+        for combination in models_to_dock:
 
-            out_file = self.path / f"rigidbody_{idx}.out"
-            structure_file = self.path / f"rigidbody_{idx}.pdb"
-            structure_list.append(structure_file)
+            #  generate docking takes a list with file names
+            pdb_fname_list = [e[0].full_name for e in combination]
+            psf_fname_list = [e[1].full_name for e in combination]
 
-            job = CNSJob(
-                inp_file,
-                out_file,
-                cns_folder=self.cns_folder_path,
-                modpath=self.path,
-                config_path=self.params['config_path'],
-                cns_exec=self.params['cns_exec'],
-                )
+            for _i in range(sampling_factor):
+                inp_file = generate_docking(
+                    idx,
+                    pdb_fname_list,
+                    psf_fname_list,
+                    self.path,
+                    self.recipe_str,
+                    self.params,
+                    ambig_fname=self.params['ambig_fname'],
+                    )
 
-            jobs.append(job)
+                log_fname = Path(self.path, f"rigidbody_{idx}.out")
+                output_pdb_fname = Path(self.path, f"rigidbody_{idx}.pdb")
+
+                # Create a model for the expected output
+                model = PDBFile(output_pdb_fname, path=self.path)
+                model.topology = [e[1] for e in combination]
+                structure_list.append(model)
+
+                job = CNSJob(
+                    inp_file,
+                    log_fname,
+                    cns_folder=self.cns_folder_path,
+                    modpath=self.path,
+                    config_path=self.params['config_path'],
+                    cns_exec=self.params['cns_exec'],
+                    )
+                jobs.append(job)
+
+                idx += 1
 
         # Run CNS engine
         log.info(f"Running CNS engine with {len(jobs)} jobs")
@@ -145,27 +172,30 @@ class HaddockModule(BaseHaddockModule):
             ('w_vdw', 'w_elec', 'w_desolv', 'w_air', 'w_bsa')
         weights = {e: self.params[e] for e in _weight_keys}
 
-        expected = []
-        not_found = []
+        not_present = []
         for model in structure_list:
-            if not model.exists():
-                not_found.append(model.name)
+            if not model.is_present():
+                not_present.append(model.name)
 
-            haddock_score = HaddockModel(model).calc_haddock_score(**weights)
+            # Score the model
+            haddock_score = \
+                HaddockModel(model.full_name).calc_haddock_score(**weights)
 
-            pdb = PDBFile(model, path=self.path)
-            pdb.score = haddock_score
-            pdb.topology = topologies
-            expected.append(pdb)
+            model.score = haddock_score
 
-        if not_found:
-            # Check for generated output,
+        # Check for generated output
+        if len(not_present) == len(structure_list):
             # fail if not all expected files are found
-            self.finish_with_error("Several files were not generated:"
-                                   f" {not_found}")
+            self.finish_with_error("No models were generated.")
+
+        if not_present:
+            # also fail is some are not found
+            # Note: we can add some fault tolerancy here,
+            #  and only finish if a given % of models were not generated
+            self.finish_with_error(f"Several models were not generated"
+                                   f" {not_present}")
 
         # Save module information
         io = ModuleIO()
-        io.add(structure_list)
-        io.add(expected, "o")
+        io.add(structure_list, "o")
         io.save(self.path)

--- a/src/haddock/modules/topology/topoaa/__init__.py
+++ b/src/haddock/modules/topology/topoaa/__init__.py
@@ -127,7 +127,6 @@ class HaddockModule(BaseHaddockModule):
         #  are found
         expected = {}
         not_found = []
-        # for i in models_dic:
         for i in models_dic:
             expected[i] = {}
             for j, model in enumerate(models_dic[i]):

--- a/src/haddock/modules/topology/topoaa/__init__.py
+++ b/src/haddock/modules/topology/topoaa/__init__.py
@@ -74,10 +74,10 @@ class HaddockModule(BaseHaddockModule):
         # Pool of jobs to be executed by the CNS engine
         jobs = []
 
-        models = []
+        models_dic = {}
         for i, molecule in enumerate(molecules, start=1):
             log.info(f"{i} - {molecule.file_name}")
-
+            models_dic[i] = []
             # Copy the molecule to the step folder
             step_molecule_path = Path(self.path, molecule.file_name.name)
             shutil.copyfile(molecule.file_name, step_molecule_path)
@@ -90,7 +90,7 @@ class HaddockModule(BaseHaddockModule):
             # Sanitize the different PDB files
             for model in splited_models:
                 log.info(f"Sanitizing molecule {model.name}")
-                models.append(model)
+                models_dic[i].append(model)
                 libpdb.sanitize(model, overwrite=True)
 
                 # Prepare generation of topologies jobs
@@ -98,7 +98,7 @@ class HaddockModule(BaseHaddockModule):
                                                       self.path,
                                                       self.recipe_str,
                                                       self.params)
-                log.info("Topology CNS input created in {topology_filename}")
+                log.info(f"Topology CNS input created in {topology_filename}")
 
                 # Add new job to the pool
                 output_filename = Path(
@@ -125,35 +125,39 @@ class HaddockModule(BaseHaddockModule):
 
         # Check for generated output, fail it not all expected files
         #  are found
-        expected = []
+        expected = {}
         not_found = []
-        for model in models:
-            model_name = model.stem
-            processed_pdb = Path(
-                self.path,
-                f"{model_name}_haddock.{Format.PDB}"
-                )
-            if not processed_pdb.is_file():
-                not_found.append(processed_pdb.name)
-            processed_topology = Path(
-                self.path,
-                f"{model_name}_haddock.{Format.TOPOLOGY}"
-                )
-            if not processed_topology.is_file():
-                not_found.append(processed_topology.name)
-            topology = TopologyFile(processed_topology,
-                                    path=self.path)
-            expected.append(topology)
-            expected.append(PDBFile(processed_pdb,
-                                    topology,
-                                    path=self.path))
+        # for i in models_dic:
+        for i in models_dic:
+            expected[i] = {}
+            for j, model in enumerate(models_dic[i]):
+                model_name = model.stem
+                processed_pdb = Path(
+                    self.path,
+                    f"{model_name}_haddock.{Format.PDB}"
+                    )
+                if not processed_pdb.is_file():
+                    not_found.append(processed_pdb.name)
+                processed_topology = Path(
+                    self.path,
+                    f"{model_name}_haddock.{Format.TOPOLOGY}"
+                    )
+                if not processed_topology.is_file():
+                    not_found.append(processed_topology.name)
+
+                topology = TopologyFile(processed_topology,
+                                        path=self.path)
+                pdb = PDBFile(processed_pdb,
+                              topology,
+                              path=self.path)
+                expected[i][j] = (pdb, topology)
+
         if not_found:
             self.finish_with_error("Several files were not generated:"
                                    f" {not_found}")
 
         # Save module information
         io = ModuleIO()
-        for model in models:
-            io.add(PDBFile(model))
-        io.add(expected, "o")
+        for i in expected:
+            io.add(expected[i], "o")
         io.save(self.path)

--- a/src/haddock/modules/topology/topoaa/__init__.py
+++ b/src/haddock/modules/topology/topoaa/__init__.py
@@ -150,7 +150,7 @@ class HaddockModule(BaseHaddockModule):
                 pdb = PDBFile(processed_pdb,
                               topology,
                               path=self.path)
-                expected[i][j] = (pdb, topology)
+                expected[i][j] = pdb
 
         if not_found:
             self.finish_with_error("Several files were not generated:"


### PR DESCRIPTION
This PR implements ensemble support for docking and closes #148.

Note that for this to work I had to change the data structure of `topoaa`, meaning that all modules that come after it need to be refactored, meaning meaning that we can no longer do refinement runs (but I'm not sure if this was possible anyway `topoaa > flexref`), let's work on this example in another PR.