### PR TITLE
Fixes arrays being overwritten in `caprieval`

### DIFF
--- a/src/haddock/modules/analysis/caprieval/__init__.py
+++ b/src/haddock/modules/analysis/caprieval/__init__.py
@@ -208,14 +208,16 @@ class CAPRI:
         ref_interface_resdic = identify_interface(self.reference, cutoff)
 
         # Load interface coordinates
-        Q, _ = load_coords(self.reference,
-                           filter_resdic=ref_interface_resdic,
-                           atoms=self.atoms,
-                           ignore_missing=self.ignore_missing)
+        _Q, _ = load_coords(self.reference,
+                            filter_resdic=ref_interface_resdic,
+                            atoms=self.atoms,
+                            ignore_missing=self.ignore_missing)
         # Move to centroids
-        Q = Q - centroid(Q)
+        _Q -= centroid(_Q)
 
         for model in self.model_list:
+
+            Q = copy.deepcopy(_Q)
 
             P, _ = load_coords(model,
                                filter_resdic=ref_interface_resdic,
@@ -250,18 +252,21 @@ class CAPRI:
         del ref_receptor_resdic[ligand_chain]
 
         # Get reference coordinates
-        Q_all, chain_ranges = load_coords(self.reference,
-                                          filter_resdic=ref_resdic,
-                                          atoms=self.atoms,
-                                          ignore_missing=self.ignore_missing)
+        _Q, chain_ranges = load_coords(self.reference,
+                                       filter_resdic=ref_resdic,
+                                       atoms=self.atoms,
+                                       ignore_missing=self.ignore_missing)
 
         receptor_start = chain_ranges[receptor_chain][0]
         receptor_end = chain_ranges[receptor_chain][1]
-        Q_receptor = Q_all[receptor_start:receptor_end]
+        _Q_receptor = _Q[receptor_start:receptor_end]
 
         # loop goes here
         model = self.model_list[0]
         for model in self.model_list:
+
+            Q_all = copy.deepcopy(_Q)
+            Q_receptor = copy.deepcopy(_Q_receptor)
 
             P_all, _ = load_coords(model,
                                    filter_resdic=ref_resdic,
@@ -319,10 +324,10 @@ class CAPRI:
         ref_interface_resdic = identify_interface(self.reference, cutoff)
 
         # Load interface coordinates
-        Q, chain_ranges = load_coords(self.reference,
-                                      filter_resdic=ref_resdic,
-                                      atoms=self.atoms,
-                                      ignore_missing=self.ignore_missing)
+        _Q, chain_ranges = load_coords(self.reference,
+                                       filter_resdic=ref_resdic,
+                                       atoms=self.atoms,
+                                       ignore_missing=self.ignore_missing)
 
         Q_int, _ = load_coords(self.reference,
                                filter_resdic=ref_interface_resdic,
@@ -334,7 +339,7 @@ class CAPRI:
 
         for model in self.model_list:
 
-            Q_all = copy.deepcopy(Q)
+            Q_all = copy.deepcopy(_Q)
 
             P_all, _ = load_coords(model,
                                    filter_resdic=ref_resdic,

--- a/src/haddock/modules/analysis/caprieval/__init__.py
+++ b/src/haddock/modules/analysis/caprieval/__init__.py
@@ -217,6 +217,8 @@ class CAPRI:
 
         for model in self.model_list:
 
+            # This has no effect, but keep it here
+            #  for the next time we need to debug this function
             Q = copy.deepcopy(_Q)
 
             P, _ = load_coords(model,
@@ -247,9 +249,6 @@ class CAPRI:
         log.info(f'  Receptor chain = {receptor_chain}')
         log.info(f'  Ligand chain = {ligand_chain}')
         ref_resdic = read_res(self.reference)
-
-        ref_receptor_resdic = copy.deepcopy(ref_resdic)
-        del ref_receptor_resdic[ligand_chain]
 
         # Get reference coordinates
         _Q, chain_ranges = load_coords(self.reference,


### PR DESCRIPTION
This PR fixes #154 


```tsv
# before
model	fnat	irmsd	lrmsd	ilrmsd	
rigidbody_1.pdb	0.167	3.96	12.74	5.51	
rigidbody_2.pdb	0.083	4.78	68.65	5.90	
rigidbody_3.pdb	0.500	1.28	2.65	1.62	
rigidbody_4.pdb	0.500	1.30	64.36	1.58	
rigidbody_5.pdb	0.556	1.46	3.60	2.20	
```
```tsv
# after
model	fnat	irmsd	lrmsd	ilrmsd	
rigidbody_1.pdb	0.167	3.96	12.74	5.51	
rigidbody_2.pdb	0.083	4.78	14.49	5.90	
rigidbody_3.pdb	0.500	1.28	2.65	1.62	
rigidbody_4.pdb	0.500	1.30	2.49	1.58	
rigidbody_5.pdb	0.556	1.46	3.60	2.20	
```