### PR TITLE
empty strings are written to CNS

### DIFF
--- a/src/haddock/libs/libcns.py
+++ b/src/haddock/libs/libcns.py
@@ -47,7 +47,7 @@ def filter_empty_vars(v):
         If the type of `value` is not supported by CNS.
     """
     cases = (
-        (lambda x: isinstance(x, str), bool),
+        (lambda x: isinstance(x, str), true),
         (lambda x: isinstance(x, bool), true),  # it should return True
         (lambda x: isinstance(x, Path), true),
         (lambda x: type(x) in (int, float), true),

--- a/tests/test_libcns.py
+++ b/tests/test_libcns.py
@@ -32,6 +32,7 @@ def test_empty_vars_error(value):
         3453.543,
         'str',
         Path('path'),
+        '',
         ]
     )
 def test_empty_vars_True(value):
@@ -43,7 +44,7 @@ def test_empty_vars_True(value):
 
 @pytest.mark.parametrize(
     'value',
-    ["", None]
+    [None],
     )
 def test_empty_vars_False(value):
     """Test empty vars of types that are not supported."""
@@ -74,6 +75,7 @@ def test_load_workflow_params():
         f'eval ($var3=true){os.linesep}'
         f'eval ($var4="some/path"){os.linesep}'
         f'eval ($var5=5.5){os.linesep}'
+        f'eval ($var6=""){os.linesep}'
         )
 
     assert result == expected


### PR DESCRIPTION
Empty strings `""` are now written to CNS file. I had misunderstood the requirements from #162. 