### PR TITLE
Add .vscode to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,6 +134,8 @@ dmypy.json
 tags
 .vim
 
+# VSCode
+.vscode
 
 ## Specific to this project
 bin/cns


### PR DESCRIPTION
If we can have vim stuff in .gitignore we can also have VSCode stuff 😉 