### PR TITLE
Implement HPC execution

### DIFF
--- a/examples/docking-protein-protein/docking-protein-protein-hpc.cfg
+++ b/examples/docking-protein-protein/docking-protein-protein-hpc.cfg
@@ -1,0 +1,66 @@
+# ====================================================================
+# Rigid-body docking example
+
+# directory in which the scoring will be done
+run_dir = "run1"
+
+# ###
+mode = 'hpc'
+# concatenate models inside each job, concat = 5 each .job will produce 5 models
+concat = 1
+#  Limit the number of concurrent submissions to the queue
+queue_limit = 100
+# cns_exec = "path/to/bin/cns" # optional
+# ###
+
+# molecules to be docked
+molecules =  [
+    "data/e2aP_1F3G.pdb",
+    "data/hpr_ensemble.pdb"
+    ]
+
+# ====================================================================
+# Parameters for each stage are defined below, prefer full paths
+#####################################################################
+# WARNING: THE PARAMETERS HERE ARE ILLUSTRATIVE
+#  THE WORKFLOW IS WORK-IN-PROGRESS
+#####################################################################
+[topoaa]
+autohis = false
+[topoaa.input.mol1]
+nhisd = 0
+nhise = 1
+hise_1 = 75
+[topoaa.input.mol2]
+nhisd = 1
+hisd_1 = 76
+nhise = 1
+hise_1 = 15
+
+[rigidbody]
+ambig_fname = 'data/e2a-hpr_air.tbl'
+sampling = 1000
+noecv = true
+
+[caprieval]
+reference = 'data/e2a-hpr_1GGR.pdb'
+
+[seletop]
+select = 200
+
+[flexref]
+ambig_fname = 'data/e2a-hpr_air.tbl'
+noecv = true
+
+[caprieval]
+reference = 'data/e2a-hpr_1GGR.pdb'
+
+[emref]
+ambig_fname = 'data/e2a-hpr_air.tbl'
+noecv = true
+
+[caprieval]
+reference = 'data/e2a-hpr_1GGR.pdb'
+
+# ====================================================================
+

--- a/src/haddock/clis/cli_bm.py
+++ b/src/haddock/clis/cli_bm.py
@@ -48,6 +48,7 @@ from functools import partial
 from pathlib import Path
 
 from haddock import log
+from haddock.libs.libhpc import create_job_header_funcs
 
 
 # first character allowed for benchmark test cases, we use digits and
@@ -312,88 +313,6 @@ def create_job(
     return job_header + job_body + job_tail
 
 
-def create_torque_header(
-        job_name,
-        work_dir,
-        stdout_path,
-        stderr_path,
-        queue='medium',
-        ncores=48,
-        ):
-    """
-    Create HADDOCK3 Alcazar job file.
-
-    Parameters
-    ----------
-    job_name : str
-        The name of the job.
-
-    work_dir : pathlib.Path
-        The working dir of the example. That is, the directory where
-        `input`, `jobs`, and `logs` reside. Injected in `create_job_header`.
-
-    **job_params
-        According to `job_setup`.
-
-    Return
-    ------
-    str
-        Torque-based job file for HADDOCK3 benchmarking.
-    """
-    header = \
-f"""#!/usr/bin/env tcsh
-#PBS -N {job_name}
-#PBS -q {queue}
-#PBS -l nodes=1:ppn={str(ncores)}
-#PBS -S /bin/tcsh
-#PBS -o {stdout_path}
-#PBS -e {stderr_path}
-#PBS -wd {work_dir}
-"""
-    return header
-
-
-def create_slurm_header(
-        job_name,
-        work_dir,
-        stdout_path,
-        stderr_path,
-        queue='medium',
-        ncores=48,
-        ):
-    """
-    Create HADDOCK3 Slurm Batch job file.
-
-    Parameters
-    ----------
-    job_name : str
-        The name of the job.
-
-    work_dir : pathlib.Path
-        The working dir of the example. That is, the directory where
-        `input`, `jobs`, and `logs` reside. Injected in `create_job_header`.
-
-    **job_params
-        According to `job_setup`.
-
-    Return
-    ------
-    str
-        Slurm-based job file for HADDOCK3 benchmarking.
-    """
-    header = \
-f"""#!/usr/bin/env bash
-#SBATCH -J {job_name}
-#SBATCH -p {queue}
-#SBATCH --nodes=1
-#SBATCH --tasks-per-node={str(ncores)}
-#SBATCH --output={stdout_path}
-#SBATCH --error={stderr_path}
-#SBATCH --workdir={work_dir}
-"""
-    return header
-
-
 def setup_haddock3_job(available_flag, running_flag, conf_f):
     """
     Write body for the job script.
@@ -567,8 +486,8 @@ def make_daemon_job(
         ):
     """Make a daemon-ready job."""
     job_header = create_job_func(
-        job_name,
-        workdir,
+        job_name=job_name,
+        work_dir=workdir,
         stdout_path=stdout_path,
         stderr_path=stderr_path,
         queue=queue,
@@ -588,13 +507,6 @@ haddock3-dmn {str(target_dir)}
 
 
 # helper dictionaries
-
-# the different job submission queues
-create_job_header_funcs = {
-    'torque': create_torque_header,
-    'slurm': create_slurm_header,
-    }
-
 
 # the different scenarios covered
 benchmark_scenarios = {

--- a/src/haddock/libs/libhpc.py
+++ b/src/haddock/libs/libhpc.py
@@ -11,6 +11,15 @@ from haddock import log
 
 STATE_REGEX = r"JobState=(\w*)"
 
+JOB_STATUS_DIC = {
+    "PENDING": "submitted",
+    "RUNNING": "running",
+    "SUSPENDED": "hold",
+    "COMPLETING": "running",
+    "COMPLETED": "finished",
+    "FAILED": "failed",
+    }
+
 
 class HPCWorker:
     """Defines the HPC Job."""
@@ -41,18 +50,7 @@ class HPCWorker:
             # TODO: Maybe a regex here is overkill
             # https://regex101.com/r/M2vbAc/1
             status = re.findall(STATE_REGEX, out)[0]
-            if status == "PENDING":
-                self.job_status = "submitted"
-            elif status == "RUNNING":
-                self.job_status = "running"
-            elif status == "SUSPENDED":
-                self.job_status = "hold"
-            elif status == "COMPLETING":
-                self.job_status = "running"
-            elif status == "COMPLETED":
-                self.job_status = "finished"
-            elif status == "FAILED":
-                self.job_status = "failed"
+            self.job_status = JOB_STATUS_DIC[status]
         else:
             self.job_status = "finished"
 

--- a/src/haddock/libs/libhpc.py
+++ b/src/haddock/libs/libhpc.py
@@ -144,8 +144,6 @@ class HPCScheduler:
         """Run tasks in the Queue."""
         # split by maximum number of submission so we do it in batches
         adaptive_l = []
-        completed_count = 0
-        failed_count = 0
         batch = [
             self.worker_list[i:i + self.queue_limit]
             for i in range(0, len(self.worker_list), self.queue_limit)
@@ -168,10 +166,10 @@ class HPCScheduler:
                                 f" {worker.job_status}"
                                 )
 
-                    completed_count += sum(
+                    completed_count = sum(
                         w.job_status == "finished" for w in job_list
                         )
-                    failed_count += sum(
+                    failed_count = sum(
                         w.job_status == "failed" for w in job_list
                         )
 

--- a/src/haddock/libs/libhpc.py
+++ b/src/haddock/libs/libhpc.py
@@ -1,0 +1,196 @@
+"""Module in charge of running tasks in HPC."""
+from haddock import log
+from pathlib import Path
+import subprocess
+import os
+import shlex
+import re
+import time
+
+STATE_REGEX = r"JobState=(\w*)"
+
+
+class HPCWorker:
+    """Defines the HPC Job."""
+
+    def __init__(self, tasks):
+        self.tasks = tasks
+        log.debug(f"HPCWorker ready with {len(self.tasks)}")
+        self.job_id = None
+        self.job_status = "unknown"
+        self.job_fname = ""
+
+    def run(self, identifier):
+        """Execute the tasks."""
+        job_file = self.prepare_job_file(self.tasks, identifier)
+        cmd = f"sbatch {job_file}"
+        p = subprocess.run(shlex.split(cmd), capture_output=True)
+        self.job_id = int(p.stdout.decode("utf-8").split()[-1])
+        self.job_status = "submitted"
+
+    def update_status(self):
+        """Retrieve the status of this worker."""
+        cmd = f"scontrol show jobid -dd {self.job_id}"
+        p = subprocess.run(shlex.split(cmd), capture_output=True)
+        out = p.stdout.decode("utf-8")
+        # err = p.stderr.decode('utf-8')
+        if out:
+            # TODO: Maybe a regex here is overkill
+            # https://regex101.com/r/M2vbAc/1
+            status = re.findall(STATE_REGEX, out)[0]
+            if status == "PENDING":
+                self.job_status = "submitted"
+            elif status == "RUNNING":
+                self.job_status = "running"
+            elif status == "SUSPENDED":
+                self.job_status = "hold"
+            elif status == "COMPLETING":
+                self.job_status = "running"
+            elif status == "COMPLETED":
+                self.job_status = "finished"
+            elif status == "FAILED":
+                self.job_status = "failed"
+        else:
+            self.job_status = "finished"
+
+        return self.job_status
+
+    def prepare_job_file(self, job_list, id):
+        job_name = "haddock3"
+        queue = "haddock"
+        moddir = job_list[0].modpath
+        module = job_list[0].cns_folder
+        run = job_list[0].config_path
+        toppar = job_list[0].toppar
+        module_name = job_list[0].modpath.name.split("_")[-1]
+        self.job_fname = Path(moddir, f"{module_name}_{id}.job")
+        out_fname = Path(moddir, f"{module_name}_{id}.out")
+        err_fname = Path(moddir, f"{module_name}_{id}.err")
+
+        header = f"#!/bin/sh{os.linesep}"
+        header += f"#SBATCH -J {job_name}{os.linesep}"
+        header += f"#SBATCH -p {queue}{os.linesep}"
+        header += f"#SBATCH --nodes=1{os.linesep}"
+        header += f"#SBATCH --tasks-per-node=1{os.linesep}"
+        header += f"#SBATCH --output={out_fname}{os.linesep}"
+        header += f"#SBATCH --error={err_fname}{os.linesep}"
+        header += f"#SBATCH --workdir={moddir}{os.linesep}"
+
+        envs = f"export MODDIR={moddir}{os.linesep}"
+        envs += f"export MODULE={module}{os.linesep}"
+        envs += f"export RUN={run}{os.linesep}"
+        envs += f"export TOPPAR={toppar}{os.linesep}"
+
+        body = envs
+
+        body += f"cd {moddir}" + os.linesep
+        for job in job_list:
+            cmd = (
+                f"{job.cns_exec} < {job.input_file} > {job.output_file}"
+                f"{os.linesep}"
+                )
+            body += cmd
+
+        with open(self.job_fname, "w") as job_fh:
+            job_fh.write(header)
+            job_fh.write(body)
+
+        return self.job_fname
+
+    def cancel(self):
+        """Cancel the execution."""
+        bypass_statuses = ["finished", "failed"]
+        if self.update_status() not in bypass_statuses:
+            log.info(f"Canceling {self.job_fname.name} - {self.job_id}")
+            cmd = f"scancel {self.job_id}"
+            _ = subprocess.run(shlex.split(cmd), capture_output=True)
+
+
+class HPCScheduler:
+    """Schedules tasks to run in HPC."""
+
+    def __init__(self, task_list, queue_limit, concat):
+        self.num_tasks = len(task_list)
+        # FIXME: The defaults are hardcoded here
+        if not concat:
+            concat = 1
+        if not queue_limit:
+            queue_limit = 100
+        # =======
+        self.queue_limit = queue_limit
+        self.concat = concat
+
+        # split tasks according to concat level
+        if concat > 1:
+            log.info(f"Concatenating, each .job will produce {concat} models")
+        job_list = [
+            task_list[i:i + concat] for i in range(0, len(task_list), concat)
+            ]
+
+        self.worker_list = [HPCWorker(t) for t in job_list]
+
+        log.debug(f"{self.num_tasks} HPC tasks ready.")
+
+    def run(self):
+        """Run tasks in the Queue."""
+        # split by maximum number of submission so we do it in batches
+        batch = [
+            self.worker_list[i:i + self.queue_limit]
+            for i in range(0, len(self.worker_list), self.queue_limit)
+            ]
+        try:
+            for batch_num, worker_list in enumerate(batch, start=1):
+                log.info(f"> Running batch {batch_num}/{len(batch)}")
+                for i, worker in enumerate(worker_list, start=1):
+                    worker.run(i)
+
+                # check if those finished
+                completed = False
+                while not completed:
+                    for worker in worker_list:
+                        worker.update_status()
+                        if worker.job_status != "finished":
+                            log.info(
+                                f">> {worker.job_fname.name}"
+                                f" {worker.job_status}"
+                                )
+
+                    completed_count = sum(
+                        w.job_status == "finished" for w in worker_list
+                        )
+                    failed_count = sum(
+                        w.job_status == "failed" for w in worker_list
+                        )
+
+                    per = (
+                        (completed_count + failed_count) / len(self.worker_list)
+                        ) * 100
+                    log.info(f">> {per:.0f}% done")
+                    if completed_count + failed_count == len(worker_list):
+                        completed = True
+                    else:
+                        sleep_timer = 0
+                        if len(worker_list) < 10:
+                            # this is a small batch, wait just a little
+                            sleep_timer = 10
+                        elif len(worker_list) < 50:
+                            # this is a bit larger, wait longer
+                            sleep_timer = 30
+                        else:
+                            # this can be large, wait more!
+                            sleep_timer = 60
+                        log.info(f">> Waiting... ({sleep_timer}s)")
+                        time.sleep(sleep_timer)
+                log.info(f"> Batch {batch_num}/{len(batch)} done")
+
+        except KeyboardInterrupt as err:
+            self.terminate()
+            raise err
+
+    def terminate(self):
+        """Terminate all jobs in the queue in a controlled way."""
+        log.info("Terminate signal recieved, removing jobs from the queue...")
+        for worker in self.worker_list:
+            worker.cancel()
+
+        log.info("The jobs in the queue were terminated in a controlled way")

--- a/src/haddock/libs/libhpc.py
+++ b/src/haddock/libs/libhpc.py
@@ -1,11 +1,13 @@
 """Module in charge of running tasks in HPC."""
-from haddock import log
-from pathlib import Path
-import subprocess
 import os
-import shlex
 import re
+import shlex
+import subprocess
 import time
+from pathlib import Path
+
+from haddock import log
+
 
 STATE_REGEX = r"JobState=(\w*)"
 
@@ -57,6 +59,7 @@ class HPCWorker:
         return self.job_status
 
     def prepare_job_file(self, job_list):
+        """Prepare a .job file for SLURM."""
         job_name = "haddock3"
         queue = "haddock"
         moddir = job_list[0].modpath

--- a/src/haddock/libs/libhpc.py
+++ b/src/haddock/libs/libhpc.py
@@ -20,22 +20,76 @@ JOB_STATUS_DIC = {
     "FAILED": "failed",
     }
 
+HPCScheduler_CONCAT_DEFAULT = 1
+HPCWorker_QUEUE_LIMIT_DEFAULT = 100
+
 
 class HPCWorker:
     """Defines the HPC Job."""
 
-    def __init__(self, tasks, num):
+    def __init__(
+            self,
+            tasks,
+            num,
+            job_id=None,
+            queue_type='slurm',
+            ):
+        """
+        Define the HPC job.
+
+        Parameters
+        ----------
+        tasks : list of libs.libcns.CNSJob objects
+
+        num : int
+            The number of the worker.
+        """
         self.tasks = tasks
         log.debug(f"HPCWorker ready with {len(self.tasks)}")
-        self.job_id = None
         self.job_num = num
+        self.job_id = job_id
         self.job_status = "unknown"
-        self.job_fname = ""
+
+        self.moddir = tasks[0].modpath
+        self.module_name = self.moddir.name.split('_')[-1]
+        self.config_path = tasks[0].config_path
+        self.toppar = tasks[0].toppar
+        self.cns_folder = tasks[0].cns_folder
+        self.job_fname = Path(self.moddir, f'{self.module_name}_{num}.job')
+        self.queue_type = queue_type
+
+    def prepare_job_file(self, queue_type='slurm'):
+        """Prepare the job file for all the jobs in the task list."""
+        job_file_contents = create_job_header_funcs[queue_type](
+            job_name='haddock3',
+            queue='haddock',
+            ncores=1,
+            work_dir=self.moddir,
+            stdout_path=self.job_fname.with_suffix('.out'),
+            stderr_path=self.job_fname.with_suffix('.err'),
+            )
+
+        job_file_contents += create_CNS_export_envvars(
+            MODDIR=self.moddir,
+            MODULE=self.cns_folder,
+            RUN=self.config_path,
+            TOPPAR=self.toppar,
+            )
+
+        job_file_contents += f"cd {self.moddir}{os.linesep}"
+        for job in self.tasks:
+            cmd = (
+                f"{job.cns_exec} < {job.input_file} > {job.output_file}"
+                f"{os.linesep}"
+                )
+            job_file_contents += cmd
+
+        self.job_fname.write_text(job_file_contents)
 
     def run(self):
         """Execute the tasks."""
-        job_file = self.prepare_job_file(self.tasks)
-        cmd = f"sbatch {job_file}"
+        self.prepare_job_file(self.queue_type)
+        cmd = f"sbatch {self.job_fname}"
         p = subprocess.run(shlex.split(cmd), capture_output=True)
         self.job_id = int(p.stdout.decode("utf-8").split()[-1])
         self.job_status = "submitted"
@@ -56,52 +110,8 @@ class HPCWorker:
 
         return self.job_status
 
-    def prepare_job_file(self, job_list):
-        """Prepare a .job file for SLURM."""
-        job_name = "haddock3"
-        queue = "haddock"
-        moddir = job_list[0].modpath
-        module = job_list[0].cns_folder
-        run = job_list[0].config_path
-        toppar = job_list[0].toppar
-        module_name = job_list[0].modpath.name.split("_")[-1]
-        self.job_fname = Path(moddir, f"{module_name}_{self.job_num}.job")
-        out_fname = Path(moddir, f"{module_name}_{self.job_num}_job.out")
-        err_fname = Path(moddir, f"{module_name}_{self.job_num}_job.err")
-
-        header = f"#!/bin/sh{os.linesep}"
-        header += f"#SBATCH -J {job_name}{os.linesep}"
-        header += f"#SBATCH -p {queue}{os.linesep}"
-        header += f"#SBATCH --nodes=1{os.linesep}"
-        header += f"#SBATCH --tasks-per-node=1{os.linesep}"
-        header += f"#SBATCH --output={out_fname}{os.linesep}"
-        header += f"#SBATCH --error={err_fname}{os.linesep}"
-        header += f"#SBATCH --workdir={moddir}{os.linesep}"
-
-        envs = f"export MODDIR={moddir}{os.linesep}"
-        envs += f"export MODULE={module}{os.linesep}"
-        envs += f"export RUN={run}{os.linesep}"
-        envs += f"export TOPPAR={toppar}{os.linesep}"
-
-        body = envs
-
-        body += f"cd {moddir}" + os.linesep
-        for job in job_list:
-            cmd = (
-                f"{job.cns_exec} < {job.input_file} > {job.output_file}"
-                f"{os.linesep}"
-                )
-            body += cmd
-
-        with open(self.job_fname, "w") as job_fh:
-            job_fh.write(header)
-            job_fh.write(body)
-
-        return self.job_fname
-
-    def cancel(self):
+    def cancel(self, bypass_statuses=("finished", "failed")):
         """Cancel the execution."""
-        bypass_statuses = ["finished", "failed"]
         if self.update_status() not in bypass_statuses:
             log.info(f"Canceling {self.job_fname.name} - {self.job_id}")
             cmd = f"scancel {self.job_id}"
@@ -111,14 +121,13 @@ class HPCWorker:
 class HPCScheduler:
     """Schedules tasks to run in HPC."""
 
-    def __init__(self, task_list, queue_limit, concat):
+    def __init__(
+            self,
+            task_list,
+            queue_limit=HPCWorker_QUEUE_LIMIT_DEFAULT,
+            concat=HPCScheduler_CONCAT_DEFAULT,
+            ):
         self.num_tasks = len(task_list)
-        # FIXME: The defaults are hardcoded here
-        if not concat:
-            concat = 1
-        if not queue_limit:
-            queue_limit = 100
-        # =======
         self.queue_limit = queue_limit
         self.concat = concat
 
@@ -210,3 +219,120 @@ class HPCScheduler:
             worker.cancel()
 
         log.info("The jobs in the queue were terminated in a controlled way")
+
+
+def create_slurm_header(
+        job_name='haddock3_slurm_job',
+        work_dir='.',
+        stdout_path='haddock3_job.out',
+        stderr_path='haddock3_job.err',
+        queue='medium',
+        ncores=48,
+        ):
+    """
+    Create HADDOCK3 Slurm Batch job file.
+
+    Parameters
+    ----------
+    job_name : str
+        The name of the job.
+
+    work_dir : pathlib.Path
+        The working dir of the example. That is, the directory where
+        `input`, `jobs`, and `logs` reside. Injected in `create_job_header`.
+
+    **job_params
+        According to `job_setup`.
+
+    Return
+    ------
+    str
+        Slurm-based job file for HADDOCK3.
+    """
+    header = \
+f"""#!/usr/bin/env bash
+#SBATCH -J {job_name}
+#SBATCH -p {queue}
+#SBATCH --nodes=1
+#SBATCH --tasks-per-node={str(ncores)}
+#SBATCH --output={stdout_path}
+#SBATCH --error={stderr_path}
+#SBATCH --workdir={work_dir}
+
+"""  # noqa: E128
+    return header
+
+
+def create_torque_header(
+        job_name='haddock3_torque_job',
+        work_dir='.',
+        stdout_path='haddock3_job.out',
+        stderr_path='haddock3_job.err',
+        queue='medium',
+        ncores=48,
+        ):
+    """
+    Create HADDOCK3 Alcazar job file.
+
+    Parameters
+    ----------
+    job_name : str
+        The name of the job.
+
+    work_dir : pathlib.Path
+        The working dir of the example. That is, the directory where
+        `input`, `jobs`, and `logs` reside. Injected in `create_job_header`.
+
+    **job_params
+        According to `job_setup`.
+
+    Return
+    ------
+    str
+        Torque-based job file for HADDOCK3 benchmarking.
+    """
+    header = \
+f"""#!/usr/bin/env tcsh
+#PBS -N {job_name}
+#PBS -q {queue}
+#PBS -l nodes=1:ppn={str(ncores)}
+#PBS -S /bin/tcsh
+#PBS -o {stdout_path}
+#PBS -e {stderr_path}
+#PBS -wd {work_dir}
+
+"""  # noqa: E128
+    return header
+
+
+def create_CNS_export_envvars(**envvars):
+    """Create a string exporting envvars needed for CNS.
+
+    Parameters
+    ----------
+    envvars : dict
+        A dictionary containing envvariables where keys are var names
+        and values are the values.
+
+    Returns
+    -------
+    str
+        In the form of:
+        export VAR1=VALUE1
+        export VAR2=VALUE2
+        export VAR3=VALUE3
+
+    """
+    exports = os.linesep.join(
+        f'export {key.upper()}={value}'
+        for key, value in envvars.items()
+        )
+
+    return exports + os.linesep + os.linesep
+
+
+# the different job submission queues
+create_job_header_funcs = {
+    'torque': create_torque_header,
+    'slurm': create_slurm_header,
+    }

--- a/src/haddock/libs/libworkflow.py
+++ b/src/haddock/libs/libworkflow.py
@@ -39,7 +39,7 @@ class Workflow:
             run_dir=None,
             cns_exec=None,
             config_path=None,
-            mode=None,
+            mode='local',
             concat=HPCScheduler_CONCAT_DEFAULT,
             queue_limit=HPCWorker_QUEUE_LIMIT_DEFAULT,
             **ignore):

--- a/src/haddock/libs/libworkflow.py
+++ b/src/haddock/libs/libworkflow.py
@@ -7,6 +7,10 @@ from pathlib import Path
 from haddock import log
 from haddock.core.exceptions import HaddockError, StepError
 from haddock.gear.config_reader import get_module_name
+from haddock.libs.libhpc import (
+    HPCScheduler_CONCAT_DEFAULT,
+    HPCWorker_QUEUE_LIMIT_DEFAULT,
+    )
 from haddock.libs.libutil import zero_fill
 from haddock.modules import modules_category
 
@@ -36,9 +40,9 @@ class Workflow:
             cns_exec=None,
             config_path=None,
             mode=None,
-            concat=None,
-            queue_limit=None,
-            **ig):
+            concat=HPCScheduler_CONCAT_DEFAULT,
+            queue_limit=HPCWorker_QUEUE_LIMIT_DEFAULT,
+            **ignore):
         # Create the list of steps contained in this workflow
         self.steps = []
         for num_stage, (stage_name, params) in enumerate(content.items()):

--- a/src/haddock/libs/libworkflow.py
+++ b/src/haddock/libs/libworkflow.py
@@ -35,6 +35,9 @@ class Workflow:
             run_dir=None,
             cns_exec=None,
             config_path=None,
+            mode=None,
+            concat=None,
+            queue_limit=None,
             **ig):
         # Create the list of steps contained in this workflow
         self.steps = []
@@ -46,6 +49,9 @@ class Workflow:
             params.setdefault('ncores', ncores)
             params.setdefault('cns_exec', cns_exec)
             params.setdefault('config_path', config_path)
+            params.setdefault('mode', mode)
+            params.setdefault('concat', concat)
+            params.setdefault('queue_limit', queue_limit)
 
             try:
                 _ = Step(

--- a/src/haddock/modules/__init__.py
+++ b/src/haddock/modules/__init__.py
@@ -24,7 +24,9 @@ modules_category = {
 values are their categories. Categories are the modules parent folders."""
 
 
-general_parameters_affecting_modules = {'ncores', 'cns_exec'}
+general_parameters_affecting_modules = {
+    'ncores', 'cns_exec', 'mode', 'concat', 'queue_limit'
+    }
 """These parameters are general parameters that may be applicable to modules
 specifically. Therefore, they should be considered as part of the "default"
 module's parameters. Usually, this set is used to filter parameters during
@@ -96,6 +98,9 @@ class BaseHaddockModule(ABC):
         self.update_params(**params)
         self.params.setdefault('ncores', None)
         self.params.setdefault('cns_exec', None)
+        self.params.setdefault('mode', None)
+        self.params.setdefault('concat', None)
+        self.params.setdefault('queue_limit', None)
         self._run()
         log.info(f'Module [{self.name}] finished.')
 

--- a/src/haddock/modules/__init__.py
+++ b/src/haddock/modules/__init__.py
@@ -2,13 +2,16 @@
 import contextlib
 import os
 from abc import ABC, abstractmethod
+from functools import partial
 from pathlib import Path
 
 from haddock import log as log
 from haddock.core.defaults import MODULE_IO_FILE
 from haddock.core.exceptions import StepError
 from haddock.gear.config_reader import read_config
+from haddock.libs.libhpc import HPCScheduler
 from haddock.libs.libontology import ModuleIO
+from haddock.libs.libparallel import Scheduler
 from haddock.libs.libutil import recursive_dict_update
 
 
@@ -170,3 +173,40 @@ def working_directory(path):
         yield
     finally:
         os.chdir(prev_cwd)
+
+
+def get_engine(mode, params):
+    """
+    Create an engine to run the jobs.
+
+    Parameters
+    ----------
+    mode : str
+        The type of engine to create
+
+    params : dict
+        A dictionary containing parameters for the engine.
+        `get_engine` will retrieve from `params` only those parameters
+        needed and ignore the others.
+    """
+    # a bit of a factory pattern here
+    # this might end up in another module but for now its fine here
+    if mode == 'hpc':
+        return partial(
+            HPCScheduler,
+            queue_limit=params['queue_limit'],
+            concat=params['concat'],
+            )
+
+    elif mode == 'local':
+        return partial(
+            Scheduler,
+            ncores=params['ncores'],
+            )
+
+    else:
+        available_engines = ('hpc', 'local')
+        raise ValueError(
+            f"Scheduler `mode` {mode!r} not recognized. "
+            f"Available options are {', '.join(available_engines)}"
+            )

--- a/src/haddock/modules/refinement/emref/__init__.py
+++ b/src/haddock/modules/refinement/emref/__init__.py
@@ -3,11 +3,9 @@ from pathlib import Path
 
 from haddock.gear.haddockmodel import HaddockModel
 from haddock.libs.libcns import prepare_cns_input, prepare_expected_pdb
-from haddock.libs.libhpc import HPCScheduler
 from haddock.libs.libontology import ModuleIO
-from haddock.libs.libparallel import Scheduler
 from haddock.libs.libsubprocess import CNSJob
-from haddock.modules import BaseHaddockModule
+from haddock.modules import BaseHaddockModule, get_engine
 
 
 RECIPE_PATH = Path(__file__).resolve().parent
@@ -87,11 +85,8 @@ class HaddockModule(BaseHaddockModule):
 
         # Run CNS Jobs
         self.log(f"Running CNS Jobs n={len(jobs)}")
-        if self.params['mode'] == 'hpc':
-            engine = HPCScheduler(jobs, queue_limit=self.params['queue_limit'],
-                                  concat=self.params["concat"])
-        else:
-            engine = Scheduler(jobs, ncores=self.params['ncores'])
+        Engine = get_engine(self.params['mode'], self.params)
+        engine = Engine(jobs)
         engine.run()
         self.log("CNS jobs have finished")
 

--- a/src/haddock/modules/refinement/emref/__init__.py
+++ b/src/haddock/modules/refinement/emref/__init__.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from haddock.gear.haddockmodel import HaddockModel
 from haddock.libs.libcns import prepare_cns_input, prepare_expected_pdb
+from haddock.libs.libhpc import HPCScheduler
 from haddock.libs.libontology import ModuleIO
 from haddock.libs.libparallel import Scheduler
 from haddock.libs.libsubprocess import CNSJob
@@ -84,11 +85,15 @@ class HaddockModule(BaseHaddockModule):
 
                 idx += 1
 
-        # Run CNS engine
-        self.log(f"Running CNS engine with {len(jobs)} jobs")
-        engine = Scheduler(jobs, ncores=self.params["ncores"])
+        # Run CNS Jobs
+        self.log(f"Running CNS Jobs n={len(jobs)}")
+        if self.params['mode'] == 'hpc':
+            engine = HPCScheduler(jobs, queue_limit=self.params['queue_limit'],
+                                  concat=self.params["concat"])
+        else:
+            engine = Scheduler(jobs, ncores=self.params['ncores'])
         engine.run()
-        self.log("CNS engine has finished")
+        self.log("CNS jobs have finished")
 
         # Get the weights needed for the CNS module
         _weight_keys = ("w_vdw", "w_elec", "w_desolv", "w_air", "w_bsa")

--- a/src/haddock/modules/refinement/flexref/__init__.py
+++ b/src/haddock/modules/refinement/flexref/__init__.py
@@ -3,11 +3,9 @@ from pathlib import Path
 
 from haddock.gear.haddockmodel import HaddockModel
 from haddock.libs.libcns import prepare_cns_input, prepare_expected_pdb
-from haddock.libs.libhpc import HPCScheduler
 from haddock.libs.libontology import ModuleIO
-from haddock.libs.libparallel import Scheduler
 from haddock.libs.libsubprocess import CNSJob
-from haddock.modules import BaseHaddockModule
+from haddock.modules import BaseHaddockModule, get_engine
 
 
 RECIPE_PATH = Path(__file__).resolve().parent
@@ -86,11 +84,8 @@ class HaddockModule(BaseHaddockModule):
 
         # Run CNS Jobs
         self.log(f"Running CNS Jobs n={len(jobs)}")
-        if self.params['mode'] == 'hpc':
-            engine = HPCScheduler(jobs, queue_limit=self.params['queue_limit'],
-                                  concat=self.params["concat"])
-        else:
-            engine = Scheduler(jobs, ncores=self.params['ncores'])
+        Engine = get_engine(self.params['mode'], self.params)
+        engine = Engine(jobs)
         engine.run()
         self.log("CNS jobs have finished")
 

--- a/src/haddock/modules/refinement/flexref/__init__.py
+++ b/src/haddock/modules/refinement/flexref/__init__.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from haddock.gear.haddockmodel import HaddockModel
 from haddock.libs.libcns import prepare_cns_input, prepare_expected_pdb
+from haddock.libs.libhpc import HPCScheduler
 from haddock.libs.libontology import ModuleIO
 from haddock.libs.libparallel import Scheduler
 from haddock.libs.libsubprocess import CNSJob
@@ -83,11 +84,15 @@ class HaddockModule(BaseHaddockModule):
 
                 idx += 1
 
-        # Run CNS engine
-        self.log(f"Running CNS engine with {len(jobs)} jobs")
-        engine = Scheduler(jobs, ncores=self.params["ncores"])
+        # Run CNS Jobs
+        self.log(f"Running CNS Jobs n={len(jobs)}")
+        if self.params['mode'] == 'hpc':
+            engine = HPCScheduler(jobs, queue_limit=self.params['queue_limit'],
+                                  concat=self.params["concat"])
+        else:
+            engine = Scheduler(jobs, ncores=self.params['ncores'])
         engine.run()
-        self.log("CNS engine has finished")
+        self.log("CNS jobs have finished")
 
         # Get the weights from the defaults
         _weight_keys = ("w_vdw", "w_elec", "w_desolv", "w_air", "w_bsa")

--- a/src/haddock/modules/refinement/mdref/__init__.py
+++ b/src/haddock/modules/refinement/mdref/__init__.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from haddock.gear.haddockmodel import HaddockModel
 from haddock.libs.libcns import prepare_cns_input, prepare_expected_pdb
+from haddock.libs.libhpc import HPCScheduler
 from haddock.libs.libontology import ModuleIO
 from haddock.libs.libparallel import Scheduler
 from haddock.libs.libsubprocess import CNSJob
@@ -81,11 +82,15 @@ class HaddockModule(BaseHaddockModule):
 
                 idx += 1
 
-        # Run CNS engine
-        self.log(f"Running CNS engine with {len(jobs)} jobs")
-        engine = Scheduler(jobs, ncores=self.params["ncores"])
+        # Run CNS Jobs
+        self.log(f"Running CNS Jobs n={len(jobs)}")
+        if self.params['mode'] == 'hpc':
+            engine = HPCScheduler(jobs, queue_limit=self.params['queue_limit'],
+                                  concat=self.params["concat"])
+        else:
+            engine = Scheduler(jobs, ncores=self.params['ncores'])
         engine.run()
-        self.log("CNS engine has finished")
+        self.log("CNS jobs have finished")
 
         # Get the weights from the defaults
         _weight_keys = ("w_vdw", "w_elec", "w_desolv", "w_air", "w_bsa")

--- a/src/haddock/modules/refinement/mdref/__init__.py
+++ b/src/haddock/modules/refinement/mdref/__init__.py
@@ -3,11 +3,9 @@ from pathlib import Path
 
 from haddock.gear.haddockmodel import HaddockModel
 from haddock.libs.libcns import prepare_cns_input, prepare_expected_pdb
-from haddock.libs.libhpc import HPCScheduler
 from haddock.libs.libontology import ModuleIO
-from haddock.libs.libparallel import Scheduler
 from haddock.libs.libsubprocess import CNSJob
-from haddock.modules import BaseHaddockModule
+from haddock.modules import BaseHaddockModule, get_engine
 
 
 RECIPE_PATH = Path(__file__).resolve().parent
@@ -84,11 +82,8 @@ class HaddockModule(BaseHaddockModule):
 
         # Run CNS Jobs
         self.log(f"Running CNS Jobs n={len(jobs)}")
-        if self.params['mode'] == 'hpc':
-            engine = HPCScheduler(jobs, queue_limit=self.params['queue_limit'],
-                                  concat=self.params["concat"])
-        else:
-            engine = Scheduler(jobs, ncores=self.params['ncores'])
+        Engine = get_engine(self.params['mode'], self.params)
+        engine = Engine(jobs)
         engine.run()
         self.log("CNS jobs have finished")
 

--- a/src/haddock/modules/sampling/rigidbody/__init__.py
+++ b/src/haddock/modules/sampling/rigidbody/__init__.py
@@ -3,11 +3,9 @@ from pathlib import Path
 
 from haddock.gear.haddockmodel import HaddockModel
 from haddock.libs.libcns import prepare_cns_input
-from haddock.libs.libhpc import HPCScheduler
 from haddock.libs.libontology import ModuleIO, PDBFile
-from haddock.libs.libparallel import Scheduler
 from haddock.libs.libsubprocess import CNSJob
-from haddock.modules import BaseHaddockModule
+from haddock.modules import BaseHaddockModule, get_engine
 
 
 RECIPE_PATH = Path(__file__).resolve().parent
@@ -93,11 +91,8 @@ class HaddockModule(BaseHaddockModule):
 
         # Run CNS Jobs
         self.log(f"Running CNS Jobs n={len(jobs)}")
-        if self.params['mode'] == 'hpc':
-            engine = HPCScheduler(jobs, queue_limit=self.params['queue_limit'],
-                                  concat=self.params["concat"])
-        else:
-            engine = Scheduler(jobs, ncores=self.params['ncores'])
+        Engine = get_engine(self.params['mode'], self.params)
+        engine = Engine(jobs)
         engine.run()
         self.log("CNS jobs have finished")
 

--- a/src/haddock/modules/topology/topoaa/__init__.py
+++ b/src/haddock/modules/topology/topoaa/__init__.py
@@ -9,12 +9,10 @@ from haddock.libs.libcns import (
     prepare_output,
     prepare_single_input,
     )
-from haddock.libs.libhpc import HPCScheduler
 from haddock.libs.libontology import Format, ModuleIO, PDBFile, TopologyFile
-from haddock.libs.libparallel import Scheduler
 from haddock.libs.libstructure import make_molecules
 from haddock.libs.libsubprocess import CNSJob
-from haddock.modules import BaseHaddockModule
+from haddock.modules import BaseHaddockModule, get_engine
 
 
 RECIPE_PATH = Path(__file__).resolve().parent
@@ -149,11 +147,8 @@ class HaddockModule(BaseHaddockModule):
 
         # Run CNS Jobs
         self.log(f"Running CNS Jobs n={len(jobs)}")
-        if self.params['mode'] == 'hpc':
-            engine = HPCScheduler(jobs, queue_limit=self.params['queue_limit'],
-                                  concat=self.params["concat"])
-        else:
-            engine = Scheduler(jobs, ncores=self.params['ncores'])
+        Engine = get_engine(self.params['mode'], self.params)
+        engine = Engine(jobs)
         engine.run()
         self.log("CNS jobs have finished")
 

--- a/src/haddock/modules/topology/topoaa/__init__.py
+++ b/src/haddock/modules/topology/topoaa/__init__.py
@@ -9,6 +9,7 @@ from haddock.libs.libcns import (
     prepare_output,
     prepare_single_input,
     )
+from haddock.libs.libhpc import HPCScheduler
 from haddock.libs.libontology import Format, ModuleIO, PDBFile, TopologyFile
 from haddock.libs.libparallel import Scheduler
 from haddock.libs.libstructure import make_molecules
@@ -146,11 +147,15 @@ class HaddockModule(BaseHaddockModule):
 
                 jobs.append(job)
 
-        # Run CNS engine
-        self.log(f"Running CNS engine with {len(jobs)} jobs")
-        engine = Scheduler(jobs, ncores=self.params['ncores'])
+        # Run CNS Jobs
+        self.log(f"Running CNS Jobs n={len(jobs)}")
+        if self.params['mode'] == 'hpc':
+            engine = HPCScheduler(jobs, queue_limit=self.params['queue_limit'],
+                                  concat=self.params["concat"])
+        else:
+            engine = Scheduler(jobs, ncores=self.params['ncores'])
         engine.run()
-        self.log("CNS engine has finished")
+        self.log("CNS jobs have finished")
 
         # Check for generated output, fail it not all expected files
         #  are found


### PR DESCRIPTION
I implemented a new `libhpc` to handle the HPC executions (SLURM, but we can add TORQUE later). I tried my best to follow the same design of Brian's `libparallel`.

I also implemented `queue_limit` that defines the size of the submission batches and `concat`, similar to what we have in haddock2.4

```python
# concatenate models inside each .job, concat = 5 each .job will produce 5 models
concat = 1
#  Limit the number of concurrent submissions to the queue
queue_limit = 100
```
```
[2021-12-09 12:44:57,404 __init__ INFO] [topoaa] Running CNS Jobs n=11
[2021-12-09 12:44:57,404 libhpc INFO] Concatenating, each .job will produce 5 (or less) models
[2021-12-09 12:44:57,405 libhpc INFO] > Running batch 1/1
[2021-12-09 12:44:57,503 libhpc INFO] >> topoaa_1.job submitted
[2021-12-09 12:44:57,531 libhpc INFO] >> topoaa_2.job submitted
[2021-12-09 12:44:57,555 libhpc INFO] >> topoaa_3.job submitted
[2021-12-09 12:44:57,556 libhpc INFO] >> 0% done
[2021-12-09 12:44:57,557 libhpc INFO] >> Waiting... (10.00s)
[2021-12-09 12:45:07,638 libhpc INFO] >> 100% done
[2021-12-09 12:45:07,638 libhpc INFO] >> Took 10.23s
[2021-12-09 12:45:07,638 libhpc INFO] > Batch 1/1 done
```

I also added a "terminate signal" that will remove the .jobs from the queue:
```
^C[2021-12-09 12:41:54,179 libhpc INFO] Terminate signal recieved, removing jobs from the queue...
[2021-12-09 12:41:54,214 libhpc INFO] Canceling topoaa_1.job - 20353291
[2021-12-09 12:41:54,261 libhpc INFO] Canceling topoaa_2.job - 20353292
[2021-12-09 12:41:54,313 libhpc INFO] Canceling topoaa_3.job - 20353293
[2021-12-09 12:41:54,360 libhpc INFO] Canceling topoaa_4.job - 20353294
[2021-12-09 12:41:54,410 libhpc INFO] Canceling topoaa_5.job - 20353295
[2021-12-09 12:41:54,465 libhpc INFO] Canceling topoaa_6.job - 20353296
[2021-12-09 12:41:54,516 libhpc INFO] Canceling topoaa_7.job - 20353297
[2021-12-09 12:41:54,563 libhpc INFO] Canceling topoaa_8.job - 20353298
[2021-12-09 12:41:54,615 libhpc INFO] Canceling topoaa_9.job - 20353299
[2021-12-09 12:41:54,670 libhpc INFO] Canceling topoaa_10.job - 20353300
[2021-12-09 12:41:54,721 libhpc INFO] Canceling topoaa_11.job - 20353301
[2021-12-09 12:41:54,744 libhpc INFO] The jobs in the queue were terminated in a controlled way
[2021-12-09 12:41:54,745 libworkflow INFO] You have halted subprocess execution by hitting Ctrl+c
[2021-12-09 12:41:54,746 libworkflow INFO] Exiting...
```

As for the `wait` to check if the .jobs have finished I added an "adaptive timer" to be both HPC friendly and efficient: in the first batch submission is uses pre-defined wait timers `10s (<10 jobs), 30s (<50) and 60s (>50)`, after that it keeps track of how long each batch took to finish and then waits for the average time. 

I have NOT added the re-submission logic, let's do it in another PR. This one is just for the implementation of `libhpc`