### PR TITLE
Sort tasks while initializing `libparallel`

### DIFF
--- a/src/haddock/libs/libparallel.py
+++ b/src/haddock/libs/libparallel.py
@@ -2,7 +2,7 @@
 from multiprocessing import Process
 
 from haddock import log
-from haddock.libs.libutil import parse_ncores
+from haddock.libs.libutil import get_number_from_path_stem, parse_ncores
 
 
 class Worker(Process):
@@ -46,22 +46,15 @@ class Scheduler:
 
         # Sort the tasks by input_file name and its length,
         #  so we know that 2 comes before 10
-        task_name_dic = {}
-        for i, t in enumerate(tasks):
-            task_name_dic[i] = t.input_file, len(str(t.input_file))
-        
-        sorted_task_list = []
-        for e in sorted(task_name_dic.items(), key=lambda x: (x[0], x[1])):
-            idx = e[0]
-            sorted_task_list.append(tasks[idx])
-
-        tasks = sorted_task_list
+        sorted_task_list = sorted(
+            tasks,
+            key=lambda x: get_number_from_path_stem(x.input_file)
+            )
 
         _n = self.num_processes
         job_list = [
-            sorted_task_list[i:i + _n] for i in range(
-                0, len(sorted_task_list), _n
-                )
+            sorted_task_list[i:i + _n]
+            for i in range(0, len(sorted_task_list), _n)
             ]
 
         self.worker_list = [Worker(jobs) for jobs in job_list]

--- a/src/haddock/libs/libparallel.py
+++ b/src/haddock/libs/libparallel.py
@@ -44,9 +44,25 @@ class Scheduler:
         # Do not waste resources
         self.num_processes = min(self.num_processes, self.num_tasks)
 
-        # step trick by @brianjimenez
+        # Sort the tasks by input_file name and its length,
+        #  so we know that 2 comes before 10
+        task_name_dic = {}
+        for i, t in enumerate(tasks):
+            task_name_dic[i] = t.input_file, len(str(t.input_file))
+        
+        sorted_task_list = []
+        for e in sorted(task_name_dic.items(), key=lambda x: (x[0], x[1])):
+            idx = e[0]
+            sorted_task_list.append(tasks[idx])
+
+        tasks = sorted_task_list
+
         _n = self.num_processes
-        job_list = [tasks[i::_n] for i in range(_n)]
+        job_list = [
+            sorted_task_list[i:i + _n] for i in range(
+                0, len(sorted_task_list), _n
+                )
+            ]
 
         self.worker_list = [Worker(jobs) for jobs in job_list]
 

--- a/src/haddock/libs/libparallel.py
+++ b/src/haddock/libs/libparallel.py
@@ -66,6 +66,7 @@ class Scheduler:
 
         self.worker_list = [Worker(jobs) for jobs in job_list]
 
+        log.info(f"Using {self.num_processes} cores")
         log.debug(f"{self.num_tasks} tasks ready.")
 
     @property


### PR DESCRIPTION
This closes #196 
```
[2021-12-13 15:50:17,612 __init__ INFO] [rigidbody] Running CNS Jobs n=20
[2021-12-13 15:51:53,516 libparallel INFO] >> 01_rigidbody/rigidbody_1.inp completed 5% 
[2021-12-13 15:51:59,156 libparallel INFO] >> 01_rigidbody/rigidbody_2.inp completed 10% 
[2021-12-13 15:52:00,784 libparallel INFO] >> 01_rigidbody/rigidbody_3.inp completed 15% 
[2021-12-13 15:52:02,497 libparallel INFO] >> 01_rigidbody/rigidbody_4.inp completed 20% 
[2021-12-13 15:52:05,320 libparallel INFO] >> 01_rigidbody/rigidbody_5.inp completed 25% 
[2021-12-13 15:52:05,320 libparallel INFO] >> 01_rigidbody/rigidbody_6.inp completed 30% 
[2021-12-13 15:52:05,320 libparallel INFO] >> 01_rigidbody/rigidbody_7.inp completed 35% 
[2021-12-13 15:52:05,320 libparallel INFO] >> 01_rigidbody/rigidbody_8.inp completed 40% 
[2021-12-13 15:52:05,320 libparallel INFO] >> 01_rigidbody/rigidbody_9.inp completed 45% 
[2021-12-13 15:52:05,321 libparallel INFO] >> 01_rigidbody/rigidbody_10.inp completed 50% 
[2021-12-13 15:52:05,321 libparallel INFO] >> 01_rigidbody/rigidbody_11.inp completed 55% 
[2021-12-13 15:52:05,321 libparallel INFO] >> 01_rigidbody/rigidbody_12.inp completed 60% 
[2021-12-13 15:52:05,321 libparallel INFO] >> 01_rigidbody/rigidbody_13.inp completed 65% 
[2021-12-13 15:52:05,321 libparallel INFO] >> 01_rigidbody/rigidbody_14.inp completed 70% 
[2021-12-13 15:52:05,321 libparallel INFO] >> 01_rigidbody/rigidbody_15.inp completed 75% 
[2021-12-13 15:52:05,322 libparallel INFO] >> 01_rigidbody/rigidbody_16.inp completed 80% 
[2021-12-13 15:52:05,322 libparallel INFO] >> 01_rigidbody/rigidbody_17.inp completed 85% 
[2021-12-13 15:52:05,322 libparallel INFO] >> 01_rigidbody/rigidbody_18.inp completed 90% 
[2021-12-13 15:52:05,322 libparallel INFO] >> 01_rigidbody/rigidbody_19.inp completed 95% 
[2021-12-13 15:52:05,322 libparallel INFO] >> 01_rigidbody/rigidbody_20.inp completed 100% 
```