### PR TITLE
Use `MODDIR` instead of `MODRUN` `rigidbody.cns`

### DIFF
--- a/src/haddock/modules/sampling/rigidbody/cns/rigidbody.cns
+++ b/src/haddock/modules/sampling/rigidbody/cns/rigidbody.cns
@@ -358,7 +358,7 @@ if ($NUMNOE = 0) then
         if ($Data.surfrest eq FALSE) then
             if ($Data.cmrest eq FALSE) then
                 if ($Data.ranair eq FALSE) then
-                    evaluate ($errfile = "MODRUN:WARNING")
+                    evaluate ($errfile = "MODDIR:WARNING")
                     fileexist $errfile end
                     if ($result eq false) then
                         set display=$errfile end
@@ -401,7 +401,7 @@ flag excl cdih end
 
 if ($Data.ranair eq true) then
     if ($Data.ncomponents > 2) then
-        evaluate ($errfile = "MODRUN:FAILED")
+        evaluate ($errfile = "MODDIR:FAILED")
         fileexist $errfile end
         if ($result eq false) then
             set display=$errfile end


### PR DESCRIPTION
Replaced wrong environment variable. 

***
Closes  #206