### PR TITLE
Write `ambig_fname` as full path

### DIFF
--- a/src/haddock/libs/libcns.py
+++ b/src/haddock/libs/libcns.py
@@ -387,6 +387,7 @@ def prepare_cns_input(
     input_str = prepare_multiple_input(pdb_list, psf_list)
 
     if ambig_fname:
+        ambig_fname = Path(ambig_fname).resolve()
         ambig_str = load_ambig(ambig_fname)
     else:
         ambig_str = ""


### PR DESCRIPTION
This closes #208, note that for now `libcns` only writes `ambig.tbl`, for it to use the other supported restraints we need to refactor the `prepare_cns_input` function.