### PR TITLE
Export environment variables to a file per module.

### DIFF
--- a/src/haddock/libs/libparallel.py
+++ b/src/haddock/libs/libparallel.py
@@ -93,7 +93,7 @@ class Scheduler:
                 worker.join()
                 for t in worker.tasks:
                     per = (c / float(self.num_tasks)) * 100
-                    task_ident = f'{t.modpath.name}/{t.input_file.name}'
+                    task_ident = f'{t.input_file.parents[0].name}/{t.input_file.name}'
                     log.info(f'>> {task_ident} completed {per:.0f}% ')
                     c += 1
 

--- a/src/haddock/libs/libparallel.py
+++ b/src/haddock/libs/libparallel.py
@@ -93,7 +93,10 @@ class Scheduler:
                 worker.join()
                 for t in worker.tasks:
                     per = (c / float(self.num_tasks)) * 100
-                    task_ident = f'{t.input_file.parents[0].name}/{t.input_file.name}'
+                    task_ident = (
+                        f'{t.input_file.parents[0].name}/'
+                        f'{t.input_file.name}'
+                        )
                     log.info(f'>> {task_ident} completed {per:.0f}% ')
                     c += 1
 

--- a/src/haddock/libs/libsubprocess.py
+++ b/src/haddock/libs/libsubprocess.py
@@ -2,9 +2,7 @@
 import os
 import shlex
 import subprocess
-from pathlib import Path
 
-from haddock import toppar_path as global_toppar
 from haddock.core.defaults import cns_exec
 from haddock.core.exceptions import CNSRunningError, JobRunningError
 
@@ -63,26 +61,10 @@ class CNSJob:
             The path to the .out CNS file, where the standard output
             will be saved.
 
-        cns_folder : str of pathlib.Path
-            The path where the CNS scripts needed for the module reside.
-            For example, `modules/rigidibody/cns`.
-
-        mod_path : str of pathlib.Path
-            Path where the results of the haddock3 module executing this
-            CNS job will be saved.
-
-        config_path : str of pathlib.Path
-            Path of the haddock3 configuration file. Will be used to
-            manage paths in relative manner.
-
-        cns_exec : str of pathlib.Path, optional
-            The path to the CNS exec. If not provided defaults to the
-            global configuration in HADDOCK3.
-
-        toppar : str of pathlib.Path, optional
-            Path to the folder containing CNS topology parameters.
-            If `None` is given defaults to `cns/toppar` inside HADDOCK3
-            source code.
+        envvars : dict
+            A dictionary containing the environment variables needed for
+            the CNSJob. These will be passed to subprocess.Popen.env
+            argument.
         """
         self.input_file = input_file
         self.output_file = output_file
@@ -123,13 +105,6 @@ class CNSJob:
         """Run this CNS job script."""
         with open(self.input_file) as inp, \
                 open(self.output_file, 'w+') as outf:
-
-            #env = {
-            #    'MODDIR': str(self.modpath),
-            #    'MODULE': str(self.cns_folder),
-            #    'RUN': str(self.config_path),
-            #    'TOPPAR': str(self.toppar),
-            #    }
 
             p = subprocess.Popen(
                 self.cns_exec,

--- a/src/haddock/libs/libsubprocess.py
+++ b/src/haddock/libs/libsubprocess.py
@@ -2,6 +2,7 @@
 import os
 import shlex
 import subprocess
+from pathlib import Path
 
 from haddock.core.defaults import cns_exec
 from haddock.core.exceptions import CNSRunningError, JobRunningError
@@ -82,6 +83,10 @@ class CNSJob:
         self._envvars = envvars or {}
         if not isinstance(self._envvars, dict):
             raise ValueError('`envvars` must be a dictionary.')
+
+        for k, v in self._envvars.items():
+            if isinstance(v, Path):
+                self._envvars[k] = str(v)
 
     @property
     def cns_exec(self):

--- a/src/haddock/libs/libsubprocess.py
+++ b/src/haddock/libs/libsubprocess.py
@@ -47,11 +47,7 @@ class CNSJob:
             self,
             input_file,
             output_file,
-            cns_folder,
-            modpath,
-            config_path,
-            cns_exec=None,
-            toppar=None,
+            envvars=None,
             ):
         """
         CNS subprocess.
@@ -90,12 +86,20 @@ class CNSJob:
         """
         self.input_file = input_file
         self.output_file = output_file
-        self.cns_folder = cns_folder
-        self.modpath = modpath
-        self.config_path = Path(config_path).parent
-
-        self.toppar = toppar or global_toppar
+        self.envvars = envvars
         self.cns_exec = cns_exec
+
+    @property
+    def envvars(self):
+        """CNS environment vars."""
+        return self._envvars
+
+    @envvars.setter
+    def envvars(self, envvars):
+        """CNS environment vars."""
+        self._envvars = envvars or {}
+        if not isinstance(self._envvars, dict):
+            raise ValueError('`envvars` must be a dictionary.')
 
     @property
     def cns_exec(self):
@@ -120,12 +124,12 @@ class CNSJob:
         with open(self.input_file) as inp, \
                 open(self.output_file, 'w+') as outf:
 
-            env = {
-                'MODDIR': str(self.modpath),
-                'MODULE': str(self.cns_folder),
-                'RUN': str(self.config_path),
-                'TOPPAR': str(self.toppar),
-                }
+            #env = {
+            #    'MODDIR': str(self.modpath),
+            #    'MODULE': str(self.cns_folder),
+            #    'RUN': str(self.config_path),
+            #    'TOPPAR': str(self.toppar),
+            #    }
 
             p = subprocess.Popen(
                 self.cns_exec,
@@ -133,7 +137,7 @@ class CNSJob:
                 stdout=outf,
                 stderr=subprocess.PIPE,
                 close_fds=True,
-                env=env,
+                env=self.envvars,
                 )
 
             out, error = p.communicate()

--- a/src/haddock/libs/libworkflow.py
+++ b/src/haddock/libs/libworkflow.py
@@ -44,7 +44,8 @@ class Workflow:
             queue=HPCWorker_QUEUE_DEFAULT,
             concat=HPCScheduler_CONCAT_DEFAULT,
             queue_limit=HPCWorker_QUEUE_LIMIT_DEFAULT,
-            **ignore):
+            relative_envvars=True,
+            **others):
         # Create the list of steps contained in this workflow
         self.steps = []
         for num_stage, (stage_name, params) in enumerate(content.items()):
@@ -59,6 +60,7 @@ class Workflow:
             params.setdefault('queue', queue)
             params.setdefault('concat', concat)
             params.setdefault('queue_limit', queue_limit)
+            params.setdefault('relative_envvars', relative_envvars)
 
             try:
                 _ = Step(

--- a/src/haddock/modules/__init__.py
+++ b/src/haddock/modules/__init__.py
@@ -168,19 +168,20 @@ class BaseHaddockModule(ABC):
         getattr(log, level)(f'[{self.name}] {msg}')
 
     def default_envvars(self, **envvars):
-        """Save envvars to disk."""
+        """Return default env vars updated to `envvars` (if given)."""
         default_envvars = {
             'MODULE': self.cns_folder_path,
             'MODIR': self.path,
             'RUN': self.params["config_path"],
             'TOPPAR': global_toppar,
             }
+
         default_envvars.update(envvars)
 
         return default_envvars
 
     def save_envvars(self, filename='envvars', **envvars):
-        """Save envvars to file."""
+        """Save envvars needed for CNS to a file in the module's folder."""
         common_path = os.path.commonpath(list(envvars.values()))
 
         envvars = {
@@ -196,7 +197,7 @@ class BaseHaddockModule(ABC):
 
         banshee = '#!/bin/bash' + os.linesep
         root = 'export COMMON_PATH_FOR_HD3={}'.format(common_path) + os.linesep
-        fstr =  banshee + root + os.linesep.join(lines)
+        fstr = banshee + root + os.linesep.join(lines)
         Path(self.path, filename).write_text(fstr)
         return
 
@@ -248,6 +249,3 @@ def get_engine(mode, params):
             f"Scheduler `mode` {mode!r} not recognized. "
             f"Available options are {', '.join(available_engines)}"
             )
-
-
-

--- a/src/haddock/modules/__init__.py
+++ b/src/haddock/modules/__init__.py
@@ -171,7 +171,7 @@ class BaseHaddockModule(ABC):
         """Return default env vars updated to `envvars` (if given)."""
         default_envvars = {
             "MODULE": self.cns_folder_path,
-            "MODIR": self.path,
+            "MODDIR": self.path,
             "RUN": self.params["config_path"],
             "TOPPAR": global_toppar,
             }

--- a/src/haddock/modules/__init__.py
+++ b/src/haddock/modules/__init__.py
@@ -6,6 +6,7 @@ from functools import partial
 from pathlib import Path
 
 from haddock import log as log
+from haddock import toppar_path as global_toppar
 from haddock.core.defaults import MODULE_IO_FILE
 from haddock.core.exceptions import StepError
 from haddock.gear.config_reader import read_config
@@ -104,6 +105,9 @@ class BaseHaddockModule(ABC):
         self.params.setdefault('mode', None)
         self.params.setdefault('concat', None)
         self.params.setdefault('queue_limit', None)
+        if getattr(self, 'cns_protocol_path', False):
+            self.envvars = self.default_envvars()
+            self.save_envvars(**self.envvars)
         self._run()
         log.info(f'Module [{self.name}] finished.')
 
@@ -163,6 +167,39 @@ class BaseHaddockModule(ABC):
         """
         getattr(log, level)(f'[{self.name}] {msg}')
 
+    def default_envvars(self, **envvars):
+        """Save envvars to disk."""
+        default_envvars = {
+            'MODULE': self.cns_folder_path,
+            'MODIR': self.path,
+            'RUN': self.params["config_path"],
+            'TOPPAR': global_toppar,
+            }
+        default_envvars.update(envvars)
+
+        return default_envvars
+
+    def save_envvars(self, filename='envvars', **envvars):
+        """Save envvars to file."""
+        common_path = os.path.commonpath(list(envvars.values()))
+
+        envvars = {
+            k: v.relative_to(common_path)
+            for k, v in envvars.items()
+            }
+
+        # SyntaxError: f-string expression part cannot include a backslash
+        lines = (
+            'export ' + k + '=${COMMON_PATH_FOR_HD3}/' + str(v)
+            for k, v in envvars.items()
+            )
+
+        banshee = '#!/bin/bash' + os.linesep
+        root = 'export COMMON_PATH_FOR_HD3={}'.format(common_path) + os.linesep
+        fstr =  banshee + root + os.linesep.join(lines)
+        Path(self.path, filename).write_text(fstr)
+        return
+
 
 @contextlib.contextmanager
 def working_directory(path):
@@ -211,3 +248,6 @@ def get_engine(mode, params):
             f"Scheduler `mode` {mode!r} not recognized. "
             f"Available options are {', '.join(available_engines)}"
             )
+
+
+

--- a/src/haddock/modules/__init__.py
+++ b/src/haddock/modules/__init__.py
@@ -105,7 +105,7 @@ class BaseHaddockModule(ABC):
         self.params.setdefault('mode', None)
         self.params.setdefault('concat', None)
         self.params.setdefault('queue_limit', None)
-        if getattr(self, 'cns_protocol_path', False):
+        if getattr(self, "cns_protocol_path", False):
             self.envvars = self.default_envvars()
             self.save_envvars(**self.envvars)
         self._run()
@@ -170,17 +170,17 @@ class BaseHaddockModule(ABC):
     def default_envvars(self, **envvars):
         """Return default env vars updated to `envvars` (if given)."""
         default_envvars = {
-            'MODULE': self.cns_folder_path,
-            'MODIR': self.path,
-            'RUN': self.params["config_path"],
-            'TOPPAR': global_toppar,
+            "MODULE": self.cns_folder_path,
+            "MODIR": self.path,
+            "RUN": self.params["config_path"],
+            "TOPPAR": global_toppar,
             }
 
         default_envvars.update(envvars)
 
         return default_envvars
 
-    def save_envvars(self, filename='envvars', **envvars):
+    def save_envvars(self, filename="envvars", **envvars):
         """Save envvars needed for CNS to a file in the module's folder."""
         common_path = os.path.commonpath(list(envvars.values()))
 
@@ -191,12 +191,12 @@ class BaseHaddockModule(ABC):
 
         # SyntaxError: f-string expression part cannot include a backslash
         lines = (
-            'export ' + k + '=${COMMON_PATH_FOR_HD3}/' + str(v)
+            "export " + k + "=${COMMON_PATH_FOR_HD3}/" + str(v)
             for k, v in envvars.items()
             )
 
-        banshee = '#!/bin/bash' + os.linesep
-        root = 'export COMMON_PATH_FOR_HD3={}'.format(common_path) + os.linesep
+        banshee = "#!/bin/bash" + os.linesep
+        root = "export COMMON_PATH_FOR_HD3={}".format(common_path) + os.linesep
         fstr = banshee + root + os.linesep.join(lines)
         Path(self.path, filename).write_text(fstr)
         return

--- a/src/haddock/modules/refinement/emref/__init__.py
+++ b/src/haddock/modules/refinement/emref/__init__.py
@@ -70,14 +70,7 @@ class HaddockModule(BaseHaddockModule):
 
                 refined_structure_list.append(expected_pdb)
 
-                job = CNSJob(
-                    inp_file,
-                    out_file,
-                    cns_folder=self.cns_folder_path,
-                    modpath=self.path,
-                    config_path=self.params["config_path"],
-                    cns_exec=self.params["cns_exec"],
-                    )
+                job = CNSJob(inp_file, out_file, envvars=self.envvars)
 
                 jobs.append(job)
 

--- a/src/haddock/modules/refinement/flexref/__init__.py
+++ b/src/haddock/modules/refinement/flexref/__init__.py
@@ -69,14 +69,7 @@ class HaddockModule(BaseHaddockModule):
                     )
                 refined_structure_list.append(expected_pdb)
 
-                job = CNSJob(
-                    inp_file,
-                    out_file,
-                    cns_folder=self.cns_folder_path,
-                    modpath=self.path,
-                    config_path=self.params["config_path"],
-                    cns_exec=self.params["cns_exec"],
-                    )
+                job = CNSJob(inp_file, out_file, envvars=self.envvars)
 
                 jobs.append(job)
 

--- a/src/haddock/modules/refinement/mdref/__init__.py
+++ b/src/haddock/modules/refinement/mdref/__init__.py
@@ -65,16 +65,10 @@ class HaddockModule(BaseHaddockModule):
                 expected_pdb = prepare_expected_pdb(
                     model, idx, self.path, "mdref"
                     )
+
                 refined_structure_list.append(expected_pdb)
 
-                job = CNSJob(
-                    inp_file,
-                    out_file,
-                    cns_folder=self.cns_folder_path,
-                    modpath=self.path,
-                    config_path=self.params["config_path"],
-                    cns_exec=self.params["cns_exec"],
-                    )
+                job = CNSJob(inp_file, out_file, envvars=self.envvars)
 
                 jobs.append(job)
 

--- a/src/haddock/modules/sampling/rigidbody/__init__.py
+++ b/src/haddock/modules/sampling/rigidbody/__init__.py
@@ -77,14 +77,7 @@ class HaddockModule(BaseHaddockModule):
                 model.topology = [e.topology for e in combination]
                 structure_list.append(model)
 
-                job = CNSJob(
-                    inp_file,
-                    log_fname,
-                    cns_folder=self.cns_folder_path,
-                    modpath=self.path,
-                    config_path=self.params["config_path"],
-                    cns_exec=self.params["cns_exec"],
-                    )
+                job = CNSJob(inp_file, log_fname, envvars=self.envvars)
                 jobs.append(job)
 
                 idx += 1

--- a/src/haddock/modules/scoring/emscoring/__init__.py
+++ b/src/haddock/modules/scoring/emscoring/__init__.py
@@ -57,14 +57,7 @@ class HaddockModule(BaseHaddockModule):
                 )
             scored_structure_list.append(expected_pdb)
 
-            job = CNSJob(
-                scoring_inp,
-                scoring_out,
-                cns_folder=self.cns_folder_path,
-                modpath=self.path,
-                config_path=self.params['config_path'],
-                cns_exec=self.params['cns_exec'],
-                )
+            job = CNSJob(scoring_inp, scoring_out, envvars=self.envvars)
 
             jobs.append(job)
 

--- a/src/haddock/modules/topology/topoaa/__init__.py
+++ b/src/haddock/modules/topology/topoaa/__init__.py
@@ -137,10 +137,7 @@ class HaddockModule(BaseHaddockModule):
                 job = CNSJob(
                     topology_filename,
                     output_filename,
-                    cns_folder=self.cns_folder_path,
-                    modpath=self.path,
-                    config_path=self.params['config_path'],
-                    cns_exec=self.params['cns_exec'],
+                    envvars=self.envvars,
                     )
 
                 jobs.append(job)


### PR DESCRIPTION
To facilitate running the `.inp` CNS scripts independently from the HADDOCK3 shell we need a file with the environment variables that can be sourced independently. FYI, when the HADDOCK3's python shell runs the environment variables are sent directly to the `subprocess.Popen`.

Saving the `envvars` to a file is now part of the `BaseHaddockModule` class and saving triggers automatically for all Modules that use CNS. The new file is called `envvars` and is inside each modules folder `00_`, `01_`, etc; as long as that module uses CNS.

The `envvars` file has a `COMMON_PATH_HD3` variable that can be changed easily in case we transport the haddock installation and the examples folder to another computer.

`source envvars` and you are good to go.

Example:

```bash
#!/bin/bash
export COMMON_PATH_FOR_HD3=/root/user/haddock3
export MODULE=${COMMON_PATH_FOR_HD3}/src/haddock/modules/topology/topoaa/cns
export MODIR=${COMMON_PATH_FOR_HD3}/examples/refine-complex/run1/00_topoaa
export RUN=${COMMON_PATH_FOR_HD3}/examples/refine-complex/refine-complex.cfg
export TOPPAR=${COMMON_PATH_FOR_HD3}/src/haddock/cns/toppar
```