### PR TITLE
fix `caprieval` reading from the wrong reslist when assembling the numbering reference

### DIFF
--- a/src/haddock/modules/analysis/caprieval/capri.py
+++ b/src/haddock/modules/analysis/caprieval/capri.py
@@ -874,7 +874,7 @@ def align_seq(reference, model, output_path):
                 start_b, end_b = seg_b
 
                 reslist_a = list(seqdic_a[a].keys())[start_a:end_a]
-                reslist_b = list(seqdic_a[a].keys())[start_b:end_b]
+                reslist_b = list(seqdic_b[b].keys())[start_b:end_b]
 
                 align_dic[a].update(
                     dict((i, j) for i, j in zip(reslist_a, reslist_b))


### PR DESCRIPTION
Small typos, big consequences. 🤦🏽 

This PR fixes #236 

```
          model                 rank     score     irmsd      fnat     lrmsd    ilrmsd
04_flexref/flexref_1.pdb           1   -66.080     0.548     0.962     1.263     1.250
04_flexref/flexref_3.pdb           2   -53.998     0.572     0.962     1.330     1.319
04_flexref/flexref_2.pdb           3   -52.696     0.866     0.923     1.683     1.662
04_flexref/flexref_5.pdb           4   -49.181     0.812     0.923     2.294     2.271
04_flexref/flexref_4.pdb           5   -12.472     1.849     0.769     5.824     5.775
```