### PR TITLE
Add cluster information in `PDBobject`

### DIFF
--- a/src/haddock/libs/libontology.py
+++ b/src/haddock/libs/libontology.py
@@ -54,6 +54,9 @@ class PDBFile(Persistent):
         super().__init__(file_name, Format.PDB, path)
         self.topology = topology
         self.score = score
+        self.clt_id = None
+        self.clt_rank = None
+        self.clt_model_rank = None
 
 
 class TopologyFile(Persistent):

--- a/src/haddock/modules/analysis/clustfcc/__init__.py
+++ b/src/haddock/modules/analysis/clustfcc/__init__.py
@@ -119,10 +119,11 @@ class HaddockModule(BaseHaddockModule):
                 cluster_fcc.output_clusters(fh, clusters)
             fh.close()
 
+            clt_centers = {}
             for clt in clusters:
                 cluster_id = clt.name
                 clt_dic[cluster_id] = []
-                # cluster_center = clt.center.name
+                clt_centers[cluster_id] = models_to_cluster[clt.center.name - 1]
                 for model in clt.members:
                     model_id = model.name
                     pdb = models_to_cluster[model_id - 1]
@@ -170,6 +171,10 @@ class HaddockModule(BaseHaddockModule):
             output_str += f"> threshold={self.params['threshold']}{os.linesep}"
             output_str += (
                 f"> strictness={self.params['strictness']}{os.linesep}")
+            output_str += os.linesep
+            output_str += (
+                "Note: Models marked with * represent the center of the cluster"
+                )
             output_str += (
                 f"-----------------------------------------------{os.linesep}")
             output_str += os.linesep
@@ -177,6 +182,8 @@ class HaddockModule(BaseHaddockModule):
 
             for cluster_rank, _e in enumerate(sorted_score_dic, start=1):
                 cluster_id, _ = _e
+                center_pdb = clt_centers[cluster_id]
+                clt_dic[cluster_id].append(center_pdb)
                 model_score_l = [(e.score, e) for e in clt_dic[cluster_id]]
                 model_score_l.sort()
                 top_score = sum(
@@ -194,9 +201,14 @@ class HaddockModule(BaseHaddockModule):
                 output_str += f'clt_rank\tmodel_name\tscore{os.linesep}'
                 for model_ranking, element in enumerate(model_score_l, start=1):
                     score, pdb = element
-                    output_str += (
-                        f"{model_ranking}\t{pdb.file_name}\t{score:.2f}"
-                        f"{os.linesep}")
+                    if pdb.file_name == center_pdb.file_name:
+                        output_str += (
+                            f"{model_ranking}\t{pdb.file_name}\t{score:.2f}\t*"
+                            f"{os.linesep}")
+                    else:
+                        output_str += (
+                            f"{model_ranking}\t{pdb.file_name}\t{score:.2f}"
+                            f"{os.linesep}")
             output_str += (
                 "-----------------------------------------------"
                 f"{os.linesep}")

--- a/src/haddock/modules/analysis/clustfcc/__init__.py
+++ b/src/haddock/modules/analysis/clustfcc/__init__.py
@@ -110,29 +110,105 @@ class HaddockModule(BaseHaddockModule):
             )
 
         # Prepare output and read the elements
-        cluster_dic = {}
+        clt_dic = {}
         if clusters:
-            # use fcc's output
+            # write the classic output file for compatibility reasons
+            log.info('Saving output to cluster.out')
             cluster_out = Path('cluster.out')
             with open(cluster_out, 'w') as fh:
                 cluster_fcc.output_clusters(fh, clusters)
             fh.close()
 
-            # Extract the cluster elements
-            # Q: Can we do this without having to re-open the file?
-            with open(cluster_out, 'r') as fh:
-                for line in fh.readlines():
-                    data = line.split()
-                    cluster_id = int(data[1])
-                    cluster_dic[cluster_id] = []
-                    cluster_elements = list(map(int, data[4:]))
-                    for element in cluster_elements:
-                        pdb = models_to_cluster[element - 1]
-                        cluster_dic[cluster_id].append(pdb)
+            for clt in clusters:
+                cluster_id = clt.name
+                clt_dic[cluster_id] = []
+                # cluster_center = clt.center.name
+                for model in clt.members:
+                    model_id = model.name
+                    pdb = models_to_cluster[model_id - 1]
+                    clt_dic[cluster_id].append(pdb)
+
+            # Rank the clusters
+            #  they are sorted by the top4 models in each cluster
+            top_n = 4
+            score_dic = {}
+            for clt_id in clt_dic:
+                score_l = [p.score for p in clt_dic[clt_id]]
+                score_l.sort()
+                top4_score = sum(score_l[:top_n]) / float(top_n)
+                score_dic[clt_id] = top4_score
+
+            sorted_score_dic = sorted(score_dic.items(), key=lambda k: k[1])
+
+            # Add this info to the models
+            clustered_models = []
+            for cluster_rank, _e in enumerate(sorted_score_dic, start=1):
+                cluster_id, _ = _e
+                # sort the models by score
+                model_score_l = [(e.score, e) for e in clt_dic[cluster_id]]
+                model_score_l.sort()
+                # rank the models
+                for model_ranking, element in enumerate(model_score_l, start=1):
+                    score, pdb = element
+                    pdb.clt_id = cluster_id
+                    pdb.clt_rank = cluster_rank
+                    pdb.clt_model_rank = model_ranking
+                    clustered_models.append(pdb)
+
+            # Prepare clustfcc.txt
+            output_fname = Path('clustfcc.txt')
+            output_str = f'### clustfcc output ###{os.linesep}'
+            output_str += os.linesep
+            output_str += f'Clustering parameters {os.linesep}'
+            output_str += (
+                "> contact_distance_cutoff="
+                f"{self.params['contact_distance_cutoff']}A"
+                f"{os.linesep}")
+            output_str += (
+                f"> fraction_cutoff={self.params['fraction_cutoff']}"
+                f"{os.linesep}")
+            output_str += f"> threshold={self.params['threshold']}{os.linesep}"
+            output_str += (
+                f"> strictness={self.params['strictness']}{os.linesep}")
+            output_str += (
+                f"-----------------------------------------------{os.linesep}")
+            output_str += os.linesep
+            output_str += f'Total # of clusters: {len(clusters)}{os.linesep}'
+
+            for cluster_rank, _e in enumerate(sorted_score_dic, start=1):
+                cluster_id, _ = _e
+                model_score_l = [(e.score, e) for e in clt_dic[cluster_id]]
+                model_score_l.sort()
+                top_score = sum(
+                    [e[0] for e in model_score_l][:top_n]
+                    ) / top_n
+                output_str += (
+                    f"{os.linesep}"
+                    "-----------------------------------------------"
+                    f"{os.linesep}"
+                    f"Cluster {cluster_rank} (#{cluster_id}, "
+                    f"n={len(model_score_l)}, "
+                    f"top{top_n}_avg_score = {top_score:.2f})"
+                    f"{os.linesep}")
+                output_str += os.linesep
+                output_str += f'clt_rank\tmodel_name\tscore{os.linesep}'
+                for model_ranking, element in enumerate(model_score_l, start=1):
+                    score, pdb = element
+                    output_str += (
+                        f"{model_ranking}\t{pdb.file_name}\t{score:.2f}"
+                        f"{os.linesep}")
+            output_str += (
+                "-----------------------------------------------"
+                f"{os.linesep}")
+
+            log.info('Saving detailed output to clustfcc.txt')
+            with open(output_fname, 'w') as out_fh:
+                out_fh.write(output_str)
         else:
             log.warning('No clusters were found')
+            clustered_models = models_to_cluster
 
         # Save module information
         io = ModuleIO()
-        io.add(cluster_dic, "o")
+        io.add(clustered_models, "o")
         io.save()

--- a/src/haddock/modules/analysis/clustfcc/__init__.py
+++ b/src/haddock/modules/analysis/clustfcc/__init__.py
@@ -174,7 +174,7 @@ class HaddockModule(BaseHaddockModule):
             output_str += os.linesep
             output_str += (
                 "Note: Models marked with * represent the center of the cluster"
-                )
+                f"{os.linesep}")
             output_str += (
                 f"-----------------------------------------------{os.linesep}")
             output_str += os.linesep


### PR DESCRIPTION
This PR closes #243 by adding the following to `libontology`
```python
        self.clt_id = None
        self.clt_rank = None
        self.clt_model_rank = None
```
* * *
And since @amjjbonvin commented that:
> It would also be handy to have the output saved on file.

I used the information to write a detailed version of `cluster.out` named `clustfcc.txt` (both are written)

### `cluster.out`
```
Cluster 1 -> 17 3 8 9 11 12 14 16 18 24 26 29 35 37 38 48 62 73 77 78 79 83 84 
Cluster 2 -> 74 10 31 82 86 93 98 
Cluster 3 -> 85 5 7 40 81 95 
Cluster 4 -> 80 6 28 33 50 
Cluster 5 -> 61 41 45 49 71 
Cluster 6 -> 44 15 32 39 43 
Cluster 7 -> 2 53 55 57 58 
Cluster 8 -> 59 64 66 67 
```

### `clustfcc.txt`

```
### clustfcc output ###

Clustering parameters 
> contact_distance_cutoff=5.0A
> fraction_cutoff=0.6
> threshold=4
> strictness=0.75
-----------------------------------------------

Total # of clusters: 8

-----------------------------------------------
Cluster 1 (#1, n=22, top4_avg_score = -32.24)

clt_rank	model_name	score
1	rigidbody_62.pdb	-32.87
2	rigidbody_12.pdb	-32.42
3	rigidbody_24.pdb	-32.29
4	rigidbody_29.pdb	-31.37
5	rigidbody_48.pdb	-30.58
6	rigidbody_26.pdb	-29.89
7	rigidbody_14.pdb	-28.42
8	rigidbody_38.pdb	-27.90
9	rigidbody_3.pdb	-27.30
10	rigidbody_79.pdb	-26.91
11	rigidbody_16.pdb	-26.68
12	rigidbody_11.pdb	-26.49
13	rigidbody_9.pdb	-25.78
14	rigidbody_78.pdb	-24.50
15	rigidbody_37.pdb	-24.21
16	rigidbody_73.pdb	-23.10
17	rigidbody_84.pdb	-22.29
18	rigidbody_8.pdb	-21.98
19	rigidbody_77.pdb	-21.98
20	rigidbody_35.pdb	-21.70
21	rigidbody_18.pdb	-17.53
22	rigidbody_83.pdb	-14.61

-----------------------------------------------
Cluster 2 (#3, n=5, top4_avg_score = -25.87)

clt_rank	model_name	score
1	rigidbody_81.pdb	-27.58
2	rigidbody_40.pdb	-27.37
3	rigidbody_5.pdb	-24.34
4	rigidbody_95.pdb	-24.18
5	rigidbody_7.pdb	-24.13

-----------------------------------------------
Cluster 3 (#7, n=4, top4_avg_score = -20.86)

clt_rank	model_name	score
1	rigidbody_55.pdb	-21.96
2	rigidbody_58.pdb	-21.77
3	rigidbody_57.pdb	-20.88
4	rigidbody_53.pdb	-18.81

-----------------------------------------------
Cluster 4 (#6, n=4, top4_avg_score = -19.53)

clt_rank	model_name	score
1	rigidbody_32.pdb	-21.78
2	rigidbody_39.pdb	-21.13
3	rigidbody_15.pdb	-19.00
4	rigidbody_43.pdb	-16.22

-----------------------------------------------
Cluster 5 (#2, n=6, top4_avg_score = -18.54)

clt_rank	model_name	score
1	rigidbody_98.pdb	-21.78
2	rigidbody_93.pdb	-19.51
3	rigidbody_31.pdb	-16.60
4	rigidbody_10.pdb	-16.27
5	rigidbody_86.pdb	-13.71
6	rigidbody_82.pdb	-10.85

-----------------------------------------------
Cluster 6 (#4, n=4, top4_avg_score = -14.06)

clt_rank	model_name	score
1	rigidbody_6.pdb	-16.44
2	rigidbody_33.pdb	-15.37
3	rigidbody_28.pdb	-13.90
4	rigidbody_50.pdb	-10.54

-----------------------------------------------
Cluster 7 (#5, n=4, top4_avg_score = -13.42)

clt_rank	model_name	score
1	rigidbody_71.pdb	-15.95
2	rigidbody_41.pdb	-12.80
3	rigidbody_49.pdb	-12.65
4	rigidbody_45.pdb	-12.28

-----------------------------------------------
Cluster 8 (#8, n=3, top4_avg_score = -13.25)

clt_rank	model_name	score
1	rigidbody_66.pdb	-22.29
2	rigidbody_67.pdb	-16.65
3	rigidbody_64.pdb	-14.06
-----------------------------------------------
```