### PR TITLE
Implement automatic threshold in `clustfcc`

### DIFF
--- a/examples/docking-protein-protein/docking-protein-protein.cfg
+++ b/examples/docking-protein-protein/docking-protein-protein.cfg
@@ -56,7 +56,6 @@ noecv = true
 reference_fname = 'data/e2a-hpr_1GGR.pdb'
 
 [clustfcc]
-threshold = 1
 
 # ====================================================================
 

--- a/src/haddock/modules/analysis/clustfcc/__init__.py
+++ b/src/haddock/modules/analysis/clustfcc/__init__.py
@@ -104,10 +104,27 @@ class HaddockModule(BaseHaddockModule):
             self.params['strictness'],
             )
 
-        _, clusters = cluster_fcc.cluster_elements(
-            pool,
-            threshold=self.params['threshold'],
-            )
+        cluster_check = False
+        while not cluster_check:
+            for threshold in range(self.params['threshold'], 0, -1):
+                log.info(f'Clustering with threshold={threshold}')
+                _, clusters = cluster_fcc.cluster_elements(
+                    pool,
+                    threshold=threshold,
+                    )
+                if not clusters:
+                    log.info(
+                        "[WARNING] No cluster was found, increasing threshold!"
+                        )
+                else:
+                    cluster_check = True
+                    # pass the actual threshold back to the param dict
+                    #  because it will be use in the detailed output
+                    self.params['threshold'] = threshold
+                    break
+            if not cluster_check:
+                # No cluster was obtained in any threshold
+                cluster_check = True
 
         # Prepare output and read the elements
         clt_dic = {}

--- a/src/haddock/modules/analysis/clustfcc/__init__.py
+++ b/src/haddock/modules/analysis/clustfcc/__init__.py
@@ -114,7 +114,7 @@ class HaddockModule(BaseHaddockModule):
                     )
                 if not clusters:
                     log.info(
-                        "[WARNING] No cluster was found, increasing threshold!"
+                        "[WARNING] No cluster was found, decreasing threshold!"
                         )
                 else:
                     cluster_check = True


### PR DESCRIPTION
This PR closes #253 by adding a logic to **decrease** the threshold in case no clusters were found. This changed threshold is then passed back to the parameter dictionary so it can be written in the detailed `clustfcc.txt`.