### PR TITLE
Implement fault tolerance

### DIFF
--- a/src/haddock/libs/libontology.py
+++ b/src/haddock/libs/libontology.py
@@ -143,7 +143,7 @@ class ModuleIO:
         """Check how many of the output exists."""
         total = 0.0
         present = 0.0
-        for i, element in enumerate(self.output):
+        for element in self.output:
             if isinstance(element, dict):
                 total += len(element.values())
                 present += sum([j.is_present() for j in element.values()])

--- a/src/haddock/libs/libontology.py
+++ b/src/haddock/libs/libontology.py
@@ -44,7 +44,7 @@ class Persistent:
 
     def is_present(self):
         """Check if the persisent file exists on disk."""
-        return Path(self.path, self.file_name).exists()
+        return self.rel_path.resolve().exists()
 
 
 class PDBFile(Persistent):
@@ -138,6 +138,23 @@ class ModuleIO:
             model_list = list(itertools.chain(*input_dic.values()))
 
         return model_list
+
+    def check_faulty(self):
+        """Check how many of the output exists."""
+        total = 0.0
+        present = 0.0
+        for i, element in enumerate(self.output):
+            if isinstance(element, dict):
+                total += len(element.values())
+                present += sum([j.is_present() for j in element.values()])
+            else:
+                total += 1
+                if element.is_present():
+                    present += 1
+
+        faulty_per = (1 - (present / total)) * 100
+
+        return faulty_per
 
     def __repr__(self):
         return f"Input: {self.input}{linesep}Output: {self.output}"

--- a/src/haddock/modules/refinement/emref/__init__.py
+++ b/src/haddock/modules/refinement/emref/__init__.py
@@ -88,11 +88,8 @@ class HaddockModule(BaseCNSModule):
         weights = {e: self.params[e] for e in _weight_keys}
 
         expected = []
-        not_found = []
         for pdb in refined_structure_list:
-            if not Path(pdb.file_name).exists():
-                not_found.append(pdb.file_name)
-            else:
+            if pdb.is_present():
                 haddock_score = HaddockModel(pdb.file_name).calc_haddock_score(
                     **weights
                     )
@@ -100,13 +97,14 @@ class HaddockModule(BaseCNSModule):
                 pdb.score = haddock_score
                 expected.append(pdb)
 
-        if not_found:
-            # fail if any expected files are found
-            self.finish_with_error(
-                "Several files were not generated:" f" {not_found}"
-                )
-
         # Save module information
         io = ModuleIO()
         io.add(expected, "o")
+        faulty = io.check_faulty()
+        tolerancy = self.params["tolerancy"]
+        if faulty > tolerancy:
+            _msg = (
+                f"{faulty:.2f}% of output was not generated for this module "
+                f"and tolerancy was set to {tolerancy:.2f}%.")
+            self.finish_with_error(_msg)
         io.save()

--- a/src/haddock/modules/refinement/emref/defaults.cfg
+++ b/src/haddock/modules/refinement/emref/defaults.cfg
@@ -1,3 +1,5 @@
+# tolerancy in percentage
+tolerancy = 5
 log_level = "verbose"
 sampling_factor = 1
 ambig_fname = ""

--- a/src/haddock/modules/refinement/flexref/defaults.cfg
+++ b/src/haddock/modules/refinement/flexref/defaults.cfg
@@ -1,3 +1,5 @@
+# tolerancy in percentage
+tolerancy = 5
 log_level = "verbose"
 sampling_factor = 1
 ambig_fname = ""

--- a/src/haddock/modules/refinement/mdref/__init__.py
+++ b/src/haddock/modules/refinement/mdref/__init__.py
@@ -86,11 +86,8 @@ class HaddockModule(BaseCNSModule):
         weights = {e: self.params[e] for e in _weight_keys}
 
         expected = []
-        not_found = []
         for pdb in refined_structure_list:
-            if not Path(pdb.file_name).exists():
-                not_found.append(pdb.file_name)
-            else:
+            if pdb.is_present():
                 haddock_score = HaddockModel(pdb.file_name).calc_haddock_score(
                     **weights
                     )
@@ -98,13 +95,14 @@ class HaddockModule(BaseCNSModule):
                 pdb.score = haddock_score
                 expected.append(pdb)
 
-        if not_found:
-            # fail if any expected files are found
-            self.finish_with_error(
-                "Several files were not generated:" f" {not_found}"
-                )
-
         # Save module information
         io = ModuleIO()
         io.add(expected, "o")
+        faulty = io.check_faulty()
+        tolerancy = self.params["tolerancy"]
+        if faulty > tolerancy:
+            _msg = (
+                f"{faulty:.2f}% of output was not generated for this module "
+                f"and tolerancy was set to {tolerancy:.2f}%.")
+            self.finish_with_error(_msg)
         io.save()

--- a/src/haddock/modules/refinement/mdref/defaults.cfg
+++ b/src/haddock/modules/refinement/mdref/defaults.cfg
@@ -1,3 +1,5 @@
+# tolerancy in percentage
+tolerancy = 5
 log_level = "verbose"
 sampling_factor = 1
 ambig_fname = ""

--- a/src/haddock/modules/sampling/rigidbody/__init__.py
+++ b/src/haddock/modules/sampling/rigidbody/__init__.py
@@ -95,7 +95,7 @@ class HaddockModule(BaseCNSModule):
         weights = {e: self.params[e] for e in _weight_keys}
 
         for model in structure_list:
-            if Path(model.file_name).exists():
+            if model.is_present():
                 # Score the model
                 haddock_score = HaddockModel(
                     model.file_name).calc_haddock_score(

--- a/src/haddock/modules/sampling/rigidbody/__init__.py
+++ b/src/haddock/modules/sampling/rigidbody/__init__.py
@@ -94,11 +94,8 @@ class HaddockModule(BaseCNSModule):
         _weight_keys = ("w_vdw", "w_elec", "w_desolv", "w_air", "w_bsa")
         weights = {e: self.params[e] for e in _weight_keys}
 
-        not_present = []
         for model in structure_list:
-            if not Path(model.file_name).exists():
-                not_present.append(model.file_name)
-            else:
+            if Path(model.file_name).exists():
                 # Score the model
                 haddock_score = HaddockModel(
                     model.file_name).calc_haddock_score(
@@ -107,18 +104,14 @@ class HaddockModule(BaseCNSModule):
 
                 model.score = haddock_score
 
-        # Check for generated output
-        if len(not_present) == len(structure_list):
-            # fail if not all expected files are found
-            self.finish_with_error("No models were generated.")
-
-        if not_present:
-            # fail if any expected files are found
-            self.finish_with_error(
-                f"Several models were not generated" f" {not_present}"
-                )
-
         # Save module information
         io = ModuleIO()
         io.add(structure_list, "o")
+        faulty = io.check_faulty()
+        tolerancy = self.params["tolerancy"]
+        if faulty > tolerancy:
+            _msg = (
+                f"{faulty:.2f}% of output was not generated for this module "
+                f"and tolerancy was set to {tolerancy:.2f}%.")
+            self.finish_with_error(_msg)
         io.save()

--- a/src/haddock/modules/sampling/rigidbody/defaults.cfg
+++ b/src/haddock/modules/sampling/rigidbody/defaults.cfg
@@ -1,3 +1,5 @@
+# tolerancy in percentage
+tolerancy = 0
 log_level = "verbose"
 sampling = 5
 ambig_fname = ""

--- a/src/haddock/modules/scoring/emscoring/__init__.py
+++ b/src/haddock/modules/scoring/emscoring/__init__.py
@@ -76,22 +76,14 @@ class HaddockModule(BaseCNSModule):
 
         # Check for generated output, fail it not all expected files are found
         expected = []
-        not_found = []
         for pdb in scored_structure_list:
-            if not Path(pdb.file_name).exists():
-                not_found.append(pdb.file_name)
-            else:
+            if pdb.is_present():
                 haddock_score = HaddockModel(pdb.file_name).calc_haddock_score(
                     **weights
                     )
 
                 pdb.score = haddock_score
                 expected.append(pdb)
-
-        if not_found:
-            # fail if any expected files are found
-            self.finish_with_error("Several files were not generated:"
-                                   f" {not_found}")
 
         output_fname = "emscoring.tsv"
         self.log(f"Saving output to {output_fname}")
@@ -109,4 +101,11 @@ class HaddockModule(BaseCNSModule):
         # Save module information
         io = ModuleIO()
         io.add(expected, "o")
+        faulty = io.check_faulty()
+        tolerancy = self.params["tolerancy"]
+        if faulty > tolerancy:
+            _msg = (
+                f"{faulty:.2f}% of output was not generated for this module "
+                f"and tolerancy was set to {tolerancy:.2f}%.")
+            self.finish_with_error(_msg)
         io.save()

--- a/src/haddock/modules/scoring/emscoring/defaults.cfg
+++ b/src/haddock/modules/scoring/emscoring/defaults.cfg
@@ -1,3 +1,5 @@
+# tolerancy in percentage
+tolerancy = 5
 log_level = 'verbose'
 dielec = 'cdie'
 epsilon = 1

--- a/src/haddock/modules/topology/topoaa/defaults.cfg
+++ b/src/haddock/modules/topology/topoaa/defaults.cfg
@@ -6,6 +6,9 @@ iniseed = 917
 ligand_param_fname = ""
 ligand_top_fname = ""
 
+# tolerancy in percentage
+tolerancy = 0
+
 [input]
 [input.mol1]
 prot_segid = 'A'


### PR DESCRIPTION
This PR closes #227 by adding a fault tolerance logic to the modules.

The new parameter `tolerance` is set in `defaults.cfg` as % and the check is made directly into `ModuleIO`.