### PR TITLE
No limit of 20 molecules for `topoaa`

### DIFF
--- a/src/haddock/modules/topology/topoaa/__init__.py
+++ b/src/haddock/modules/topology/topoaa/__init__.py
@@ -1,4 +1,6 @@
 """Create and manage CNS all-atom topology."""
+import operator
+from functools import partial
 from pathlib import Path
 
 from haddock.libs import libpdb
@@ -90,9 +92,9 @@ class HaddockModule(BaseCNSModule):
         mol_params_keys = list(mol_params.keys())[::-1]
 
         if self.params['limit']:
-            mol_params_pop = mol_params_keys.pop
+            mol_params_get = mol_params_keys.pop
         else:
-            mol_params_first = partial(operator.getitem, mol_params_keys, -1)
+            mol_params_get = partial(operator.getitem, mol_params_keys, -1)
 
         # Pool of jobs to be executed by the CNS engine
         jobs = []
@@ -116,7 +118,7 @@ class HaddockModule(BaseCNSModule):
 
             # nice variable name, isn't it? :-)
             # molecule parameters are shared among models of the same molecule
-            parameters_for_this_molecule = mol_params[mol_params_keys.pop()]
+            parameters_for_this_molecule = mol_params[mol_params_get()]
 
             # Sanitize the different PDB files
             relative_paths_models = (

--- a/src/haddock/modules/topology/topoaa/__init__.py
+++ b/src/haddock/modules/topology/topoaa/__init__.py
@@ -89,6 +89,11 @@ class HaddockModule(BaseCNSModule):
         # of `mol_params` with inverted order (we will use .pop)
         mol_params_keys = list(mol_params.keys())[::-1]
 
+        if self.params['limit']:
+            mol_params_pop = mol_params_keys.pop
+        else:
+            mol_params_first = partial(operator.getitem, mol_params_keys, -1)
+
         # Pool of jobs to be executed by the CNS engine
         jobs = []
 

--- a/src/haddock/modules/topology/topoaa/defaults.cfg
+++ b/src/haddock/modules/topology/topoaa/defaults.cfg
@@ -5,6 +5,7 @@ log_level = 'verbose'
 iniseed = 917
 ligand_param_fname = ""
 ligand_top_fname = ""
+limit = true
 
 [input]
 [input.mol1]


### PR DESCRIPTION
Useful when the next module is `emscoring`.

Activate it with the new parameter

```toml
[topoaa]
limit = false
```

@amjjbonvin 