### PR TITLE
Implemented `JobInputFirst`

### DIFF
--- a/src/haddock/libs/libsubprocess.py
+++ b/src/haddock/libs/libsubprocess.py
@@ -43,7 +43,7 @@ def Job(BaseJob):
 
     Runs with the following scheme:
 
-        $ cmd INPUT ARGS
+        $ cmd ARGS INPUT
     """
     def make_cmd(self):
         """Execute subprocess job."""
@@ -55,13 +55,13 @@ def Job(BaseJob):
         return
 
 
-class JobArgFirst(BaseJob):
+class JobInputFirst(BaseJob):
     """
     Instantiate a subprocess job with inverted args and input.
 
-    Runs with the following scheme:
+    Runs with the following scheme, INPUT comes first:
 
-        $ cmd ARGS INPUT
+        $ cmd INPUT ARGS
     """
 
     def make_cmd(self):

--- a/src/haddock/modules/analysis/clustfcc/__init__.py
+++ b/src/haddock/modules/analysis/clustfcc/__init__.py
@@ -8,7 +8,7 @@ from haddock import FCC_path, log
 from haddock.gear.config_reader import read_config
 from haddock.libs.libontology import ModuleIO
 from haddock.libs.libparallel import Scheduler
-from haddock.libs.libsubprocess import JobArgFirst
+from haddock.libs.libsubprocess import JobInputFirst
 from haddock.modules import BaseHaddockModule
 
 
@@ -51,7 +51,7 @@ class HaddockModule(BaseHaddockModule):
         for model in models_to_cluster:
             pdb_f = Path(model.rel_path)
             contact_f = Path(model.file_name.replace('.pdb', '.con'))
-            job = JobArgFirst(
+            job = JobInputFirst(
                 pdb_f,
                 contact_f,
                 contact_executable,

--- a/src/haddock/modules/analysis/clustfcc/__init__.py
+++ b/src/haddock/modules/analysis/clustfcc/__init__.py
@@ -8,7 +8,7 @@ from haddock import FCC_path, log
 from haddock.gear.config_reader import read_config
 from haddock.libs.libontology import ModuleIO
 from haddock.libs.libparallel import Scheduler
-from haddock.libs.libsubprocess import Job
+from haddock.libs.libsubprocess import JobArgFirst
 from haddock.modules import BaseHaddockModule
 
 
@@ -51,12 +51,11 @@ class HaddockModule(BaseHaddockModule):
         for model in models_to_cluster:
             pdb_f = Path(model.rel_path)
             contact_f = Path(model.file_name.replace('.pdb', '.con'))
-            job = Job(
+            job = JobArgFirst(
                 pdb_f,
                 contact_f,
                 contact_executable,
                 self.params['contact_distance_cutoff'],
-                arg_first=True,
                 )
             contact_jobs.append(job)
 


### PR DESCRIPTION
Closes #245 

Creates a proper subclass. I decided to use `make_cmd` instead of using the `super()` function because `make_cmd` can serve a prestep for testing or any other functionality.