### PR TITLE
Refactored the parameter flow

### DIFF
--- a/src/haddock/__init__.py
+++ b/src/haddock/__init__.py
@@ -14,12 +14,9 @@ add_syserr_handler(log)
 haddock3_source_path = Path(__file__).resolve().parent
 haddock3_repository_path = haddock3_source_path.parents[1]
 toppar_path = Path(haddock3_source_path, "cns", "toppar")
+modules_defaults_path = Path(haddock3_source_path, "modules", "defaults.cfg")
 
-FCC_path = Path(
-    Path(__file__).resolve().parents[1],
-    'fcc',
-    )
-
+FCC_path = Path(haddock3_source_path.parent, 'fcc')
 
 # version
 version = "3.0.0"

--- a/src/haddock/gear/parameters.py
+++ b/src/haddock/gear/parameters.py
@@ -1,5 +1,4 @@
 """Relates to logic or definition of parameters."""
-from haddock.core.defaults import cns_exec
 
 
 config_mandatory_general_parameters = {
@@ -7,10 +6,3 @@ config_mandatory_general_parameters = {
     'run_dir',
     }
 """The mandatory general arguments of the configuration file."""
-
-non_mandatory_general_parameters_defaults = {
-    "self_contained": False,
-    "ncores": 8,
-    "cns_exec": cns_exec,
-    "mode": "local",
-    }

--- a/src/haddock/gear/prepare_run.py
+++ b/src/haddock/gear/prepare_run.py
@@ -172,7 +172,7 @@ def validate_modules_params(modules_params):
         diff = set(args.keys()) \
             - set(defaults.keys()) \
             - set(config_mandatory_general_parameters) \
-            - non_mandatory_general_parameters_defaults
+            - set(non_mandatory_general_parameters_defaults.keys())
 
         if diff:
             _msg = (

--- a/src/haddock/gear/prepare_run.py
+++ b/src/haddock/gear/prepare_run.py
@@ -11,10 +11,7 @@ from haddock import contact_us, haddock3_source_path, log
 from haddock.core.exceptions import ConfigurationError, ModuleError
 from haddock.gear.config_reader import get_module_name, read_config
 from haddock.gear.greetings import get_goodbye_help
-from haddock.gear.parameters import (
-    config_mandatory_general_parameters,
-    non_mandatory_general_parameters_defaults,
-    )
+from haddock.gear.parameters import config_mandatory_general_parameters
 from haddock.gear.restart_run import remove_folders_after_number
 from haddock.libs.libutil import (
     make_list_if_string,
@@ -22,8 +19,8 @@ from haddock.libs.libutil import (
     zero_fill,
     )
 from haddock.modules import (
-    general_parameters_affecting_modules,
     modules_category,
+    non_mandatory_general_parameters_defaults,
     )
 
 
@@ -78,12 +75,11 @@ def setup_run(workflow_path, restart_from=None):
     # read config
     params = read_config(workflow_path)
 
+    check_mandatory_argments_are_present(params)
     validate_module_names_are_not_mispelled(params)
 
     # update default non-mandatory parameters with user params
     params = {**non_mandatory_general_parameters_defaults, **params}
-
-    check_mandatory_argments_are_present(params)
 
     clean_rundir_according_to_restart(params['run_dir'], restart_from)
 
@@ -136,7 +132,7 @@ def validate_modules_names(params):
     keys = \
         set(params) \
         - set(config_mandatory_general_parameters) \
-        - set(general_parameters_affecting_modules)
+        - set(non_mandatory_general_parameters_defaults)
 
     for module in keys:
         if get_module_name(module) not in modules_category.keys():
@@ -176,7 +172,7 @@ def validate_modules_params(modules_params):
         diff = set(args.keys()) \
             - set(defaults.keys()) \
             - set(config_mandatory_general_parameters) \
-            - general_parameters_affecting_modules
+            - non_mandatory_general_parameters_defaults
 
         if diff:
             _msg = (

--- a/src/haddock/gear/prepare_run.py
+++ b/src/haddock/gear/prepare_run.py
@@ -15,6 +15,7 @@ from haddock.gear.parameters import config_mandatory_general_parameters
 from haddock.gear.restart_run import remove_folders_after_number
 from haddock.libs.libutil import (
     make_list_if_string,
+    recursive_dict_update,
     remove_dict_keys,
     zero_fill,
     )
@@ -79,7 +80,9 @@ def setup_run(workflow_path, restart_from=None):
     validate_module_names_are_not_mispelled(params)
 
     # update default non-mandatory parameters with user params
-    params = {**non_mandatory_general_parameters_defaults, **params}
+    params = recursive_dict_update(
+        non_mandatory_general_parameters_defaults,
+        params)
 
     clean_rundir_according_to_restart(params['run_dir'], restart_from)
 

--- a/src/haddock/libs/libhpc.py
+++ b/src/haddock/libs/libhpc.py
@@ -6,7 +6,8 @@ import subprocess
 import time
 from pathlib import Path
 
-from haddock import log
+from haddock import log, modules_defaults_path
+from haddock.gear.config_reader import read_config
 
 
 STATE_REGEX = r"JobState=(\w*)"
@@ -20,9 +21,13 @@ JOB_STATUS_DIC = {
     "FAILED": "failed",
     }
 
-HPCScheduler_CONCAT_DEFAULT = 1
-HPCWorker_QUEUE_LIMIT_DEFAULT = 100
-HPCWorker_QUEUE_DEFAULT = None
+# if you change these defaults, chage also the values in the
+# modules/defaults.cfg file
+_tmpcfg = read_config(modules_defaults_path)
+HPCScheduler_CONCAT_DEFAULT = _tmpcfg["concat"]  # original value 1
+HPCWorker_QUEUE_LIMIT_DEFAULT = _tmpcfg["queue"]  # original value 100
+HPCWorker_QUEUE_DEFAULT = _tmpcfg["queue_limit"]  # original value None
+del _tmpcfg
 
 
 class HPCWorker:

--- a/src/haddock/libs/libutil.py
+++ b/src/haddock/libs/libutil.py
@@ -222,13 +222,26 @@ def recursive_dict_update(d, u):
     Update dictionary recursively.
 
     https://stackoverflow.com/questions/3232943
+
+    Returns
+    -------
+    dict
+        A new dict object with updated key: values. The original dictionaries
+        are not modified.
     """
-    for k, v in u.items():
-        if isinstance(v, collections.abc.Mapping):
-            d[k] = recursive_dict_update(d.get(k, {}), v)
-        else:
-            d[k] = v
-    return d
+    def _recurse(d_, u_):
+        for k, v in u_.items():
+            if isinstance(v, collections.abc.Mapping):
+                d_[k] = _recurse(d_.get(k, {}), v)
+            else:
+                d_[k] = deepcopy(v)  # in case these are also lists
+
+        return d_
+
+    new = deepcopy(d)
+    _recurse(new, u)
+
+    return new
 
 
 def get_number_from_path_stem(path):

--- a/src/haddock/libs/libworkflow.py
+++ b/src/haddock/libs/libworkflow.py
@@ -6,11 +6,8 @@ from pathlib import Path
 from haddock import log
 from haddock.core.exceptions import HaddockError, StepError
 from haddock.gear.config_reader import get_module_name
-from haddock.libs.libutil import zero_fill
-from haddock.modules import (
-    modules_category,
-    non_mandatory_general_parameters_defaults,
-    )
+from haddock.libs.libutil import recursive_dict_update, zero_fill
+from haddock.modules import modules_category
 
 
 class WorkflowManager:
@@ -38,16 +35,14 @@ class Workflow:
 
             # updates the module's specific parameter with global parameters
             # that are applicable to the modules. But keep priority to the local
-            # level by using the setdefault.
-            for gparam, gvalue in other_params.items():
-                if gparam in non_mandatory_general_parameters_defaults:
-                    params.setdefault(gparam, gvalue)
+            # level
+            params_up = recursive_dict_update(other_params, params)
 
             try:
                 _ = Step(
                     get_module_name(stage_name),
                     order=num_stage,
-                    **params,
+                    **params_up,
                     )
                 self.steps.append(_)
 

--- a/src/haddock/libs/libworkflow.py
+++ b/src/haddock/libs/libworkflow.py
@@ -7,7 +7,10 @@ from haddock import log
 from haddock.core.exceptions import HaddockError, StepError
 from haddock.gear.config_reader import get_module_name
 from haddock.libs.libutil import recursive_dict_update, zero_fill
-from haddock.modules import modules_category
+from haddock.modules import (
+    modules_category,
+    non_mandatory_general_parameters_defaults,
+    )
 
 
 class WorkflowManager:
@@ -28,6 +31,14 @@ class Workflow:
     """Represent a set of stages to be executed by HADDOCK."""
 
     def __init__(self, content, **other_params):
+
+        # filter out those parameters not belonging to the modules
+        _general_modules = {
+            k: v
+            for k, v in other_params.items()
+            if k in non_mandatory_general_parameters_defaults
+            }
+
         # Create the list of steps contained in this workflow
         self.steps = []
         for num_stage, (stage_name, params) in enumerate(content.items()):
@@ -36,7 +47,7 @@ class Workflow:
             # updates the module's specific parameter with global parameters
             # that are applicable to the modules. But keep priority to the local
             # level
-            params_up = recursive_dict_update(other_params, params)
+            params_up = recursive_dict_update(_general_modules, params)
 
             try:
                 _ = Step(

--- a/src/haddock/libs/libworkflow.py
+++ b/src/haddock/libs/libworkflow.py
@@ -30,10 +30,10 @@ class WorkflowManager:
 class Workflow:
     """Represent a set of stages to be executed by HADDOCK."""
 
-    def __init__(self, content, **other_params):
+    def __init__(self, modules_parameters, **other_params):
 
         # filter out those parameters not belonging to the modules
-        _general_modules = {
+        general_modules = {
             k: v
             for k, v in other_params.items()
             if k in non_mandatory_general_parameters_defaults
@@ -41,13 +41,14 @@ class Workflow:
 
         # Create the list of steps contained in this workflow
         self.steps = []
-        for num_stage, (stage_name, params) in enumerate(content.items()):
+        _items = enumerate(modules_parameters.items())
+        for num_stage, (stage_name, params) in _items:
             log.info(f"Reading instructions of [{stage_name}] step")
 
             # updates the module's specific parameter with global parameters
             # that are applicable to the modules. But keep priority to the local
             # level
-            params_up = recursive_dict_update(_general_modules, params)
+            params_up = recursive_dict_update(general_modules, params)
 
             try:
                 _ = Step(

--- a/src/haddock/libs/libworkflow.py
+++ b/src/haddock/libs/libworkflow.py
@@ -4,16 +4,13 @@ import sys
 from pathlib import Path
 
 from haddock import log
-from haddock.core.defaults import cns_exec as global_cns_exec
 from haddock.core.exceptions import HaddockError, StepError
 from haddock.gear.config_reader import get_module_name
-from haddock.libs.libhpc import (
-    HPCScheduler_CONCAT_DEFAULT,
-    HPCWorker_QUEUE_DEFAULT,
-    HPCWorker_QUEUE_LIMIT_DEFAULT,
-    )
 from haddock.libs.libutil import zero_fill
-from haddock.modules import modules_category
+from haddock.modules import (
+    modules_category,
+    non_mandatory_general_parameters_defaults,
+    )
 
 
 class WorkflowManager:
@@ -33,33 +30,18 @@ class WorkflowManager:
 class Workflow:
     """Represent a set of stages to be executed by HADDOCK."""
 
-    def __init__(
-            self,
-            content,
-            ncores=None,
-            cns_exec=global_cns_exec,
-            config_path=None,
-            mode='local',
-            queue=HPCWorker_QUEUE_DEFAULT,
-            concat=HPCScheduler_CONCAT_DEFAULT,
-            queue_limit=HPCWorker_QUEUE_LIMIT_DEFAULT,
-            self_contained=False,
-            **others):
+    def __init__(self, content, **other_params):
         # Create the list of steps contained in this workflow
         self.steps = []
         for num_stage, (stage_name, params) in enumerate(content.items()):
             log.info(f"Reading instructions of [{stage_name}] step")
 
-            # uses gobal ncores parameter unless module-specific value
-            # hasn't been used
-            params.setdefault('ncores', ncores)
-            params.setdefault('cns_exec', cns_exec)
-            params.setdefault('config_path', config_path)
-            params.setdefault('mode', mode)
-            params.setdefault('queue', queue)
-            params.setdefault('concat', concat)
-            params.setdefault('queue_limit', queue_limit)
-            params.setdefault('self_contained', self_contained)
+            # updates the module's specific parameter with global parameters
+            # that are applicable to the modules. But keep priority to the local
+            # level by using the setdefault.
+            for gparam, gvalue in other_params.items():
+                if gparam in non_mandatory_general_parameters_defaults:
+                    params.setdefault(gparam, gvalue)
 
             try:
                 _ = Step(

--- a/src/haddock/modules/__init__.py
+++ b/src/haddock/modules/__init__.py
@@ -113,7 +113,7 @@ class BaseHaddockModule(ABC):
         if update_from_cfg_file and params:
             _msg = (
                 "You can not provide both `update_from_cfg_file` "
-                "and key arguments"
+                "and key arguments."
                 )
             raise TypeError(_msg)
 

--- a/src/haddock/modules/__init__.py
+++ b/src/haddock/modules/__init__.py
@@ -3,15 +3,10 @@ from abc import ABC, abstractmethod
 from functools import partial
 from pathlib import Path
 
-from haddock import log as log
-from haddock.core.defaults import MODULE_IO_FILE, cns_exec
+from haddock import log, modules_defaults_path
+from haddock.core.defaults import MODULE_IO_FILE
 from haddock.gear.config_reader import read_config
-from haddock.libs.libhpc import (
-    HPCScheduler,
-    HPCScheduler_CONCAT_DEFAULT,
-    HPCWorker_QUEUE_DEFAULT,
-    HPCWorker_QUEUE_LIMIT_DEFAULT,
-    )
+from haddock.libs.libhpc import HPCScheduler
 from haddock.libs.libio import working_directory
 from haddock.libs.libontology import ModuleIO
 from haddock.libs.libparallel import Scheduler
@@ -35,15 +30,8 @@ values are their categories. Categories are the modules parent folders."""
 # module where the module definition overwrites global definition. Not all
 # modules will use these parameters. It is the responsibility of the module to
 # extract the parameters it needs.
-non_mandatory_general_parameters_defaults = {
-    "concat": HPCScheduler_CONCAT_DEFAULT,
-    "cns_exec": str(cns_exec),
-    "mode": "local",
-    "ncores": 8,
-    "queue": HPCWorker_QUEUE_DEFAULT,
-    "queue_limit": HPCWorker_QUEUE_LIMIT_DEFAULT,
-    "self_contained": False,
-    }
+# the config file is in modules/defaults.cfg
+non_mandatory_general_parameters_defaults = read_config(modules_defaults_path)
 
 
 class BaseHaddockModule(ABC):

--- a/src/haddock/modules/__init__.py
+++ b/src/haddock/modules/__init__.py
@@ -140,7 +140,7 @@ class BaseHaddockModule(ABC):
         """Execute the module."""
         log.info(f'Running [{self.name}] module')
 
-        self.params = params
+        self.update_params(**params)
         self.add_parent_to_paths()
 
         with working_directory(self.path):

--- a/src/haddock/modules/base_cns_module.py
+++ b/src/haddock/modules/base_cns_module.py
@@ -36,7 +36,7 @@ class BaseCNSModule(BaseHaddockModule):
         """Execute the module."""
         log.info(f'Running [{self.name}] module')
 
-        self.update_params_with_defaults(**params)
+        self.params = params
         self.add_parent_to_paths()
         self.envvars = self.default_envvars()
 

--- a/src/haddock/modules/base_cns_module.py
+++ b/src/haddock/modules/base_cns_module.py
@@ -36,7 +36,7 @@ class BaseCNSModule(BaseHaddockModule):
         """Execute the module."""
         log.info(f'Running [{self.name}] module')
 
-        self.params = params
+        self.update_params(**params)
         self.add_parent_to_paths()
         self.envvars = self.default_envvars()
 

--- a/src/haddock/modules/base_cns_module.py
+++ b/src/haddock/modules/base_cns_module.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from haddock import log
 from haddock import toppar_path as global_toppar
+from haddock.core.defaults import cns_exec as global_cns_exec
 from haddock.libs.libio import working_directory
 from haddock.modules import BaseHaddockModule
 
@@ -92,7 +93,7 @@ class BaseCNSModule(BaseHaddockModule):
         self.envvars = self.default_envvars()
         self.save_envvars()
 
-        _cns_exec = self.params["cns_exec"]
+        _cns_exec = self.params["cns_exec"] or global_cns_exec
         new_cns = Path(".", Path(_cns_exec).name)
         if not new_cns.exists():
             self.params["cns_exec"] = shutil.copyfile(_cns_exec, new_cns)

--- a/src/haddock/modules/defaults.cfg
+++ b/src/haddock/modules/defaults.cfg
@@ -1,0 +1,17 @@
+# None will use the global CNS installation. Otherwise provide a string pointing
+# to the CNS executable
+cns_exec = None
+
+# execution mode
+ncores = 8
+
+# available options "hpc", "local"
+mode = "local"
+
+# hpc related parameters
+concat = 1
+queue = None
+queue_limit = 100
+
+# make runs self containable. CNS source files are copied to the run dir
+self_contained = False

--- a/tests/test_libutil.py
+++ b/tests/test_libutil.py
@@ -7,6 +7,7 @@ from haddock.libs.libutil import (
     file_exists,
     get_number_from_path_stem,
     non_negative_int,
+    recursive_dict_update,
     sort_numbered_paths,
     )
 
@@ -108,3 +109,14 @@ def test_sort_numbered_inputs_error(in1, error):
     """Test sort numbered inputs raised Errors."""
     with pytest.raises(error):
         sort_numbered_paths(in1)
+
+
+def test_recursive_dict_update():
+    """Test recursive dict update."""
+    a = {"a": 1, "b": {"c": 2, "d": {"e": 3}}}
+    b = {"a": 2, "b": {"d": {"e": 4}}, "z": {"z1": 6}}
+    c = recursive_dict_update(a, b)
+    assert a is not c
+    assert a["b"] is not c["b"]
+    assert a["b"]["d"] is not c["b"]["d"]
+    assert c == {"a": 2, "b": {"c": 2, "d": {"e": 4}}, "z": {"z1": 6}}

--- a/tests/test_libutil.py
+++ b/tests/test_libutil.py
@@ -114,9 +114,11 @@ def test_sort_numbered_inputs_error(in1, error):
 def test_recursive_dict_update():
     """Test recursive dict update."""
     a = {"a": 1, "b": {"c": 2, "d": {"e": 3}}}
-    b = {"a": 2, "b": {"d": {"e": 4}}, "z": {"z1": 6}}
+    _list = list(range(10))
+    b = {"a": 2, "b": {"d": {"e": 4}}, "z": {"z1": _list}}
     c = recursive_dict_update(a, b)
     assert a is not c
     assert a["b"] is not c["b"]
     assert a["b"]["d"] is not c["b"]["d"]
-    assert c == {"a": 2, "b": {"c": 2, "d": {"e": 4}}, "z": {"z1": 6}}
+    assert b["z"]["z1"] is not c["z"]["z1"]
+    assert c == {"a": 2, "b": {"c": 2, "d": {"e": 4}}, "z": {"z1": _list}}


### PR DESCRIPTION
After the last months PRs, I noticed the way module's global parameters were defined was not escalating properly.

Now parameters are properly separated into:

1. global parameters that serve diverse purposes but are **not** injectable into modules

2. global parameters that are applicable to modules but that can be defined also per module basis; in these cases module-defined parameters always overwrite global-defined ones

3. module-specific parameters that are defined in the default config files

Also, the most critical point of refactor concerns point 2. Before, parameters referent to 2. where being defined in several different places. Now, I implemented engines to retrieve the those parameter's defaults wherever they are needed, yet the parameter values are defined in a single place (`modules.__init__.non_mandatory_general_parameters_defaults`).