### PR TITLE
Add dockq metric to `caprieval`

### DIFF
--- a/src/haddock/modules/analysis/caprieval/__init__.py
+++ b/src/haddock/modules/analysis/caprieval/__init__.py
@@ -80,6 +80,10 @@ class HaddockModule(BaseHaddockModule):
                 cutoff=ilrmsd_cutoff,
                 )
 
+        if self.params["dockq"]:
+            self.log("Calculating DockQ metric")
+            capri.dockq()
+
         output_fname = "capri.tsv"
         self.log(f" Saving output to {output_fname}")
         capri.output(

--- a/src/haddock/modules/analysis/caprieval/capri.py
+++ b/src/haddock/modules/analysis/caprieval/capri.py
@@ -88,6 +88,7 @@ class CAPRI:
         self.lrmsd_dic = {}
         self.ilrmsd_dic = {}
         self.fnat_dic = {}
+        self.dockq_dic = {}
         self.atoms = get_atoms(model_list + [reference])
         self.r_chain = receptor_chain
         self.l_chain = ligand_chain
@@ -361,6 +362,19 @@ class CAPRI:
             self.fnat_dic[model] = fnat
         return self.fnat_dic
 
+    def dockq(self):
+        """Calculate the DockQ metric."""
+        for model in self.model_list:
+            irmsd = self.irmsd_dic[model]
+            fnat = self.fnat_dic[model]
+            lrmsd = self.lrmsd_dic[model]
+            dockq = (float(fnat) + 1 / (1 + (irmsd / 1.5) * (irmsd / 1.5))
+                     + 1 / (1 + (lrmsd / 8.5) * (lrmsd / 8.5))
+                     ) / 3
+            self.dockq_dic[model] = dockq
+
+        return self.dockq_dic
+
     def output(
             self, output_f, sortby_key, sort_ascending, rankby_key,
             rank_ascending):
@@ -382,6 +396,8 @@ class CAPRI:
                 data["lrmsd"] = self.lrmsd_dic[model]
             if model in self.ilrmsd_dic:
                 data["ilrmsd"] = self.ilrmsd_dic[model]
+            if model in self.dockq_dic:
+                data["dockq"] = self.dockq_dic[model]
             # list of dictionaries
             output_l.append(data)
 


### PR DESCRIPTION
This pr closes #284 by adding the DockQ metric to `caprieval`, based on their own code , the dockq metric is given by:

```python
DockQ=(float(fnat) + 1/(1+(irms/1.5)*(irms/1.5)) + 1/(1+(Lrms/8.5)*(Lrms/8.5)))/3
```
https://github.com/bjornwallner/DockQ/blob/3735c160050f1e9128d2ccb23a0a1945aa98b5b2/DockQ.py#L361