### PR TITLE
[REDO] Set tolerance of modules in the workflow integration tests to 20% 

### DIFF
--- a/examples/docking-protein-DNA/docking-protein-DNA-mdref-test.cfg
+++ b/examples/docking-protein-DNA/docking-protein-DNA-mdref-test.cfg
@@ -16,9 +16,11 @@ molecules =  [
 # Parameters for each stage are defined below, prefer full paths
 # ====================================================================
 [topoaa]
+#tolerance = 20
 autohis = true
 
 [rigidbody]
+tolerance = 20
 ambig_fname = "data/cro_air.tbl"
 sampling = 20
 epsilon = 78
@@ -26,12 +28,15 @@ dielec = "cdie"
 noecv = false
 
 [caprieval]
+#tolerance = 20
 reference_fname = "data/target.pdb"
 
 [seletop]
+#tolerance = 20
 select = 5
 
 [flexref]
+tolerance = 20
 ambig_fname = "data/cro_air.tbl"
 epsilon = 78
 dielec = "cdie"
@@ -39,15 +44,18 @@ noecv = false
 dnarest_on = true
 
 [caprieval]
+#tolerance = 20
 reference_fname = "data/target.pdb"
 
 [mdref]
+tolerance = 20
 ambig_fname = "data/cro_air.tbl"
 noecv = false
 dnarest_on = true
 keepwater = true
 
 [caprieval]
+#tolerance = 20
 reference_fname = "data/target.pdb"
 
 # ====================================================================

--- a/examples/docking-protein-DNA/docking-protein-DNA-test.cfg
+++ b/examples/docking-protein-DNA/docking-protein-DNA-test.cfg
@@ -16,9 +16,11 @@ molecules =  [
 # Parameters for each stage are defined below, prefer full paths
 # ====================================================================
 [topoaa]
+#tolerance = 20
 autohis = true
 
 [rigidbody]
+tolerance = 20
 ambig_fname = "data/cro_air.tbl"
 sampling = 20
 epsilon = 78
@@ -26,12 +28,15 @@ dielec = "cdie"
 noecv = false
 
 [caprieval]
+#tolerance = 20
 reference_fname = "data/target.pdb"
 
 [seletop]
+#tolerance = 20
 select = 5
 
 [flexref]
+tolerance = 20
 ambig_fname = "data/cro_air.tbl"
 epsilon = 78
 dielec = "cdie"
@@ -39,14 +44,17 @@ noecv = false
 dnarest_on = true
 
 [caprieval]
+#tolerance = 20
 reference_fname = "data/target.pdb"
 
 [emref]
+tolerance = 20
 ambig_fname = "data/cro_air.tbl"
 noecv = false
 dnarest_on = true
 
 [caprieval]
+#tolerance = 20
 reference_fname = "data/target.pdb"
 
 # ====================================================================

--- a/examples/docking-protein-homotrimer/docking-protein-homotrimer-test.cfg
+++ b/examples/docking-protein-homotrimer/docking-protein-homotrimer-test.cfg
@@ -17,6 +17,7 @@ molecules =  [
 # Parameters for each stage are defined below, prefer full paths
 # ====================================================================
 [topoaa]
+#tolerance = 20
 autohis = false
 [topoaa.input.mol1]
 nhisd = 1
@@ -29,6 +30,7 @@ nhisd = 1
 hisd_1 = 98
 
 [rigidbody]
+tolerance = 20
 ambig_fname = "data/1qu9_whiscy_air.tbl"
 sampling = 20
 noecv = true
@@ -62,12 +64,15 @@ c3sym_seg3_1="C"
 
 
 [caprieval]
+#tolerance = 20
 reference_fname = "data/1qu9_ABC.pdb"
 
 [seletop]
+#tolerance = 20
 select = 5
 
 [flexref]
+tolerance = 20
 ambig_fname = "data/1qu9_whiscy_air.tbl"
 noecv = true
 # Define NCS restraints between molecules
@@ -99,9 +104,11 @@ c3sym_end3_1="128"
 c3sym_seg3_1="C"
 
 [caprieval]
+#tolerance = 20
 reference_fname = "data/1qu9_ABC.pdb"
 
 [emref]
+tolerance = 20
 ambig_fname = "data/1qu9_whiscy_air.tbl"
 noecv = true
 # Define NCS restraints between molecules
@@ -133,6 +140,7 @@ c3sym_end3_1="128"
 c3sym_seg3_1="C"
 
 [caprieval]
+#tolerance = 20
 reference_fname = "data/1qu9_ABC.pdb"
 
 

--- a/examples/docking-protein-ligand-shape/docking-protein-ligand-shape-test.cfg
+++ b/examples/docking-protein-ligand-shape/docking-protein-ligand-shape-test.cfg
@@ -15,6 +15,7 @@ molecules =  [
 
 # ====================================================================
 [topoaa]
+#tolerance = 20
 ligand_param_fname = "data/ligand.param"
 ligand_top_fname = "data/ligand.top"
 delenph = false
@@ -39,6 +40,7 @@ shape = true
 # Parameters for each stage are defined below
 
 [rigidbody]
+tolerance = 20
 ambig_fname = "data/shape-restraints-from-shape-1.tbl"
 ligand_param_fname = "data/ligand.param"
 ligand_top_fname = "data/ligand.top"
@@ -56,12 +58,15 @@ fix_origin_1 = true
 fix_origin_3 = true
 
 [caprieval]
+#tolerance = 20
 reference_fname = "data/target.pdb"
 
 [seletop]
+#tolerance = 20
 select = 5
 
 [flexref]
+tolerance = 20
 ambig_fname = "data/shape-restraints-from-shape-1.tbl"
 ligand_param_fname = "data/ligand.param"
 ligand_top_fname = "data/ligand.top"
@@ -77,6 +82,7 @@ fix_origin_1 = true
 fix_origin_3 = true
 
 [caprieval]
+#tolerance = 20
 reference_fname = "data/target.pdb"
 
 # ====================================================================

--- a/examples/docking-protein-ligand/docking-protein-ligand-test.cfg
+++ b/examples/docking-protein-ligand/docking-protein-ligand-test.cfg
@@ -16,12 +16,14 @@ molecules =  [
 # Parameters for each stage are defined below
 # ====================================================================
 [topoaa]
+#tolerance = 20
 autohis = true
 ligand_param_fname = "data/ligand-prodrg.param"
 ligand_top_fname = "data/ligand-prodrg.top"
 delenph = false
 
 [rigidbody]
+tolerance = 20
 ambig_fname = "data/ambig-active-rigidbody.tbl"
 ligand_param_fname = "data/ligand-prodrg.param"
 ligand_top_fname = "data/ligand-prodrg.top"
@@ -30,12 +32,15 @@ noecv = true
 w_vdw = 1.0
 
 [caprieval]
+#tolerance = 20
 reference_fname = 'data/target.pdb'
 
 [seletop]
+#tolerance = 20
 select = 5
 
 [flexref]
+tolerance = 20
 ambig_fname = "data/ambig-passive.tbl"
 ligand_param_fname = "data/ligand-prodrg.param"
 ligand_top_fname = "data/ligand-prodrg.top"
@@ -44,6 +49,7 @@ mdsteps_rigid = 0
 mdsteps_cool1 = 0
 
 [caprieval]
+#tolerance = 20
 reference_fname = 'data/target.pdb'
 
 # ====================================================================

--- a/examples/docking-protein-peptide/docking-protein-peptide-mdref-test.cfg
+++ b/examples/docking-protein-peptide/docking-protein-peptide-mdref-test.cfg
@@ -15,6 +15,7 @@ molecules =  [
 # Parameters for each stage are defined below, prefer full paths
 # ====================================================================
 [topoaa]
+#tolerance = 20
 autohis = false
 [topoaa.input.mol1]
 nhisd = 2
@@ -24,17 +25,21 @@ nhise = 1
 hise_1 = 113
 
 [rigidbody]
+tolerance = 20
 ambig_fname = "data/ambig.tbl"
 sampling = 30
 noecv = true
 
 [caprieval]
+#tolerance = 20
 reference_fname = "data/1nx1_refe.pdb"
 
 [seletop]
+#tolerance = 20
 select = 400
 
 [flexref]
+tolerance = 20
 ambig_fname = "data/ambig.tbl"
 noecv = true
 # Define peptide as fully flexible
@@ -46,9 +51,11 @@ fleend2_1 = 11
 ssdihed = "alphabeta"
 
 [caprieval]
+#tolerance = 20
 reference_fname = "data/1nx1_refe.pdb"
 
 [mdref]
+tolerance = 20
 ambig_fname = "data/ambig.tbl"
 noecv = true
 # Define peptide as fully flexible
@@ -60,6 +67,7 @@ fleend2_1 = 11
 ssdihed = "alphabeta"
 
 [caprieval]
+#tolerance = 20
 reference_fname = "data/1nx1_refe.pdb"
 
 # ====================================================================

--- a/examples/docking-protein-peptide/docking-protein-peptide-test.cfg
+++ b/examples/docking-protein-peptide/docking-protein-peptide-test.cfg
@@ -16,6 +16,7 @@ molecules =  [
 # Parameters for each stage are defined below, prefer full paths
 # ====================================================================
 [topoaa]
+#tolerance = 20
 autohis = false
 [topoaa.input.mol1]
 nhisd = 2
@@ -25,17 +26,21 @@ nhise = 1
 hise_1 = 113
 
 [rigidbody]
+tolerance = 20
 ambig_fname = "data/ambig.tbl"
 sampling = 20
 noecv = true
 
 [caprieval]
+#tolerance = 20
 reference_fname = "data/1nx1_refe.pdb"
 
 [seletop]
+#tolerance = 20
 select = 5
 
 [flexref]
+tolerance = 20
 ambig_fname = "data/ambig.tbl"
 noecv = true
 # Define peptide as fully flexible
@@ -47,9 +52,11 @@ fleend2_1 = 11
 ssdihed = "alphabeta"
 
 [caprieval]
+#tolerance = 20
 reference_fname = "data/1nx1_refe.pdb"
 
 [emref]
+tolerance = 20
 ambig_fname = "data/ambig.tbl"
 noecv = true
 # Define peptide as fully flexible
@@ -61,6 +68,7 @@ fleend2_1 = 11
 ssdihed = "alphabeta"
 
 [caprieval]
+#tolerance = 20
 reference_fname = "data/1nx1_refe.pdb"
 
 # ====================================================================

--- a/examples/docking-protein-protein/docking-protein-protein-cltsel-test.cfg
+++ b/examples/docking-protein-protein/docking-protein-protein-cltsel-test.cfg
@@ -16,6 +16,7 @@ molecules =  [
 # Parameters for each stage are defined below, prefer full paths
 # ====================================================================
 [topoaa]
+#tolerance = 20
 autohis = false
 [topoaa.input.mol1]
 nhisd = 0
@@ -28,14 +29,17 @@ nhise = 1
 hise_1 = 15
 
 [rigidbody]
+tolerance = 20
 ambig_fname = "data/e2a-hpr_air.tbl"
 sampling = 100
 noecv = true
 
 [clustfcc]
+#tolerance = 20
 threshold=1
 
 [seletopclusts]
+#tolerance = 20
 ## select the best 4 clusters
 # top_cluster = [1, 2, 3, 4]
 ## select all the clusters
@@ -46,20 +50,25 @@ top_cluster = []
 top_models = nan
 
 [caprieval]
+#tolerance = 20
 reference_fname = "data/e2a-hpr_1GGR.pdb"
 
 [flexref]
+tolerance = 20
 ambig_fname = "data/e2a-hpr_air.tbl"
 noecv = true
 
 [caprieval]
+#tolerance = 20
 reference_fname = "data/e2a-hpr_1GGR.pdb"
 
 [emref]
+tolerance = 20
 ambig_fname = "data/e2a-hpr_air.tbl"
 noecv = true
 
 [caprieval]
+#tolerance = 20
 reference_fname = "data/e2a-hpr_1GGR.pdb"
 
 # ====================================================================

--- a/examples/docking-protein-protein/docking-protein-protein-hpc-test.cfg
+++ b/examples/docking-protein-protein/docking-protein-protein-hpc-test.cfg
@@ -26,6 +26,7 @@ molecules =  [
 # Parameters for each stage are defined below, prefer full paths
 # ====================================================================
 [topoaa]
+#tolerance = 20
 autohis = false
 [topoaa.input.mol1]
 nhisd = 0
@@ -38,28 +39,35 @@ nhise = 1
 hise_1 = 15
 
 [rigidbody]
+tolerance = 20
 ambig_fname = "data/e2a-hpr_air.tbl"
 sampling = 1000
 noecv = true
 
 [caprieval]
+#tolerance = 20
 reference_fname = "data/e2a-hpr_1GGR.pdb"
 
 [seletop]
+#tolerance = 20
 select = 200
 
 [flexref]
+tolerance = 20
 ambig_fname = "data/e2a-hpr_air.tbl"
 noecv = true
 
 [caprieval]
+#tolerance = 20
 reference_fname = "data/e2a-hpr_1GGR.pdb"
 
 [emref]
+tolerance = 20
 ambig_fname = "data/e2a-hpr_air.tbl"
 noecv = true
 
 [caprieval]
+#tolerance = 20
 reference_fname = "data/e2a-hpr_1GGR.pdb"
 
 # ====================================================================

--- a/examples/docking-protein-protein/docking-protein-protein-mdref-test.cfg
+++ b/examples/docking-protein-protein/docking-protein-protein-mdref-test.cfg
@@ -18,6 +18,7 @@ molecules =  [
 # Parameters for each stage are defined below, prefer full paths
 # ====================================================================
 [topoaa]
+#tolerance = 20
 autohis = false
 [topoaa.input.mol1]
 nhisd = 0
@@ -30,31 +31,39 @@ nhise = 1
 hise_1 = 15
 
 [rigidbody]
+tolerance = 20
 ambig_fname = "data/e2a-hpr_air.tbl"
 sampling = 20
 noecv = true
 
 [caprieval]
+#tolerance = 20
 reference_fname = "data/e2a-hpr_1GGR.pdb"
 
 [seletop]
+#tolerance = 20
 select = 5
 
 [flexref]
+tolerance = 20
 ambig_fname = "data/e2a-hpr_air.tbl"
 noecv = true
 
 [caprieval]
+#tolerance = 20
 reference_fname = "data/e2a-hpr_1GGR.pdb"
 
 [mdref]
+tolerance = 20
 ambig_fname = "data/e2a-hpr_air.tbl"
 noecv = true
 
 [caprieval]
+#tolerance = 20
 reference_fname = "data/e2a-hpr_1GGR.pdb"
 
 [clustfcc]
+#tolerance = 20
 
 # ====================================================================
 

--- a/examples/docking-protein-protein/docking-protein-protein-test.cfg
+++ b/examples/docking-protein-protein/docking-protein-protein-test.cfg
@@ -18,6 +18,7 @@ molecules =  [
 # Parameters for each stage are defined below, prefer full paths
 # ====================================================================
 [topoaa]
+#tolerance = 20
 autohis = false
 [topoaa.input.mol1]
 nhisd = 0
@@ -30,31 +31,39 @@ nhise = 1
 hise_1 = 15
 
 [rigidbody]
+tolerance = 20
 ambig_fname = "data/e2a-hpr_air.tbl"
 sampling = 20
 noecv = true
 
 [caprieval]
+#tolerance = 20
 reference_fname = "data/e2a-hpr_1GGR.pdb"
 
 [seletop]
+#tolerance = 20
 select = 5
 
 [flexref]
+tolerance = 20
 ambig_fname = "data/e2a-hpr_air.tbl"
 noecv = true
 
 [caprieval]
+#tolerance = 20
 reference_fname = "data/e2a-hpr_1GGR.pdb"
 
 [emref]
+tolerance = 20
 ambig_fname = "data/e2a-hpr_air.tbl"
 noecv = true
 
 [caprieval]
+#tolerance = 20
 reference_fname = "data/e2a-hpr_1GGR.pdb"
 
 [clustfcc]
+#tolerance = 20
 
 # ====================================================================
 

--- a/examples/refine-complex/refine-complex-test.cfg
+++ b/examples/refine-complex/refine-complex-test.cfg
@@ -16,6 +16,7 @@ molecules =  [
 # Parameters for each stage are defined below, prefer full paths
 # ====================================================================
 [topoaa]
+#tolerance = 20
 autohis = false
 [topoaa.input.mol1]
 nhisd = 0
@@ -28,10 +29,12 @@ nhise = 1
 hise_1 = 15
 
 [mdref]
+tolerance = 20
 noecv = false
 sampling_factor = 10
 
 [caprieval]
+#tolerance = 20
 reference_fname = "data/e2a-hpr_1GGR.pdb"
 
 

--- a/examples/scoring/scoring-test.cfg
+++ b/examples/scoring/scoring-test.cfg
@@ -27,7 +27,7 @@ tolerance = 20
 
 ########################
 #[clustering]
-tolerance = 20
+# tolerance = 20
 #method = "fcc"
 #details = false
 
@@ -39,7 +39,7 @@ tolerance = 20
 #]
 ########################
 #[analysis]
-tolerance = 20
+# tolerance = 20
 #template = "capri_48_161.brk"
 #reference = ""
 #analysis  = "lowest"

--- a/examples/scoring/scoring-test.cfg
+++ b/examples/scoring/scoring-test.cfg
@@ -18,13 +18,16 @@ molecules = ["data/T161-rescoring-ens.pdb",
 
 ########################
 [topoaa]
+#tolerance = 20
 autohis = true
 
 ########################
 [emscoring]
+tolerance = 20
 
 ########################
 #[clustering]
+tolerance = 20
 #method = "fcc"
 #details = false
 
@@ -36,6 +39,7 @@ autohis = true
 #]
 ########################
 #[analysis]
+tolerance = 20
 #template = "capri_48_161.brk"
 #reference = ""
 #analysis  = "lowest"


### PR DESCRIPTION
This PR is a redo of #297, this time adding `tolerance = 20` to all the examples that contain `-test.cfg` and keeping the trailing white spaces