### PR TITLE
Add documentation about whitespaces in `run_test.py`

### DIFF
--- a/examples/run_examples-full.py
+++ b/examples/run_examples-full.py
@@ -30,7 +30,7 @@ try:
     from haddock.libs.libio import working_directory
     from haddock.gear.config_reader import read_config
 except Exception:
-    print(
+    print(  # noqa: T001
         "Haddock3 could not be imported. "
         "Please activate the haddock3 python environment.",
         file=sys.stderr,
@@ -40,16 +40,17 @@ except Exception:
 
 # edit this dictionary to add or remove examples.
 # keys are the examples folder, and values are the configuration files
+# spacings are anti-pythonic but facilitate reading :-)
 examples = (
-    ("docking-protein-DNA"         , "docking-protein-DNA-full.cfg"),
-    ("docking-protein-DNA"         , "docking-protein-DNA-mdref-full.cfg"),
-    ("docking-protein-homotrimer"  , "docking-protein-homotrimer-full.cfg"),
-    ("docking-protein-ligand-shape", "docking-protein-ligand-shape-full.cfg"),
-    ("docking-protein-ligand"      , "docking-protein-ligand-full.cfg"),
-    ("docking-protein-peptide"     , "docking-protein-peptide-full.cfg"),
-    ("docking-protein-peptide"     , "docking-protein-peptide-mdref-full.cfg"),
-    ("docking-protein-protein"     , "docking-protein-protein-full.cfg"),
-    ("docking-protein-protein"     , "docking-protein-protein-mdref-full.cfg"),
+    ("docking-protein-DNA"         , "docking-protein-DNA-full.cfg"),  # noqa: E203, E501
+    ("docking-protein-DNA"         , "docking-protein-DNA-mdref-full.cfg"),  # noqa: E203, E501
+    ("docking-protein-homotrimer"  , "docking-protein-homotrimer-full.cfg"),  # noqa: E203, E501
+    ("docking-protein-ligand-shape", "docking-protein-ligand-shape-full.cfg"),  # noqa: E203, E501
+    ("docking-protein-ligand"      , "docking-protein-ligand-full.cfg"),  # noqa: E203, E501
+    ("docking-protein-peptide"     , "docking-protein-peptide-full.cfg"),  # noqa: E203, E501
+    ("docking-protein-peptide"     , "docking-protein-peptide-mdref-full.cfg"),  # noqa: E203, E501
+    ("docking-protein-protein"     , "docking-protein-protein-full.cfg"),  # noqa: E203, E501
+    ("docking-protein-protein"     , "docking-protein-protein-mdref-full.cfg"),  # noqa: E203, E501
     )
 
 
@@ -78,15 +79,15 @@ def main(examples, break_on_errors=True):
     """Run all the examples."""
     for folder, file_ in examples:
 
-        print()
-        print(f" {file_.upper()} ".center(80, "*"))
-        print()
+        print()  # noqa: T001
+        print(f" {file_.upper()} ".center(80, "*"))  # noqa: T001
+        print()  # noqa: T001
 
         with working_directory(folder):
 
             params = read_config(file_)
             rmtree(params["run_dir"], ignore_errors=True)
-            p = subprocess.run(
+            subprocess.run(
                 f"haddock3 {file_}",
                 shell=True,
                 check=break_on_errors,

--- a/examples/run_tests.py
+++ b/examples/run_tests.py
@@ -30,7 +30,7 @@ try:
     from haddock.libs.libio import working_directory
     from haddock.gear.config_reader import read_config
 except Exception:
-    print(
+    print(  # noqa: T001
         "Haddock3 could not be imported. "
         "Please activate the haddock3 python environment.",
         file=sys.stderr,
@@ -40,20 +40,20 @@ except Exception:
 
 # edit this dictionary to add or remove examples.
 # keys are the examples folder, and values are the configuration files
-#  the whitespaces below were added on purpose and must not be removed
+# the whitespaces below are anti-pythonic but facilitate reading :-)
 examples = (
-    ("docking-protein-DNA"         , "docking-protein-DNA-test.cfg"),
-    ("docking-protein-DNA"         , "docking-protein-DNA-mdref-test.cfg"),
-    ("docking-protein-homotrimer"  , "docking-protein-homotrimer-test.cfg"),
-    ("docking-protein-ligand-shape", "docking-protein-ligand-shape-test.cfg"),
-    ("docking-protein-ligand"      , "docking-protein-ligand-test.cfg"),
-    ("docking-protein-peptide"     , "docking-protein-peptide-test.cfg"),
-    ("docking-protein-peptide"     , "docking-protein-peptide-mdref-test.cfg"),
-    ("docking-protein-protein"     , "docking-protein-protein-test.cfg"),
-    ("docking-protein-protein"     , "docking-protein-protein-cltsel-test.cfg"),
-    ("docking-protein-protein"     , "docking-protein-protein-mdref-test.cfg"),
-    ("refine-complex"              , "refine-complex-test.cfg"),
-    ("scoring"                     , "scoring-test.cfg"),
+    ("docking-protein-DNA"         , "docking-protein-DNA-test.cfg"),  # noqa: E203, E501
+    ("docking-protein-DNA"         , "docking-protein-DNA-mdref-test.cfg"),  # noqa: E203, E501
+    ("docking-protein-homotrimer"  , "docking-protein-homotrimer-test.cfg"),  # noqa: E203, E501
+    ("docking-protein-ligand-shape", "docking-protein-ligand-shape-test.cfg"),  # noqa: E203, E501
+    ("docking-protein-ligand"      , "docking-protein-ligand-test.cfg"),  # noqa: E203, E501
+    ("docking-protein-peptide"     , "docking-protein-peptide-test.cfg"),  # noqa: E203, E501
+    ("docking-protein-peptide"     , "docking-protein-peptide-mdref-test.cfg"),  # noqa: E203, E501
+    ("docking-protein-protein"     , "docking-protein-protein-test.cfg"),  # noqa: E203, E501
+    ("docking-protein-protein"     , "docking-protein-protein-cltsel-test.cfg"),  # noqa: E203, E501
+    ("docking-protein-protein"     , "docking-protein-protein-mdref-test.cfg"),  # noqa: E203, E501
+    ("refine-complex"              , "refine-complex-test.cfg"),  # noqa: E203, E501
+    ("scoring"                     , "scoring-test.cfg"),  # noqa: E203, E501
     )
 
 
@@ -82,15 +82,15 @@ def main(examples, break_on_errors=True):
     """Run all the examples."""
     for folder, file_ in examples:
 
-        print()
-        print(f" {file_.upper()} ".center(80, "*"))
-        print()
+        print()  # noqa: T001
+        print(f" {file_.upper()} ".center(80, "*"))  # noqa: T001
+        print()  # noqa: T001
 
         with working_directory(folder):
 
             params = read_config(file_)
             rmtree(params["run_dir"], ignore_errors=True)
-            p = subprocess.run(
+            subprocess.run(
                 f"haddock3 {file_}",
                 shell=True,
                 check=break_on_errors,

--- a/examples/run_tests.py
+++ b/examples/run_tests.py
@@ -40,6 +40,7 @@ except Exception:
 
 # edit this dictionary to add or remove examples.
 # keys are the examples folder, and values are the configuration files
+#  the whitespaces below were added on purpose and must not be removed
 examples = (
     ("docking-protein-DNA"         , "docking-protein-DNA-test.cfg"),
     ("docking-protein-DNA"         , "docking-protein-DNA-mdref-test.cfg"),


### PR DESCRIPTION
As pointed in https://github.com/haddocking/haddock3/pull/297#discussion_r794655989, these whitespaces must be kept but this information is not present in the document, this PR adds a minor comment about this so they are not removed by mistake.