### PR TITLE
Remove `input` layer in `topoaa` module.

### DIFF
--- a/examples/docking-protein-homotrimer/docking-protein-homotrimer-full.cfg
+++ b/examples/docking-protein-homotrimer/docking-protein-homotrimer-full.cfg
@@ -27,13 +27,13 @@ molecules =  [
 # ====================================================================
 [topoaa]
 autohis = false
-[topoaa.input.mol1]
+[topoaa.mol1]
 nhisd = 1
 hisd_1 = 98
-[topoaa.input.mol2]
+[topoaa.mol2]
 nhisd = 1
 hisd_1 = 98
-[topoaa.input.mol3]
+[topoaa.mol3]
 nhisd = 1
 hisd_1 = 98
 

--- a/examples/docking-protein-homotrimer/docking-protein-homotrimer-test.cfg
+++ b/examples/docking-protein-homotrimer/docking-protein-homotrimer-test.cfg
@@ -18,13 +18,13 @@ molecules =  [
 # ====================================================================
 [topoaa]
 autohis = false
-[topoaa.input.mol1]
+[topoaa.mol1]
 nhisd = 1
 hisd_1 = 98
-[topoaa.input.mol2]
+[topoaa.mol2]
 nhisd = 1
 hisd_1 = 98
-[topoaa.input.mol3]
+[topoaa.mol3]
 nhisd = 1
 hisd_1 = 98
 

--- a/examples/docking-protein-ligand-shape/docking-protein-ligand-shape-full.cfg
+++ b/examples/docking-protein-ligand-shape/docking-protein-ligand-shape-full.cfg
@@ -28,7 +28,7 @@ ligand_param_fname = "data/ligand.param"
 ligand_top_fname = "data/ligand.top"
 delenph = false
 autohis = false
-[topoaa.input.mol1]
+[topoaa.mol1]
 # Define histidine states
 nhisd = 1
 hisd_1 = 360
@@ -39,7 +39,7 @@ hise_3 = 45
 hise_4 = 145
 hise_5 = 181
 hise_6 = 89
-[topoaa.input.mol3]
+[topoaa.mol3]
 # Define the shape molecule
 #prot_segid = "S"
 shape = true

--- a/examples/docking-protein-ligand-shape/docking-protein-ligand-shape-test.cfg
+++ b/examples/docking-protein-ligand-shape/docking-protein-ligand-shape-test.cfg
@@ -19,7 +19,7 @@ ligand_param_fname = "data/ligand.param"
 ligand_top_fname = "data/ligand.top"
 delenph = false
 autohis = false
-[topoaa.input.mol1]
+[topoaa.mol1]
 # Define histidine states
 nhisd = 1
 hisd_1 = 360
@@ -30,7 +30,7 @@ hise_3 = 45
 hise_4 = 145
 hise_5 = 181
 hise_6 = 89
-[topoaa.input.mol3]
+[topoaa.mol3]
 # Define the shape molecule
 #prot_segid = "S"
 shape = true

--- a/examples/docking-protein-peptide/docking-protein-peptide-full.cfg
+++ b/examples/docking-protein-peptide/docking-protein-peptide-full.cfg
@@ -28,7 +28,7 @@ molecules =  [
 # ====================================================================
 [topoaa]
 autohis = false
-[topoaa.input.mol1]
+[topoaa.mol1]
 nhisd = 2
 hisd_1 = 36
 hisd_2 = 109

--- a/examples/docking-protein-peptide/docking-protein-peptide-mdref-full.cfg
+++ b/examples/docking-protein-peptide/docking-protein-peptide-mdref-full.cfg
@@ -28,7 +28,7 @@ molecules =  [
 # ====================================================================
 [topoaa]
 autohis = false
-[topoaa.input.mol1]
+[topoaa.mol1]
 nhisd = 2
 hisd_1 = 36
 hisd_2 = 109

--- a/examples/docking-protein-peptide/docking-protein-peptide-mdref-test.cfg
+++ b/examples/docking-protein-peptide/docking-protein-peptide-mdref-test.cfg
@@ -16,7 +16,7 @@ molecules =  [
 # ====================================================================
 [topoaa]
 autohis = false
-[topoaa.input.mol1]
+[topoaa.mol1]
 nhisd = 2
 hisd_1 = 36
 hisd_2 = 109

--- a/examples/docking-protein-peptide/docking-protein-peptide-test.cfg
+++ b/examples/docking-protein-peptide/docking-protein-peptide-test.cfg
@@ -17,7 +17,7 @@ molecules =  [
 # ====================================================================
 [topoaa]
 autohis = false
-[topoaa.input.mol1]
+[topoaa.mol1]
 nhisd = 2
 hisd_1 = 36
 hisd_2 = 109

--- a/examples/docking-protein-protein/docking-protein-protein-cltsel-test.cfg
+++ b/examples/docking-protein-protein/docking-protein-protein-cltsel-test.cfg
@@ -17,11 +17,11 @@ molecules =  [
 # ====================================================================
 [topoaa]
 autohis = false
-[topoaa.input.mol1]
+[topoaa.mol1]
 nhisd = 0
 nhise = 1
 hise_1 = 75
-[topoaa.input.mol2]
+[topoaa.mol2]
 nhisd = 1
 hisd_1 = 76
 nhise = 1

--- a/examples/docking-protein-protein/docking-protein-protein-full.cfg
+++ b/examples/docking-protein-protein/docking-protein-protein-full.cfg
@@ -27,11 +27,11 @@ molecules =  [
 # ====================================================================
 [topoaa]
 autohis = false
-[topoaa.input.mol1]
+[topoaa.mol1]
 nhisd = 0
 nhise = 1
 hise_1 = 75
-[topoaa.input.mol2]
+[topoaa.mol2]
 nhisd = 1
 hisd_1 = 76
 nhise = 1

--- a/examples/docking-protein-protein/docking-protein-protein-hpc-test.cfg
+++ b/examples/docking-protein-protein/docking-protein-protein-hpc-test.cfg
@@ -27,11 +27,11 @@ molecules =  [
 # ====================================================================
 [topoaa]
 autohis = false
-[topoaa.input.mol1]
+[topoaa.mol1]
 nhisd = 0
 nhise = 1
 hise_1 = 75
-[topoaa.input.mol2]
+[topoaa.mol2]
 nhisd = 1
 hisd_1 = 76
 nhise = 1

--- a/examples/docking-protein-protein/docking-protein-protein-mdref-full.cfg
+++ b/examples/docking-protein-protein/docking-protein-protein-mdref-full.cfg
@@ -27,11 +27,11 @@ molecules =  [
 # ====================================================================
 [topoaa]
 autohis = false
-[topoaa.input.mol1]
+[topoaa.mol1]
 nhisd = 0
 nhise = 1
 hise_1 = 75
-[topoaa.input.mol2]
+[topoaa.mol2]
 nhisd = 1
 hisd_1 = 76
 nhise = 1

--- a/examples/docking-protein-protein/docking-protein-protein-mdref-test.cfg
+++ b/examples/docking-protein-protein/docking-protein-protein-mdref-test.cfg
@@ -19,11 +19,11 @@ molecules =  [
 # ====================================================================
 [topoaa]
 autohis = false
-[topoaa.input.mol1]
+[topoaa.mol1]
 nhisd = 0
 nhise = 1
 hise_1 = 75
-[topoaa.input.mol2]
+[topoaa.mol2]
 nhisd = 1
 hisd_1 = 76
 nhise = 1

--- a/examples/docking-protein-protein/docking-protein-protein-test.cfg
+++ b/examples/docking-protein-protein/docking-protein-protein-test.cfg
@@ -19,11 +19,11 @@ molecules =  [
 # ====================================================================
 [topoaa]
 autohis = false
-[topoaa.input.mol1]
+[topoaa.mol1]
 nhisd = 0
 nhise = 1
 hise_1 = 75
-[topoaa.input.mol2]
+[topoaa.mol2]
 nhisd = 1
 hisd_1 = 76
 nhise = 1

--- a/examples/refine-complex/refine-complex-test.cfg
+++ b/examples/refine-complex/refine-complex-test.cfg
@@ -17,11 +17,11 @@ molecules =  [
 # ====================================================================
 [topoaa]
 autohis = false
-[topoaa.input.mol1]
+[topoaa.mol1]
 nhisd = 0
 nhise = 1
 hise_1 = 75
-[topoaa.input.mol2]
+[topoaa.mol2]
 nhisd = 1
 hisd_1 = 76
 nhise = 1

--- a/src/haddock/modules/topology/topoaa/__init__.py
+++ b/src/haddock/modules/topology/topoaa/__init__.py
@@ -86,11 +86,10 @@ class HaddockModule(BaseCNSModule):
 
         # extracts `input` key from params. The `input` keyword needs to
         # be treated separately
-        mol_params = {
-            k:v
-            for k, v in self.params.items()
-            if k.startswith("mol") and k[3:].isdigit()
-            } #self.params.pop('input')
+        mol_params = {}
+        for k in list(self.params.keys()):
+            if k.startswith("mol") and k[3:].isdigit():
+                mol_params[k] = self.params.pop(k)
 
         # to facilite the for loop down the line, we create a list with the keys
         # of `mol_params` with inverted order (we will use .pop)

--- a/src/haddock/modules/topology/topoaa/__init__.py
+++ b/src/haddock/modules/topology/topoaa/__init__.py
@@ -86,7 +86,12 @@ class HaddockModule(BaseCNSModule):
 
         # extracts `input` key from params. The `input` keyword needs to
         # be treated separately
-        mol_params = self.params.pop('input')
+        mol_params = {
+            k:v
+            for k, v in self.params.items()
+            if k.startswith("mol") and k[3:].isdigit()
+            } #self.params.pop('input')
+
         # to facilite the for loop down the line, we create a list with the keys
         # of `mol_params` with inverted order (we will use .pop)
         mol_params_keys = list(mol_params.keys())[::-1]

--- a/src/haddock/modules/topology/topoaa/defaults.cfg
+++ b/src/haddock/modules/topology/topoaa/defaults.cfg
@@ -10,8 +10,7 @@ limit = true
 # tolerance in percentage
 tolerance = 0
 
-[input]
-[input.mol1]
+[mol1]
 prot_segid = "A"
 fix_origin = false
 dna = false
@@ -25,7 +24,7 @@ nhise = 0
 hise_1 = nan
 # add more if needed
 
-[input.mol2]
+[mol2]
 prot_segid = "B"
 fix_origin = false
 dna = false
@@ -36,10 +35,10 @@ nhisd = 0
 hisd_1 = nan
 # add more if needed
 nhise = 0
-hise_1 = ""
+hise_1 = nan
 # add more if needed
 
-[input.mol3]
+[mol3]
 prot_segid = "C"
 fix_origin = false
 dna = false
@@ -53,7 +52,7 @@ nhise = 0
 hise_1 = nan
 # add more if needed
 
-[input.mol4]
+[mol4]
 prot_segid = "D"
 fix_origin = false
 dna = false
@@ -67,7 +66,7 @@ nhise = 0
 hise_1 = nan
 # add more if needed
 
-[input.mol5]
+[mol5]
 prot_segid = "E"
 fix_origin = false
 dna = false
@@ -81,7 +80,7 @@ nhise = 0
 hise_1 = nan
 # add more if needed
 
-[input.mol6]
+[mol6]
 prot_segid = "F"
 fix_origin = false
 dna = false
@@ -95,7 +94,7 @@ nhise = 0
 hise_1 = nan
 # add more if needed
 
-[input.mol7]
+[mol7]
 prot_segid = "G"
 fix_origin = false
 dna = false
@@ -109,7 +108,7 @@ nhise = 0
 hise_1 = nan
 # add more if needed
 
-[input.mol8]
+[mol8]
 prot_segid = "H"
 fix_origin = false
 dna = false
@@ -123,7 +122,7 @@ nhise = 0
 hise_1 = nan
 # add more if needed
 
-[input.mol9]
+[mol9]
 prot_segid = "I"
 fix_origin = false
 dna = false
@@ -137,7 +136,7 @@ nhise = 0
 hise_1 = nan
 # add more if needed
 
-[input.mol10]
+[mol10]
 prot_segid = "J"
 fix_origin = false
 dna = false
@@ -151,7 +150,7 @@ nhise = 0
 hise_1 = nan
 # add more if needed
 
-[input.mol11]
+[mol11]
 prot_segid = "K"
 fix_origin = false
 dna = false
@@ -165,7 +164,7 @@ nhise = 0
 hise_1 = nan
 # add more if needed
 
-[input.mol12]
+[mol12]
 prot_segid = "L"
 fix_origin = false
 dna = false
@@ -179,7 +178,7 @@ nhise = 0
 hise_1 = nan
 # add more if needed
 
-[input.mol13]
+[mol13]
 prot_segid = "M"
 fix_origin = false
 dna = false
@@ -193,7 +192,7 @@ nhise = 0
 hise_1 = nan
 # add more if needed
 
-[input.mol14]
+[mol14]
 prot_segid = "N"
 fix_origin = false
 dna = false
@@ -207,7 +206,7 @@ nhise = 0
 hise_1 = nan
 # add more if needed
 
-[input.mol15]
+[mol15]
 prot_segid = "O"
 fix_origin = false
 dna = false
@@ -221,7 +220,7 @@ nhise = 0
 hise_1 = nan
 # add more if needed
 
-[input.mol16]
+[mol16]
 prot_segid = "P"
 fix_origin = false
 dna = false
@@ -235,7 +234,7 @@ nhise = 0
 hise_1 = nan
 # add more if needed
 
-[input.mol17]
+[mol17]
 prot_segid = "Q"
 fix_origin = false
 dna = false
@@ -249,7 +248,7 @@ nhise = 0
 hise_1 = nan
 # add more if needed
 
-[input.mol18]
+[mol18]
 prot_segid = "R"
 fix_origin = false
 dna = false
@@ -263,7 +262,7 @@ nhise = 0
 hise_1 = nan
 # add more if needed
 
-[input.mol19]
+[mol19]
 prot_segid = "S"
 fix_origin = false
 dna = false
@@ -277,7 +276,7 @@ nhise = 0
 hise_1 = nan
 # add more if needed
 
-[input.mol20]
+[mol20]
 prot_segid = "T"
 fix_origin = false
 dna = false


### PR DESCRIPTION
@amjjbonvin one of the things we discussed in today's IVRESSE meeting was the possibility to remove the `input` layer from the `topoaa` module such that we have only `mol1`, `mol2`, etc, directly in the top layer of the config file. As you can see from the changes in this PR, removing the `input` layer adds no burden to the Python API (see changes in the `topoaa/__init__.py` file. I have these changes already prepared for the #274 if you accept them.

@sverhoeven