### PR TITLE
Correct `libhpc.HPCScheduler` defaults

### DIFF
--- a/src/haddock/libs/libhpc.py
+++ b/src/haddock/libs/libhpc.py
@@ -25,8 +25,8 @@ JOB_STATUS_DIC = {
 # modules/defaults.cfg file
 _tmpcfg = read_config(modules_defaults_path)
 HPCScheduler_CONCAT_DEFAULT = _tmpcfg["concat"]  # original value 1
-HPCWorker_QUEUE_LIMIT_DEFAULT = _tmpcfg["queue"]  # original value 100
-HPCWorker_QUEUE_DEFAULT = _tmpcfg["queue_limit"]  # original value None
+HPCWorker_QUEUE_LIMIT_DEFAULT = _tmpcfg["queue_limit"]  # original value 100
+HPCWorker_QUEUE_DEFAULT = _tmpcfg["queue"]  # original value ""
 del _tmpcfg
 
 


### PR DESCRIPTION
The default values for the `libhpc.HPCScheduler` was swapped. This was not affecting the runs because `modules.get_engine` was passing the correct values. This PR corrects the defaults assignments.