### PR TITLE
Correct `explevels`

### DIFF
--- a/src/haddock/__init__.py
+++ b/src/haddock/__init__.py
@@ -18,7 +18,7 @@ modules_defaults_path = Path(haddock3_source_path, "modules", "defaults.yaml")
 
 FCC_path = Path(haddock3_source_path.parent, 'fcc')
 
-config_expert_levels = ("basic", "intermediate", "guru")
+config_expert_levels = ("easy", "expert", "guru")
 
 
 class EmptyPath:

--- a/src/haddock/modules/analysis/caprieval/defaults.yaml
+++ b/src/haddock/modules/analysis/caprieval/defaults.yaml
@@ -5,7 +5,7 @@ reference_fname:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 irmsd:
   default: true
   type: boolean
@@ -13,7 +13,7 @@ irmsd:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fnat:
   default: true
   type: boolean
@@ -21,7 +21,7 @@ fnat:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 lrmsd:
   default: true
   type: boolean
@@ -29,7 +29,7 @@ lrmsd:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ilrmsd:
   default: true
   type: boolean
@@ -37,7 +37,7 @@ ilrmsd:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 dockq:
   default: true
   type: boolean
@@ -45,7 +45,7 @@ dockq:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 irmsd_cutoff:
   default: 10.0
   type: float
@@ -56,7 +56,7 @@ irmsd_cutoff:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fnat_cutoff:
   default: 5.0
   type: float
@@ -67,7 +67,7 @@ fnat_cutoff:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 lrmsd_cutoff:
   default: 10.0
   type: float
@@ -78,7 +78,7 @@ lrmsd_cutoff:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 receptor_chain:
   default: A
   type: string
@@ -88,7 +88,7 @@ receptor_chain:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ligand_chain:
   default: B
   type: string
@@ -98,7 +98,7 @@ ligand_chain:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 rankby:
   default: score
   type: string
@@ -108,7 +108,7 @@ rankby:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 rank_ascending:
   default: true
   type: boolean
@@ -116,7 +116,7 @@ rank_ascending:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 sortby:
   default: score
   type: string
@@ -126,7 +126,7 @@ sortby:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 sort_ascending:
   default: true
   type: boolean
@@ -134,7 +134,7 @@ sort_ascending:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 alignment_method:
   default: sequence
   type: string
@@ -144,7 +144,7 @@ alignment_method:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 lovoalign_exec:
   default: ''
   type: string
@@ -154,4 +154,4 @@ lovoalign_exec:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy

--- a/src/haddock/modules/analysis/clustfcc/defaults.yaml
+++ b/src/haddock/modules/analysis/clustfcc/defaults.yaml
@@ -5,7 +5,7 @@ executable:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 contact_distance_cutoff:
   default: 5.0
   type: float
@@ -16,7 +16,7 @@ contact_distance_cutoff:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fraction_cutoff:
   default: 0.6
   type: float
@@ -27,7 +27,7 @@ fraction_cutoff:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 threshold:
   default: 4
   type: integer
@@ -37,7 +37,7 @@ threshold:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 strictness:
   default: 0.75
   type: float
@@ -48,4 +48,4 @@ strictness:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy

--- a/src/haddock/modules/analysis/seletop/defaults.yaml
+++ b/src/haddock/modules/analysis/seletop/defaults.yaml
@@ -7,4 +7,4 @@ select:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy

--- a/src/haddock/modules/analysis/seletopclusts/defaults.yaml
+++ b/src/haddock/modules/analysis/seletopclusts/defaults.yaml
@@ -7,7 +7,7 @@ top_cluster:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 top_models:
   default: .nan
   type: float
@@ -18,4 +18,4 @@ top_models:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy

--- a/src/haddock/modules/defaults.yaml
+++ b/src/haddock/modules/defaults.yaml
@@ -7,7 +7,7 @@ cns_exec:
     during the installation.
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ncores:
   default: 8
   type: integer
@@ -18,7 +18,7 @@ ncores:
   short: Number of CPUs is truncated to max CPUs available minus 1
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 mode:
   default: local
   type: string
@@ -31,7 +31,7 @@ mode:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 concat:
   default: 1
   type: integer
@@ -42,7 +42,7 @@ concat:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 queue:
   default: ''
   type: string
@@ -52,7 +52,7 @@ queue:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 queue_limit:
   default: 100
   type: integer
@@ -63,7 +63,7 @@ queue_limit:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 self_contained:
   default: false
   type: boolean
@@ -71,4 +71,4 @@ self_contained:
   short: Copies the CNS scripts and executable to the run folder
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy

--- a/src/haddock/modules/refinement/emref/defaults.yaml
+++ b/src/haddock/modules/refinement/emref/defaults.yaml
@@ -7,7 +7,7 @@ tolerance:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 log_level:
   default: verbose
   type: string
@@ -17,7 +17,7 @@ log_level:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ambig_fname:
   default: ''
   type: file
@@ -25,7 +25,7 @@ ambig_fname:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 unambig_fname:
   default: ''
   type: file
@@ -33,7 +33,7 @@ unambig_fname:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 dihe_fname:
   default: ''
   type: file
@@ -41,7 +41,7 @@ dihe_fname:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 hbond_fname:
   default: ''
   type: file
@@ -49,7 +49,7 @@ hbond_fname:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ligand_param_fname:
   default: ''
   type: file
@@ -57,7 +57,7 @@ ligand_param_fname:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ligand_top_fname:
   default: ''
   type: file
@@ -65,7 +65,7 @@ ligand_top_fname:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 sampling:
   default: 5
   type: integer
@@ -75,7 +75,7 @@ sampling:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 sampling_factor:
   default: 1
   type: integer
@@ -85,7 +85,7 @@ sampling_factor:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nemsteps:
   default: 200
   type: integer
@@ -95,7 +95,7 @@ nemsteps:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 iniseed:
   default: 917
   type: integer
@@ -105,7 +105,7 @@ iniseed:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 keepwater:
   default: false
   type: boolean
@@ -113,7 +113,7 @@ keepwater:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_1:
   default: A
   type: string
@@ -123,7 +123,7 @@ prot_segid_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_2:
   default: B
   type: string
@@ -133,7 +133,7 @@ prot_segid_2:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_3:
   default: C
   type: string
@@ -143,7 +143,7 @@ prot_segid_3:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_4:
   default: D
   type: string
@@ -153,7 +153,7 @@ prot_segid_4:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_5:
   default: E
   type: string
@@ -163,7 +163,7 @@ prot_segid_5:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_6:
   default: F
   type: string
@@ -173,7 +173,7 @@ prot_segid_6:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_7:
   default: G
   type: string
@@ -183,7 +183,7 @@ prot_segid_7:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_8:
   default: H
   type: string
@@ -193,7 +193,7 @@ prot_segid_8:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_9:
   default: I
   type: string
@@ -203,7 +203,7 @@ prot_segid_9:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_10:
   default: J
   type: string
@@ -213,7 +213,7 @@ prot_segid_10:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_11:
   default: K
   type: string
@@ -223,7 +223,7 @@ prot_segid_11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_12:
   default: L
   type: string
@@ -233,7 +233,7 @@ prot_segid_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_13:
   default: M
   type: string
@@ -243,7 +243,7 @@ prot_segid_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_14:
   default: N
   type: string
@@ -253,7 +253,7 @@ prot_segid_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_15:
   default: O
   type: string
@@ -263,7 +263,7 @@ prot_segid_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_16:
   default: P
   type: string
@@ -273,7 +273,7 @@ prot_segid_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_17:
   default: Q
   type: string
@@ -283,7 +283,7 @@ prot_segid_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_18:
   default: R
   type: string
@@ -293,7 +293,7 @@ prot_segid_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_19:
   default: S
   type: string
@@ -303,7 +303,7 @@ prot_segid_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_20:
   default: T
   type: string
@@ -313,7 +313,7 @@ prot_segid_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_1:
   default: false
   type: boolean
@@ -321,7 +321,7 @@ shape_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_2:
   default: false
   type: boolean
@@ -329,7 +329,7 @@ shape_2:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_3:
   default: false
   type: boolean
@@ -337,7 +337,7 @@ shape_3:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_4:
   default: false
   type: boolean
@@ -345,7 +345,7 @@ shape_4:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_5:
   default: false
   type: boolean
@@ -353,7 +353,7 @@ shape_5:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_6:
   default: false
   type: boolean
@@ -361,7 +361,7 @@ shape_6:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_7:
   default: false
   type: boolean
@@ -369,7 +369,7 @@ shape_7:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_8:
   default: false
   type: boolean
@@ -377,7 +377,7 @@ shape_8:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_9:
   default: false
   type: boolean
@@ -385,7 +385,7 @@ shape_9:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_10:
   default: false
   type: boolean
@@ -393,7 +393,7 @@ shape_10:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_11:
   default: false
   type: boolean
@@ -401,7 +401,7 @@ shape_11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_12:
   default: false
   type: boolean
@@ -409,7 +409,7 @@ shape_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_13:
   default: false
   type: boolean
@@ -417,7 +417,7 @@ shape_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_14:
   default: false
   type: boolean
@@ -425,7 +425,7 @@ shape_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_15:
   default: false
   type: boolean
@@ -433,7 +433,7 @@ shape_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_16:
   default: false
   type: boolean
@@ -441,7 +441,7 @@ shape_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_17:
   default: false
   type: boolean
@@ -449,7 +449,7 @@ shape_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_18:
   default: false
   type: boolean
@@ -457,7 +457,7 @@ shape_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_19:
   default: false
   type: boolean
@@ -465,7 +465,7 @@ shape_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_20:
   default: false
   type: boolean
@@ -473,7 +473,7 @@ shape_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 amb_scale:
   default: 50
   type: integer
@@ -483,7 +483,7 @@ amb_scale:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 unamb_scale:
   default: 50
   type: integer
@@ -493,7 +493,7 @@ unamb_scale:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 hbond_scale:
   default: 50
   type: integer
@@ -503,7 +503,7 @@ hbond_scale:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 hbonds_on:
   default: false
   type: boolean
@@ -511,7 +511,7 @@ hbonds_on:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 noecv:
   default: false
   type: boolean
@@ -519,7 +519,7 @@ noecv:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ncvpart:
   default: 2
   type: integer
@@ -529,7 +529,7 @@ ncvpart:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 cmrest:
   default: false
   type: boolean
@@ -537,7 +537,7 @@ cmrest:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 cmtight:
   default: false
   type: boolean
@@ -545,7 +545,7 @@ cmtight:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ranair:
   default: false
   type: boolean
@@ -553,7 +553,7 @@ ranair:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 kcont:
   default: 1.0
   type: float
@@ -564,7 +564,7 @@ kcont:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ksurf:
   default: 1.0
   type: float
@@ -575,7 +575,7 @@ ksurf:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 surfrest:
   default: false
   type: boolean
@@ -583,7 +583,7 @@ surfrest:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 dihedrals_on:
   default: false
   type: boolean
@@ -591,7 +591,7 @@ dihedrals_on:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 dihedrals_scale:
   default: 200
   type: integer
@@ -601,7 +601,7 @@ dihedrals_scale:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ssdihed:
   default: none
   type: string
@@ -611,7 +611,7 @@ ssdihed:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 error_dih:
   default: 10
   type: integer
@@ -621,7 +621,7 @@ error_dih:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 dnarest_on:
   default: false
   type: boolean
@@ -629,7 +629,7 @@ dnarest_on:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 sym_on:
   default: false
   type: boolean
@@ -637,7 +637,7 @@ sym_on:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ksym:
   default: 10.0
   type: float
@@ -648,7 +648,7 @@ ksym:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 numc2sym:
   default: 0
   type: integer
@@ -658,7 +658,7 @@ numc2sym:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c2sym_sta1_1:
   default: .nan
   type: float
@@ -669,7 +669,7 @@ c2sym_sta1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c2sym_end1_1:
   default: .nan
   type: float
@@ -680,7 +680,7 @@ c2sym_end1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c2sym_seg1_1:
   default: ''
   type: string
@@ -690,7 +690,7 @@ c2sym_seg1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c2sym_sta2_1:
   default: .nan
   type: float
@@ -701,7 +701,7 @@ c2sym_sta2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c2sym_end2_1:
   default: .nan
   type: float
@@ -712,7 +712,7 @@ c2sym_end2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c2sym_seg2_1:
   default: ''
   type: string
@@ -722,7 +722,7 @@ c2sym_seg2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 numc3sym:
   default: 0
   type: integer
@@ -732,7 +732,7 @@ numc3sym:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c3sym_sta1_1:
   default: .nan
   type: float
@@ -743,7 +743,7 @@ c3sym_sta1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c3sym_end1_1:
   default: .nan
   type: float
@@ -754,7 +754,7 @@ c3sym_end1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c3sym_seg1_1:
   default: ''
   type: string
@@ -764,7 +764,7 @@ c3sym_seg1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c3sym_sta2_1:
   default: .nan
   type: float
@@ -775,7 +775,7 @@ c3sym_sta2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c3sym_end2_1:
   default: .nan
   type: float
@@ -786,7 +786,7 @@ c3sym_end2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c3sym_seg2_1:
   default: ''
   type: string
@@ -796,7 +796,7 @@ c3sym_seg2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c3sym_sta3_1:
   default: .nan
   type: float
@@ -807,7 +807,7 @@ c3sym_sta3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c3sym_end3_1:
   default: .nan
   type: float
@@ -818,7 +818,7 @@ c3sym_end3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c3sym_seg3_1:
   default: ''
   type: string
@@ -828,7 +828,7 @@ c3sym_seg3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 numc4sym:
   default: 0
   type: integer
@@ -838,7 +838,7 @@ numc4sym:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c4sym_sta1_1:
   default: .nan
   type: float
@@ -849,7 +849,7 @@ c4sym_sta1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c4sym_end1_1:
   default: .nan
   type: float
@@ -860,7 +860,7 @@ c4sym_end1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c4sym_seg1_1:
   default: ''
   type: string
@@ -870,7 +870,7 @@ c4sym_seg1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c4sym_sta2_1:
   default: .nan
   type: float
@@ -881,7 +881,7 @@ c4sym_sta2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c4sym_end2_1:
   default: .nan
   type: float
@@ -892,7 +892,7 @@ c4sym_end2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c4sym_seg2_1:
   default: ''
   type: string
@@ -902,7 +902,7 @@ c4sym_seg2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c4sym_sta3_1:
   default: .nan
   type: float
@@ -913,7 +913,7 @@ c4sym_sta3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c4sym_end3_1:
   default: .nan
   type: float
@@ -924,7 +924,7 @@ c4sym_end3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c4sym_seg3_1:
   default: ''
   type: string
@@ -934,7 +934,7 @@ c4sym_seg3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c4sym_sta4_1:
   default: .nan
   type: float
@@ -945,7 +945,7 @@ c4sym_sta4_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c4sym_end4_1:
   default: .nan
   type: float
@@ -956,7 +956,7 @@ c4sym_end4_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c4sym_seg4_1:
   default: ''
   type: string
@@ -966,7 +966,7 @@ c4sym_seg4_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 numc5sym:
   default: 0
   type: integer
@@ -976,7 +976,7 @@ numc5sym:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c5sym_sta1_1:
   default: .nan
   type: float
@@ -987,7 +987,7 @@ c5sym_sta1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c5sym_end1_1:
   default: .nan
   type: float
@@ -998,7 +998,7 @@ c5sym_end1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c5sym_seg1_1:
   default: ''
   type: string
@@ -1008,7 +1008,7 @@ c5sym_seg1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c5sym_sta2_1:
   default: .nan
   type: float
@@ -1019,7 +1019,7 @@ c5sym_sta2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c5sym_end2_1:
   default: .nan
   type: float
@@ -1030,7 +1030,7 @@ c5sym_end2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c5sym_seg2_1:
   default: ''
   type: string
@@ -1040,7 +1040,7 @@ c5sym_seg2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c5sym_sta3_1:
   default: .nan
   type: float
@@ -1051,7 +1051,7 @@ c5sym_sta3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c5sym_end3_1:
   default: .nan
   type: float
@@ -1062,7 +1062,7 @@ c5sym_end3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c5sym_seg3_1:
   default: ''
   type: string
@@ -1072,7 +1072,7 @@ c5sym_seg3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c5sym_sta4_1:
   default: .nan
   type: float
@@ -1083,7 +1083,7 @@ c5sym_sta4_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c5sym_end4_1:
   default: .nan
   type: float
@@ -1094,7 +1094,7 @@ c5sym_end4_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c5sym_seg4_1:
   default: ''
   type: string
@@ -1104,7 +1104,7 @@ c5sym_seg4_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c5sym_sta5_1:
   default: .nan
   type: float
@@ -1115,7 +1115,7 @@ c5sym_sta5_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c5sym_end5_1:
   default: .nan
   type: float
@@ -1126,7 +1126,7 @@ c5sym_end5_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c5sym_seg5_1:
   default: ''
   type: string
@@ -1136,7 +1136,7 @@ c5sym_seg5_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 numc6sym:
   default: 0
   type: integer
@@ -1146,7 +1146,7 @@ numc6sym:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_sta1_1:
   default: .nan
   type: float
@@ -1157,7 +1157,7 @@ c6sym_sta1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_end1_1:
   default: .nan
   type: float
@@ -1168,7 +1168,7 @@ c6sym_end1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_seg1_1:
   default: ''
   type: string
@@ -1178,7 +1178,7 @@ c6sym_seg1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_sta2_1:
   default: .nan
   type: float
@@ -1189,7 +1189,7 @@ c6sym_sta2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_end2_1:
   default: .nan
   type: float
@@ -1200,7 +1200,7 @@ c6sym_end2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_seg2_1:
   default: ''
   type: string
@@ -1210,7 +1210,7 @@ c6sym_seg2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_sta3_1:
   default: .nan
   type: float
@@ -1221,7 +1221,7 @@ c6sym_sta3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_end3_1:
   default: .nan
   type: float
@@ -1232,7 +1232,7 @@ c6sym_end3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_seg3_1:
   default: ''
   type: string
@@ -1242,7 +1242,7 @@ c6sym_seg3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_sta4_1:
   default: .nan
   type: float
@@ -1253,7 +1253,7 @@ c6sym_sta4_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_end4_1:
   default: .nan
   type: float
@@ -1264,7 +1264,7 @@ c6sym_end4_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_seg4_1:
   default: ''
   type: string
@@ -1274,7 +1274,7 @@ c6sym_seg4_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_sta5_1:
   default: .nan
   type: float
@@ -1285,7 +1285,7 @@ c6sym_sta5_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_end5_1:
   default: .nan
   type: float
@@ -1296,7 +1296,7 @@ c6sym_end5_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_seg5_1:
   default: ''
   type: string
@@ -1306,7 +1306,7 @@ c6sym_seg5_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_sta6_1:
   default: .nan
   type: float
@@ -1317,7 +1317,7 @@ c6sym_sta6_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_end6_1:
   default: .nan
   type: float
@@ -1328,7 +1328,7 @@ c6sym_end6_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_seg6_1:
   default: ''
   type: string
@@ -1338,7 +1338,7 @@ c6sym_seg6_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nums3sym:
   default: 0
   type: integer
@@ -1348,7 +1348,7 @@ nums3sym:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 s3sym_sta1_1:
   default: .nan
   type: float
@@ -1359,7 +1359,7 @@ s3sym_sta1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 s3sym_end1_1:
   default: .nan
   type: float
@@ -1370,7 +1370,7 @@ s3sym_end1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 s3sym_seg1_1:
   default: ''
   type: string
@@ -1380,7 +1380,7 @@ s3sym_seg1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 s3sym_sta2_1:
   default: .nan
   type: float
@@ -1391,7 +1391,7 @@ s3sym_sta2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 s3sym_end2_1:
   default: .nan
   type: float
@@ -1402,7 +1402,7 @@ s3sym_end2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 s3sym_seg2_1:
   default: ''
   type: string
@@ -1412,7 +1412,7 @@ s3sym_seg2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 s3sym_sta3_1:
   default: .nan
   type: float
@@ -1423,7 +1423,7 @@ s3sym_sta3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 s3sym_end3_1:
   default: .nan
   type: float
@@ -1434,7 +1434,7 @@ s3sym_end3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 s3sym_seg3_1:
   default: ''
   type: string
@@ -1444,7 +1444,7 @@ s3sym_seg3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ncs_on:
   default: false
   type: boolean
@@ -1452,7 +1452,7 @@ ncs_on:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 kncs:
   default: 1.0
   type: float
@@ -1463,7 +1463,7 @@ kncs:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 numncs:
   default: 0
   type: integer
@@ -1473,7 +1473,7 @@ numncs:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ncs_sta1_1:
   default: .nan
   type: float
@@ -1484,7 +1484,7 @@ ncs_sta1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ncs_end1_1:
   default: .nan
   type: float
@@ -1495,7 +1495,7 @@ ncs_end1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ncs_seg1_1:
   default: ''
   type: string
@@ -1505,7 +1505,7 @@ ncs_seg1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ncs_sta2_1:
   default: .nan
   type: float
@@ -1516,7 +1516,7 @@ ncs_sta2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ncs_end2_1:
   default: .nan
   type: float
@@ -1527,7 +1527,7 @@ ncs_end2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ncs_seg2_1:
   default: ''
   type: string
@@ -1537,7 +1537,7 @@ ncs_seg2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_1:
   default: false
   type: boolean
@@ -1545,7 +1545,7 @@ fix_origin_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_2:
   default: false
   type: boolean
@@ -1553,7 +1553,7 @@ fix_origin_2:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_3:
   default: false
   type: boolean
@@ -1561,7 +1561,7 @@ fix_origin_3:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_4:
   default: false
   type: boolean
@@ -1569,7 +1569,7 @@ fix_origin_4:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_5:
   default: false
   type: boolean
@@ -1577,7 +1577,7 @@ fix_origin_5:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_6:
   default: false
   type: boolean
@@ -1585,7 +1585,7 @@ fix_origin_6:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_7:
   default: false
   type: boolean
@@ -1593,7 +1593,7 @@ fix_origin_7:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_8:
   default: false
   type: boolean
@@ -1601,7 +1601,7 @@ fix_origin_8:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_9:
   default: false
   type: boolean
@@ -1609,7 +1609,7 @@ fix_origin_9:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_10:
   default: false
   type: boolean
@@ -1617,7 +1617,7 @@ fix_origin_10:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_11:
   default: false
   type: boolean
@@ -1625,7 +1625,7 @@ fix_origin_11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_12:
   default: false
   type: boolean
@@ -1633,7 +1633,7 @@ fix_origin_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_13:
   default: false
   type: boolean
@@ -1641,7 +1641,7 @@ fix_origin_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_14:
   default: false
   type: boolean
@@ -1649,7 +1649,7 @@ fix_origin_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_15:
   default: false
   type: boolean
@@ -1657,7 +1657,7 @@ fix_origin_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_16:
   default: false
   type: boolean
@@ -1665,7 +1665,7 @@ fix_origin_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_17:
   default: false
   type: boolean
@@ -1673,7 +1673,7 @@ fix_origin_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_18:
   default: false
   type: boolean
@@ -1681,7 +1681,7 @@ fix_origin_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_19:
   default: false
   type: boolean
@@ -1689,7 +1689,7 @@ fix_origin_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_20:
   default: false
   type: boolean
@@ -1697,7 +1697,7 @@ fix_origin_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nfle1:
   default: 0
   type: integer
@@ -1707,7 +1707,7 @@ nfle1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 flesta1_1:
   default: .nan
   type: float
@@ -1718,7 +1718,7 @@ flesta1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fleend1_1:
   default: .nan
   type: float
@@ -1729,7 +1729,7 @@ fleend1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nfle2:
   default: 0
   type: integer
@@ -1739,7 +1739,7 @@ nfle2:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 flesta2_1:
   default: .nan
   type: float
@@ -1750,7 +1750,7 @@ flesta2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fleend2_1:
   default: .nan
   type: float
@@ -1761,7 +1761,7 @@ fleend2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nfle3:
   default: 0
   type: integer
@@ -1771,7 +1771,7 @@ nfle3:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 flesta3_1:
   default: .nan
   type: float
@@ -1782,7 +1782,7 @@ flesta3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fleend3_1:
   default: .nan
   type: float
@@ -1793,7 +1793,7 @@ fleend3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nfle4:
   default: 0
   type: integer
@@ -1803,7 +1803,7 @@ nfle4:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 flesta4_1:
   default: .nan
   type: float
@@ -1814,7 +1814,7 @@ flesta4_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fleend4_1:
   default: .nan
   type: float
@@ -1825,7 +1825,7 @@ fleend4_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nfle5:
   default: 0
   type: integer
@@ -1835,7 +1835,7 @@ nfle5:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 flesta5_1:
   default: .nan
   type: float
@@ -1846,7 +1846,7 @@ flesta5_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fleend5_1:
   default: .nan
   type: float
@@ -1857,7 +1857,7 @@ fleend5_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nfle6:
   default: 0
   type: integer
@@ -1867,7 +1867,7 @@ nfle6:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 flesta6_1:
   default: .nan
   type: float
@@ -1878,7 +1878,7 @@ flesta6_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fleend6_1:
   default: .nan
   type: float
@@ -1889,7 +1889,7 @@ fleend6_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nfle7:
   default: 0
   type: integer
@@ -1899,7 +1899,7 @@ nfle7:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 flesta7_1:
   default: .nan
   type: float
@@ -1910,7 +1910,7 @@ flesta7_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fleend7_1:
   default: .nan
   type: float
@@ -1921,7 +1921,7 @@ fleend7_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nfle8:
   default: 0
   type: integer
@@ -1931,7 +1931,7 @@ nfle8:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 flesta8_1:
   default: .nan
   type: float
@@ -1942,7 +1942,7 @@ flesta8_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fleend8_1:
   default: .nan
   type: float
@@ -1953,7 +1953,7 @@ fleend8_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nfle9:
   default: 0
   type: integer
@@ -1963,7 +1963,7 @@ nfle9:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 flesta9_1:
   default: .nan
   type: float
@@ -1974,7 +1974,7 @@ flesta9_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fleend9_1:
   default: .nan
   type: float
@@ -1985,7 +1985,7 @@ fleend9_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nfle10:
   default: 0
   type: integer
@@ -1995,7 +1995,7 @@ nfle10:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 flesta10_1:
   default: .nan
   type: float
@@ -2006,7 +2006,7 @@ flesta10_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fleend10_1:
   default: .nan
   type: float
@@ -2017,7 +2017,7 @@ fleend10_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nfle11:
   default: 0
   type: integer
@@ -2027,7 +2027,7 @@ nfle11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 flesta11_1:
   default: .nan
   type: float
@@ -2038,7 +2038,7 @@ flesta11_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fleend11_1:
   default: .nan
   type: float
@@ -2049,7 +2049,7 @@ fleend11_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nfle12:
   default: 0
   type: integer
@@ -2059,7 +2059,7 @@ nfle12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 flesta12_1:
   default: .nan
   type: float
@@ -2070,7 +2070,7 @@ flesta12_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fleend12_1:
   default: .nan
   type: float
@@ -2081,7 +2081,7 @@ fleend12_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nfle13:
   default: 0
   type: integer
@@ -2091,7 +2091,7 @@ nfle13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 flesta13_1:
   default: .nan
   type: float
@@ -2102,7 +2102,7 @@ flesta13_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fleend13_1:
   default: .nan
   type: float
@@ -2113,7 +2113,7 @@ fleend13_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nfle14:
   default: 0
   type: integer
@@ -2123,7 +2123,7 @@ nfle14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 flesta14_1:
   default: .nan
   type: float
@@ -2134,7 +2134,7 @@ flesta14_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fleend14_1:
   default: .nan
   type: float
@@ -2145,7 +2145,7 @@ fleend14_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nfle15:
   default: 0
   type: integer
@@ -2155,7 +2155,7 @@ nfle15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 flesta15_1:
   default: .nan
   type: float
@@ -2166,7 +2166,7 @@ flesta15_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fleend15_1:
   default: .nan
   type: float
@@ -2177,7 +2177,7 @@ fleend15_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nfle16:
   default: 0
   type: integer
@@ -2187,7 +2187,7 @@ nfle16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 flesta16_1:
   default: .nan
   type: float
@@ -2198,7 +2198,7 @@ flesta16_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fleend16_1:
   default: .nan
   type: float
@@ -2209,7 +2209,7 @@ fleend16_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nfle17:
   default: 0
   type: integer
@@ -2219,7 +2219,7 @@ nfle17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 flesta17_1:
   default: .nan
   type: float
@@ -2230,7 +2230,7 @@ flesta17_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fleend17_1:
   default: .nan
   type: float
@@ -2241,7 +2241,7 @@ fleend17_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nfle18:
   default: 0
   type: integer
@@ -2251,7 +2251,7 @@ nfle18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 flesta18_1:
   default: .nan
   type: float
@@ -2262,7 +2262,7 @@ flesta18_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fleend18_1:
   default: .nan
   type: float
@@ -2273,7 +2273,7 @@ fleend18_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nfle19:
   default: 0
   type: integer
@@ -2283,7 +2283,7 @@ nfle19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 flesta19_1:
   default: .nan
   type: float
@@ -2294,7 +2294,7 @@ flesta19_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fleend19_1:
   default: .nan
   type: float
@@ -2305,7 +2305,7 @@ fleend19_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nfle20:
   default: 0
   type: integer
@@ -2315,7 +2315,7 @@ nfle20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 flesta20_1:
   default: .nan
   type: float
@@ -2326,7 +2326,7 @@ flesta20_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fleend20_1:
   default: .nan
   type: float
@@ -2337,7 +2337,7 @@ fleend20_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nseg1:
   default: -1
   type: integer
@@ -2347,7 +2347,7 @@ nseg1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segsta1_1:
   default: .nan
   type: float
@@ -2358,7 +2358,7 @@ segsta1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segend1_1:
   default: .nan
   type: float
@@ -2369,7 +2369,7 @@ segend1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nseg2:
   default: -1
   type: integer
@@ -2379,7 +2379,7 @@ nseg2:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segsta2_1:
   default: .nan
   type: float
@@ -2390,7 +2390,7 @@ segsta2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segend2_1:
   default: .nan
   type: float
@@ -2401,7 +2401,7 @@ segend2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nseg3:
   default: -1
   type: integer
@@ -2411,7 +2411,7 @@ nseg3:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segsta3_1:
   default: .nan
   type: float
@@ -2422,7 +2422,7 @@ segsta3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segend3_1:
   default: .nan
   type: float
@@ -2433,7 +2433,7 @@ segend3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nseg4:
   default: -1
   type: integer
@@ -2443,7 +2443,7 @@ nseg4:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segsta4_1:
   default: .nan
   type: float
@@ -2454,7 +2454,7 @@ segsta4_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segend4_1:
   default: .nan
   type: float
@@ -2465,7 +2465,7 @@ segend4_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nseg5:
   default: -1
   type: integer
@@ -2475,7 +2475,7 @@ nseg5:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segsta5_1:
   default: .nan
   type: float
@@ -2486,7 +2486,7 @@ segsta5_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segend5_1:
   default: .nan
   type: float
@@ -2497,7 +2497,7 @@ segend5_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nseg6:
   default: -1
   type: integer
@@ -2507,7 +2507,7 @@ nseg6:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segsta6_1:
   default: .nan
   type: float
@@ -2518,7 +2518,7 @@ segsta6_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segend6_1:
   default: .nan
   type: float
@@ -2529,7 +2529,7 @@ segend6_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nseg7:
   default: -1
   type: integer
@@ -2539,7 +2539,7 @@ nseg7:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segsta7_1:
   default: .nan
   type: float
@@ -2550,7 +2550,7 @@ segsta7_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segend7_1:
   default: .nan
   type: float
@@ -2561,7 +2561,7 @@ segend7_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nseg8:
   default: -1
   type: integer
@@ -2571,7 +2571,7 @@ nseg8:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segsta8_1:
   default: .nan
   type: float
@@ -2582,7 +2582,7 @@ segsta8_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segend8_1:
   default: .nan
   type: float
@@ -2593,7 +2593,7 @@ segend8_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nseg9:
   default: -1
   type: integer
@@ -2603,7 +2603,7 @@ nseg9:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segsta9_1:
   default: .nan
   type: float
@@ -2614,7 +2614,7 @@ segsta9_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segend9_1:
   default: .nan
   type: float
@@ -2625,7 +2625,7 @@ segend9_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nseg10:
   default: -1
   type: integer
@@ -2635,7 +2635,7 @@ nseg10:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segsta10_1:
   default: .nan
   type: float
@@ -2646,7 +2646,7 @@ segsta10_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segend10_1:
   default: .nan
   type: float
@@ -2657,7 +2657,7 @@ segend10_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nseg11:
   default: -1
   type: integer
@@ -2667,7 +2667,7 @@ nseg11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segsta11_1:
   default: .nan
   type: float
@@ -2678,7 +2678,7 @@ segsta11_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segend11_1:
   default: .nan
   type: float
@@ -2689,7 +2689,7 @@ segend11_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nseg12:
   default: -1
   type: integer
@@ -2699,7 +2699,7 @@ nseg12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segsta12_1:
   default: .nan
   type: float
@@ -2710,7 +2710,7 @@ segsta12_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segend12_1:
   default: .nan
   type: float
@@ -2721,7 +2721,7 @@ segend12_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nseg13:
   default: -1
   type: integer
@@ -2731,7 +2731,7 @@ nseg13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segsta13_1:
   default: .nan
   type: float
@@ -2742,7 +2742,7 @@ segsta13_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segend13_1:
   default: .nan
   type: float
@@ -2753,7 +2753,7 @@ segend13_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nseg14:
   default: -1
   type: integer
@@ -2763,7 +2763,7 @@ nseg14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segsta14_1:
   default: .nan
   type: float
@@ -2774,7 +2774,7 @@ segsta14_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segend14_1:
   default: .nan
   type: float
@@ -2785,7 +2785,7 @@ segend14_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nseg15:
   default: -1
   type: integer
@@ -2795,7 +2795,7 @@ nseg15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segsta15_1:
   default: .nan
   type: float
@@ -2806,7 +2806,7 @@ segsta15_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segend15_1:
   default: .nan
   type: float
@@ -2817,7 +2817,7 @@ segend15_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nseg16:
   default: -1
   type: integer
@@ -2827,7 +2827,7 @@ nseg16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segsta16_1:
   default: .nan
   type: float
@@ -2838,7 +2838,7 @@ segsta16_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segend16_1:
   default: .nan
   type: float
@@ -2849,7 +2849,7 @@ segend16_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nseg17:
   default: -1
   type: integer
@@ -2859,7 +2859,7 @@ nseg17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segsta17_1:
   default: .nan
   type: float
@@ -2870,7 +2870,7 @@ segsta17_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segend17_1:
   default: .nan
   type: float
@@ -2881,7 +2881,7 @@ segend17_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nseg18:
   default: -1
   type: integer
@@ -2891,7 +2891,7 @@ nseg18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segsta18_1:
   default: .nan
   type: float
@@ -2902,7 +2902,7 @@ segsta18_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segend18_1:
   default: .nan
   type: float
@@ -2913,7 +2913,7 @@ segend18_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nseg19:
   default: -1
   type: integer
@@ -2923,7 +2923,7 @@ nseg19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segsta19_1:
   default: .nan
   type: float
@@ -2934,7 +2934,7 @@ segsta19_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segend19_1:
   default: .nan
   type: float
@@ -2945,7 +2945,7 @@ segend19_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nseg20:
   default: -1
   type: integer
@@ -2955,7 +2955,7 @@ nseg20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segsta20_1:
   default: .nan
   type: float
@@ -2966,7 +2966,7 @@ segsta20_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segend20_1:
   default: .nan
   type: float
@@ -2977,7 +2977,7 @@ segend20_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_air:
   default: 0.1
   type: float
@@ -2988,7 +2988,7 @@ w_air:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_bsa:
   default: 0.0
   type: float
@@ -2999,7 +2999,7 @@ w_bsa:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_cdih:
   default: 0.0
   type: float
@@ -3010,7 +3010,7 @@ w_cdih:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_dani:
   default: 0.1
   type: float
@@ -3021,7 +3021,7 @@ w_dani:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_deint:
   default: 0.0
   type: float
@@ -3032,7 +3032,7 @@ w_deint:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_desolv:
   default: 1.0
   type: float
@@ -3043,7 +3043,7 @@ w_desolv:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_dist:
   default: 0.1
   type: float
@@ -3054,7 +3054,7 @@ w_dist:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_elec:
   default: 0.2
   type: float
@@ -3065,7 +3065,7 @@ w_elec:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_lcc:
   default: -10000.0
   type: float
@@ -3076,7 +3076,7 @@ w_lcc:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_rg:
   default: 1.0
   type: float
@@ -3087,7 +3087,7 @@ w_rg:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_sani:
   default: 0.1
   type: float
@@ -3098,7 +3098,7 @@ w_sani:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_sym:
   default: 0.1
   type: float
@@ -3109,7 +3109,7 @@ w_sym:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_vdw:
   default: 1.0
   type: float
@@ -3120,7 +3120,7 @@ w_vdw:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_vean:
   default: 0.1
   type: float
@@ -3131,7 +3131,7 @@ w_vean:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_xpcs:
   default: 0.1
   type: float
@@ -3142,7 +3142,7 @@ w_xpcs:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_xrdc:
   default: 0.1
   type: float
@@ -3153,7 +3153,7 @@ w_xrdc:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_zres:
   default: 0.1
   type: float
@@ -3164,7 +3164,7 @@ w_zres:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 elecflag:
   default: true
   type: boolean
@@ -3172,7 +3172,7 @@ elecflag:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 dielec:
   default: cdie
   type: string
@@ -3182,7 +3182,7 @@ dielec:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 epsilon:
   default: 1.0
   type: float
@@ -3193,7 +3193,7 @@ epsilon:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 dihedflag:
   default: true
   type: boolean
@@ -3201,7 +3201,7 @@ dihedflag:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 par_nonbonded:
   default: OPLSX
   type: string
@@ -3211,7 +3211,7 @@ par_nonbonded:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_1:
   default: 1.0
   type: float
@@ -3222,7 +3222,7 @@ int_1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_2:
   default: 1.0
   type: float
@@ -3233,7 +3233,7 @@ int_1_2:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_3:
   default: 1.0
   type: float
@@ -3244,7 +3244,7 @@ int_1_3:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_4:
   default: 1.0
   type: float
@@ -3255,7 +3255,7 @@ int_1_4:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_5:
   default: 1.0
   type: float
@@ -3266,7 +3266,7 @@ int_1_5:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_6:
   default: 1.0
   type: float
@@ -3277,7 +3277,7 @@ int_1_6:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_7:
   default: 1.0
   type: float
@@ -3288,7 +3288,7 @@ int_1_7:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_8:
   default: 1.0
   type: float
@@ -3299,7 +3299,7 @@ int_1_8:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_9:
   default: 1.0
   type: float
@@ -3310,7 +3310,7 @@ int_1_9:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_10:
   default: 1.0
   type: float
@@ -3321,7 +3321,7 @@ int_1_10:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_11:
   default: 1.0
   type: float
@@ -3332,7 +3332,7 @@ int_1_11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_12:
   default: 1.0
   type: float
@@ -3343,7 +3343,7 @@ int_1_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_13:
   default: 1.0
   type: float
@@ -3354,7 +3354,7 @@ int_1_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_14:
   default: 1.0
   type: float
@@ -3365,7 +3365,7 @@ int_1_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_15:
   default: 1.0
   type: float
@@ -3376,7 +3376,7 @@ int_1_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_16:
   default: 1.0
   type: float
@@ -3387,7 +3387,7 @@ int_1_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_17:
   default: 1.0
   type: float
@@ -3398,7 +3398,7 @@ int_1_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_18:
   default: 1.0
   type: float
@@ -3409,7 +3409,7 @@ int_1_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_19:
   default: 1.0
   type: float
@@ -3420,7 +3420,7 @@ int_1_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_20:
   default: 1.0
   type: float
@@ -3431,7 +3431,7 @@ int_1_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_2:
   default: 1.0
   type: float
@@ -3442,7 +3442,7 @@ int_2_2:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_3:
   default: 1.0
   type: float
@@ -3453,7 +3453,7 @@ int_2_3:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_4:
   default: 1.0
   type: float
@@ -3464,7 +3464,7 @@ int_2_4:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_5:
   default: 1.0
   type: float
@@ -3475,7 +3475,7 @@ int_2_5:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_6:
   default: 1.0
   type: float
@@ -3486,7 +3486,7 @@ int_2_6:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_7:
   default: 1.0
   type: float
@@ -3497,7 +3497,7 @@ int_2_7:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_8:
   default: 1.0
   type: float
@@ -3508,7 +3508,7 @@ int_2_8:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_9:
   default: 1.0
   type: float
@@ -3519,7 +3519,7 @@ int_2_9:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_10:
   default: 1.0
   type: float
@@ -3530,7 +3530,7 @@ int_2_10:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_11:
   default: 1.0
   type: float
@@ -3541,7 +3541,7 @@ int_2_11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_12:
   default: 1.0
   type: float
@@ -3552,7 +3552,7 @@ int_2_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_13:
   default: 1.0
   type: float
@@ -3563,7 +3563,7 @@ int_2_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_14:
   default: 1.0
   type: float
@@ -3574,7 +3574,7 @@ int_2_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_15:
   default: 1.0
   type: float
@@ -3585,7 +3585,7 @@ int_2_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_16:
   default: 1.0
   type: float
@@ -3596,7 +3596,7 @@ int_2_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_17:
   default: 1.0
   type: float
@@ -3607,7 +3607,7 @@ int_2_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_18:
   default: 1.0
   type: float
@@ -3618,7 +3618,7 @@ int_2_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_19:
   default: 1.0
   type: float
@@ -3629,7 +3629,7 @@ int_2_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_20:
   default: 1.0
   type: float
@@ -3640,7 +3640,7 @@ int_2_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_3:
   default: 1.0
   type: float
@@ -3651,7 +3651,7 @@ int_3_3:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_4:
   default: 1.0
   type: float
@@ -3662,7 +3662,7 @@ int_3_4:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_5:
   default: 1.0
   type: float
@@ -3673,7 +3673,7 @@ int_3_5:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_6:
   default: 1.0
   type: float
@@ -3684,7 +3684,7 @@ int_3_6:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_7:
   default: 1.0
   type: float
@@ -3695,7 +3695,7 @@ int_3_7:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_8:
   default: 1.0
   type: float
@@ -3706,7 +3706,7 @@ int_3_8:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_9:
   default: 1.0
   type: float
@@ -3717,7 +3717,7 @@ int_3_9:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_10:
   default: 1.0
   type: float
@@ -3728,7 +3728,7 @@ int_3_10:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_11:
   default: 1.0
   type: float
@@ -3739,7 +3739,7 @@ int_3_11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_12:
   default: 1.0
   type: float
@@ -3750,7 +3750,7 @@ int_3_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_13:
   default: 1.0
   type: float
@@ -3761,7 +3761,7 @@ int_3_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_14:
   default: 1.0
   type: float
@@ -3772,7 +3772,7 @@ int_3_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_15:
   default: 1.0
   type: float
@@ -3783,7 +3783,7 @@ int_3_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_16:
   default: 1.0
   type: float
@@ -3794,7 +3794,7 @@ int_3_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_17:
   default: 1.0
   type: float
@@ -3805,7 +3805,7 @@ int_3_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_18:
   default: 1.0
   type: float
@@ -3816,7 +3816,7 @@ int_3_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_19:
   default: 1.0
   type: float
@@ -3827,7 +3827,7 @@ int_3_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_20:
   default: 1.0
   type: float
@@ -3838,7 +3838,7 @@ int_3_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_4:
   default: 1.0
   type: float
@@ -3849,7 +3849,7 @@ int_4_4:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_5:
   default: 1.0
   type: float
@@ -3860,7 +3860,7 @@ int_4_5:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_6:
   default: 1.0
   type: float
@@ -3871,7 +3871,7 @@ int_4_6:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_7:
   default: 1.0
   type: float
@@ -3882,7 +3882,7 @@ int_4_7:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_8:
   default: 1.0
   type: float
@@ -3893,7 +3893,7 @@ int_4_8:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_9:
   default: 1.0
   type: float
@@ -3904,7 +3904,7 @@ int_4_9:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_10:
   default: 1.0
   type: float
@@ -3915,7 +3915,7 @@ int_4_10:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_11:
   default: 1.0
   type: float
@@ -3926,7 +3926,7 @@ int_4_11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_12:
   default: 1.0
   type: float
@@ -3937,7 +3937,7 @@ int_4_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_13:
   default: 1.0
   type: float
@@ -3948,7 +3948,7 @@ int_4_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_14:
   default: 1.0
   type: float
@@ -3959,7 +3959,7 @@ int_4_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_15:
   default: 1.0
   type: float
@@ -3970,7 +3970,7 @@ int_4_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_16:
   default: 1.0
   type: float
@@ -3981,7 +3981,7 @@ int_4_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_17:
   default: 1.0
   type: float
@@ -3992,7 +3992,7 @@ int_4_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_18:
   default: 1.0
   type: float
@@ -4003,7 +4003,7 @@ int_4_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_19:
   default: 1.0
   type: float
@@ -4014,7 +4014,7 @@ int_4_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_20:
   default: 1.0
   type: float
@@ -4025,7 +4025,7 @@ int_4_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_5:
   default: 1.0
   type: float
@@ -4036,7 +4036,7 @@ int_5_5:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_6:
   default: 1.0
   type: float
@@ -4047,7 +4047,7 @@ int_5_6:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_7:
   default: 1.0
   type: float
@@ -4058,7 +4058,7 @@ int_5_7:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_8:
   default: 1.0
   type: float
@@ -4069,7 +4069,7 @@ int_5_8:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_9:
   default: 1.0
   type: float
@@ -4080,7 +4080,7 @@ int_5_9:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_10:
   default: 1.0
   type: float
@@ -4091,7 +4091,7 @@ int_5_10:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_11:
   default: 1.0
   type: float
@@ -4102,7 +4102,7 @@ int_5_11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_12:
   default: 1.0
   type: float
@@ -4113,7 +4113,7 @@ int_5_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_13:
   default: 1.0
   type: float
@@ -4124,7 +4124,7 @@ int_5_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_14:
   default: 1.0
   type: float
@@ -4135,7 +4135,7 @@ int_5_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_15:
   default: 1.0
   type: float
@@ -4146,7 +4146,7 @@ int_5_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_16:
   default: 1.0
   type: float
@@ -4157,7 +4157,7 @@ int_5_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_17:
   default: 1.0
   type: float
@@ -4168,7 +4168,7 @@ int_5_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_18:
   default: 1.0
   type: float
@@ -4179,7 +4179,7 @@ int_5_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_19:
   default: 1.0
   type: float
@@ -4190,7 +4190,7 @@ int_5_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_20:
   default: 1.0
   type: float
@@ -4201,7 +4201,7 @@ int_5_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_6_6:
   default: 1.0
   type: float
@@ -4212,7 +4212,7 @@ int_6_6:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_6_7:
   default: 1.0
   type: float
@@ -4223,7 +4223,7 @@ int_6_7:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_6_8:
   default: 1.0
   type: float
@@ -4234,7 +4234,7 @@ int_6_8:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_6_9:
   default: 1.0
   type: float
@@ -4245,7 +4245,7 @@ int_6_9:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_6_10:
   default: 1.0
   type: float
@@ -4256,7 +4256,7 @@ int_6_10:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_6_11:
   default: 1.0
   type: float
@@ -4267,7 +4267,7 @@ int_6_11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_6_12:
   default: 1.0
   type: float
@@ -4278,7 +4278,7 @@ int_6_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_6_13:
   default: 1.0
   type: float
@@ -4289,7 +4289,7 @@ int_6_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_6_14:
   default: 1.0
   type: float
@@ -4300,7 +4300,7 @@ int_6_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_6_15:
   default: 1.0
   type: float
@@ -4311,7 +4311,7 @@ int_6_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_6_16:
   default: 1.0
   type: float
@@ -4322,7 +4322,7 @@ int_6_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_6_17:
   default: 1.0
   type: float
@@ -4333,7 +4333,7 @@ int_6_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_6_18:
   default: 1.0
   type: float
@@ -4344,7 +4344,7 @@ int_6_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_6_19:
   default: 1.0
   type: float
@@ -4355,7 +4355,7 @@ int_6_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_6_20:
   default: 1.0
   type: float
@@ -4366,7 +4366,7 @@ int_6_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_7_7:
   default: 1.0
   type: float
@@ -4377,7 +4377,7 @@ int_7_7:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_7_8:
   default: 1.0
   type: float
@@ -4388,7 +4388,7 @@ int_7_8:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_7_9:
   default: 1.0
   type: float
@@ -4399,7 +4399,7 @@ int_7_9:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_7_10:
   default: 1.0
   type: float
@@ -4410,7 +4410,7 @@ int_7_10:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_7_11:
   default: 1.0
   type: float
@@ -4421,7 +4421,7 @@ int_7_11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_7_12:
   default: 1.0
   type: float
@@ -4432,7 +4432,7 @@ int_7_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_7_13:
   default: 1.0
   type: float
@@ -4443,7 +4443,7 @@ int_7_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_7_14:
   default: 1.0
   type: float
@@ -4454,7 +4454,7 @@ int_7_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_7_15:
   default: 1.0
   type: float
@@ -4465,7 +4465,7 @@ int_7_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_7_16:
   default: 1.0
   type: float
@@ -4476,7 +4476,7 @@ int_7_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_7_17:
   default: 1.0
   type: float
@@ -4487,7 +4487,7 @@ int_7_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_7_18:
   default: 1.0
   type: float
@@ -4498,7 +4498,7 @@ int_7_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_7_19:
   default: 1.0
   type: float
@@ -4509,7 +4509,7 @@ int_7_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_8_8:
   default: 1.0
   type: float
@@ -4520,7 +4520,7 @@ int_8_8:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_8_9:
   default: 1.0
   type: float
@@ -4531,7 +4531,7 @@ int_8_9:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_7_20:
   default: 1.0
   type: float
@@ -4542,7 +4542,7 @@ int_7_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_8_10:
   default: 1.0
   type: float
@@ -4553,7 +4553,7 @@ int_8_10:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_8_11:
   default: 1.0
   type: float
@@ -4564,7 +4564,7 @@ int_8_11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_8_12:
   default: 1.0
   type: float
@@ -4575,7 +4575,7 @@ int_8_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_8_13:
   default: 1.0
   type: float
@@ -4586,7 +4586,7 @@ int_8_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_8_14:
   default: 1.0
   type: float
@@ -4597,7 +4597,7 @@ int_8_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_8_15:
   default: 1.0
   type: float
@@ -4608,7 +4608,7 @@ int_8_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_8_16:
   default: 1.0
   type: float
@@ -4619,7 +4619,7 @@ int_8_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_8_17:
   default: 1.0
   type: float
@@ -4630,7 +4630,7 @@ int_8_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_8_18:
   default: 1.0
   type: float
@@ -4641,7 +4641,7 @@ int_8_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_8_19:
   default: 1.0
   type: float
@@ -4652,7 +4652,7 @@ int_8_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_8_20:
   default: 1.0
   type: float
@@ -4663,7 +4663,7 @@ int_8_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_9_11:
   default: 1.0
   type: float
@@ -4674,7 +4674,7 @@ int_9_11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_9_12:
   default: 1.0
   type: float
@@ -4685,7 +4685,7 @@ int_9_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_9_13:
   default: 1.0
   type: float
@@ -4696,7 +4696,7 @@ int_9_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_9_14:
   default: 1.0
   type: float
@@ -4707,7 +4707,7 @@ int_9_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_9_15:
   default: 1.0
   type: float
@@ -4718,7 +4718,7 @@ int_9_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_9_16:
   default: 1.0
   type: float
@@ -4729,7 +4729,7 @@ int_9_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_9_17:
   default: 1.0
   type: float
@@ -4740,7 +4740,7 @@ int_9_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_9_18:
   default: 1.0
   type: float
@@ -4751,7 +4751,7 @@ int_9_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_9_19:
   default: 1.0
   type: float
@@ -4762,7 +4762,7 @@ int_9_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_9_20:
   default: 1.0
   type: float
@@ -4773,7 +4773,7 @@ int_9_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_9_9:
   default: 1.0
   type: float
@@ -4784,7 +4784,7 @@ int_9_9:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_9_10:
   default: 1.0
   type: float
@@ -4795,7 +4795,7 @@ int_9_10:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_10_10:
   default: 1.0
   type: float
@@ -4806,7 +4806,7 @@ int_10_10:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_10_11:
   default: 1.0
   type: float
@@ -4817,7 +4817,7 @@ int_10_11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_10_12:
   default: 1.0
   type: float
@@ -4828,7 +4828,7 @@ int_10_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_10_13:
   default: 1.0
   type: float
@@ -4839,7 +4839,7 @@ int_10_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_10_14:
   default: 1.0
   type: float
@@ -4850,7 +4850,7 @@ int_10_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_10_15:
   default: 1.0
   type: float
@@ -4861,7 +4861,7 @@ int_10_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_10_16:
   default: 1.0
   type: float
@@ -4872,7 +4872,7 @@ int_10_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_10_17:
   default: 1.0
   type: float
@@ -4883,7 +4883,7 @@ int_10_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_10_18:
   default: 1.0
   type: float
@@ -4894,7 +4894,7 @@ int_10_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_10_19:
   default: 1.0
   type: float
@@ -4905,7 +4905,7 @@ int_10_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_10_20:
   default: 1.0
   type: float
@@ -4916,7 +4916,7 @@ int_10_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_11_11:
   default: 1.0
   type: float
@@ -4927,7 +4927,7 @@ int_11_11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_11_12:
   default: 1.0
   type: float
@@ -4938,7 +4938,7 @@ int_11_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_11_13:
   default: 1.0
   type: float
@@ -4949,7 +4949,7 @@ int_11_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_11_14:
   default: 1.0
   type: float
@@ -4960,7 +4960,7 @@ int_11_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_11_15:
   default: 1.0
   type: float
@@ -4971,7 +4971,7 @@ int_11_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_11_16:
   default: 1.0
   type: float
@@ -4982,7 +4982,7 @@ int_11_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_11_17:
   default: 1.0
   type: float
@@ -4993,7 +4993,7 @@ int_11_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_11_18:
   default: 1.0
   type: float
@@ -5004,7 +5004,7 @@ int_11_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_11_19:
   default: 1.0
   type: float
@@ -5015,7 +5015,7 @@ int_11_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_11_20:
   default: 1.0
   type: float
@@ -5026,7 +5026,7 @@ int_11_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_12_12:
   default: 1.0
   type: float
@@ -5037,7 +5037,7 @@ int_12_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_12_13:
   default: 1.0
   type: float
@@ -5048,7 +5048,7 @@ int_12_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_12_14:
   default: 1.0
   type: float
@@ -5059,7 +5059,7 @@ int_12_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_12_15:
   default: 1.0
   type: float
@@ -5070,7 +5070,7 @@ int_12_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_12_16:
   default: 1.0
   type: float
@@ -5081,7 +5081,7 @@ int_12_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_12_17:
   default: 1.0
   type: float
@@ -5092,7 +5092,7 @@ int_12_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_12_18:
   default: 1.0
   type: float
@@ -5103,7 +5103,7 @@ int_12_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_12_19:
   default: 1.0
   type: float
@@ -5114,7 +5114,7 @@ int_12_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_12_20:
   default: 1.0
   type: float
@@ -5125,7 +5125,7 @@ int_12_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_13_13:
   default: 1.0
   type: float
@@ -5136,7 +5136,7 @@ int_13_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_13_14:
   default: 1.0
   type: float
@@ -5147,7 +5147,7 @@ int_13_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_13_15:
   default: 1.0
   type: float
@@ -5158,7 +5158,7 @@ int_13_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_13_16:
   default: 1.0
   type: float
@@ -5169,7 +5169,7 @@ int_13_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_13_17:
   default: 1.0
   type: float
@@ -5180,7 +5180,7 @@ int_13_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_13_18:
   default: 1.0
   type: float
@@ -5191,7 +5191,7 @@ int_13_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_13_19:
   default: 1.0
   type: float
@@ -5202,7 +5202,7 @@ int_13_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_13_20:
   default: 1.0
   type: float
@@ -5213,7 +5213,7 @@ int_13_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_14_14:
   default: 1.0
   type: float
@@ -5224,7 +5224,7 @@ int_14_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_14_15:
   default: 1.0
   type: float
@@ -5235,7 +5235,7 @@ int_14_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_14_16:
   default: 1.0
   type: float
@@ -5246,7 +5246,7 @@ int_14_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_14_17:
   default: 1.0
   type: float
@@ -5257,7 +5257,7 @@ int_14_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_14_18:
   default: 1.0
   type: float
@@ -5268,7 +5268,7 @@ int_14_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_14_19:
   default: 1.0
   type: float
@@ -5279,7 +5279,7 @@ int_14_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_14_20:
   default: 1.0
   type: float
@@ -5290,7 +5290,7 @@ int_14_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_15_15:
   default: 1.0
   type: float
@@ -5301,7 +5301,7 @@ int_15_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_15_16:
   default: 1.0
   type: float
@@ -5312,7 +5312,7 @@ int_15_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_15_17:
   default: 1.0
   type: float
@@ -5323,7 +5323,7 @@ int_15_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_15_18:
   default: 1.0
   type: float
@@ -5334,7 +5334,7 @@ int_15_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_15_19:
   default: 1.0
   type: float
@@ -5345,7 +5345,7 @@ int_15_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_15_20:
   default: 1.0
   type: float
@@ -5356,7 +5356,7 @@ int_15_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_16_16:
   default: 1.0
   type: float
@@ -5367,7 +5367,7 @@ int_16_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_16_17:
   default: 1.0
   type: float
@@ -5378,7 +5378,7 @@ int_16_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_16_18:
   default: 1.0
   type: float
@@ -5389,7 +5389,7 @@ int_16_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_16_19:
   default: 1.0
   type: float
@@ -5400,7 +5400,7 @@ int_16_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_16_20:
   default: 1.0
   type: float
@@ -5411,7 +5411,7 @@ int_16_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_17_17:
   default: 1.0
   type: float
@@ -5422,7 +5422,7 @@ int_17_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_17_18:
   default: 1.0
   type: float
@@ -5433,7 +5433,7 @@ int_17_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_17_19:
   default: 1.0
   type: float
@@ -5444,7 +5444,7 @@ int_17_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_17_20:
   default: 1.0
   type: float
@@ -5455,7 +5455,7 @@ int_17_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_18_18:
   default: 1.0
   type: float
@@ -5466,7 +5466,7 @@ int_18_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_18_19:
   default: 1.0
   type: float
@@ -5477,7 +5477,7 @@ int_18_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_18_20:
   default: 1.0
   type: float
@@ -5488,7 +5488,7 @@ int_18_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_19_19:
   default: 1.0
   type: float
@@ -5499,7 +5499,7 @@ int_19_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_19_20:
   default: 1.0
   type: float
@@ -5510,7 +5510,7 @@ int_19_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_20_20:
   default: 1.0
   type: float
@@ -5521,4 +5521,4 @@ int_20_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy

--- a/src/haddock/modules/refinement/flexref/defaults.yaml
+++ b/src/haddock/modules/refinement/flexref/defaults.yaml
@@ -7,7 +7,7 @@ tolerance:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 log_level:
   default: verbose
   type: string
@@ -17,7 +17,7 @@ log_level:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ambig_fname:
   default: ''
   type: file
@@ -25,7 +25,7 @@ ambig_fname:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 unambig_fname:
   default: ''
   type: file
@@ -33,7 +33,7 @@ unambig_fname:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 dihe_fname:
   default: ''
   type: file
@@ -41,7 +41,7 @@ dihe_fname:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 hbond_fname:
   default: ''
   type: file
@@ -49,7 +49,7 @@ hbond_fname:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ligand_param_fname:
   default: ''
   type: file
@@ -57,7 +57,7 @@ ligand_param_fname:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ligand_top_fname:
   default: ''
   type: file
@@ -65,7 +65,7 @@ ligand_top_fname:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 sampling_factor:
   default: 1
   type: integer
@@ -75,7 +75,7 @@ sampling_factor:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 iniseed:
   default: 917
   type: integer
@@ -85,7 +85,7 @@ iniseed:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 keepwater:
   default: false
   type: boolean
@@ -93,7 +93,7 @@ keepwater:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 mdsteps_rigid:
   default: 500
   type: integer
@@ -103,7 +103,7 @@ mdsteps_rigid:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 mdsteps_cool1:
   default: 500
   type: integer
@@ -113,7 +113,7 @@ mdsteps_cool1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 mdsteps_cool2:
   default: 1000
   type: integer
@@ -123,7 +123,7 @@ mdsteps_cool2:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 mdsteps_cool3:
   default: 1000
   type: integer
@@ -133,7 +133,7 @@ mdsteps_cool3:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 timestep:
   default: 0.002
   type: float
@@ -144,7 +144,7 @@ timestep:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 tadfactor:
   default: 8
   type: integer
@@ -154,7 +154,7 @@ tadfactor:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 sinter_rigid_init:
   default: 0.001
   type: float
@@ -165,7 +165,7 @@ sinter_rigid_init:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 sinter_rigid_final:
   default: 0.001
   type: float
@@ -176,7 +176,7 @@ sinter_rigid_final:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 sinter_cool2_init:
   default: 0.001
   type: float
@@ -187,7 +187,7 @@ sinter_cool2_init:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 sinter_cool2_final:
   default: 1.0
   type: float
@@ -198,7 +198,7 @@ sinter_cool2_final:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 sinter_cool3_init:
   default: 0.05
   type: float
@@ -209,7 +209,7 @@ sinter_cool3_init:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 sinter_cool3_final:
   default: 1.0
   type: float
@@ -220,7 +220,7 @@ sinter_cool3_final:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 temp_high:
   default: 2000
   type: integer
@@ -230,7 +230,7 @@ temp_high:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 temp_cool1_init:
   default: 2000
   type: integer
@@ -240,7 +240,7 @@ temp_cool1_init:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 temp_cool1_final:
   default: 500
   type: integer
@@ -250,7 +250,7 @@ temp_cool1_final:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 temp_cool2_init:
   default: 1000
   type: integer
@@ -260,7 +260,7 @@ temp_cool2_init:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 temp_cool2_final:
   default: 50
   type: integer
@@ -270,7 +270,7 @@ temp_cool2_final:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 temp_cool3_init:
   default: 1000
   type: integer
@@ -280,7 +280,7 @@ temp_cool3_init:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 temp_cool3_final:
   default: 50
   type: integer
@@ -290,7 +290,7 @@ temp_cool3_final:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_1:
   default: A
   type: string
@@ -300,7 +300,7 @@ prot_segid_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_2:
   default: B
   type: string
@@ -310,7 +310,7 @@ prot_segid_2:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_3:
   default: C
   type: string
@@ -320,7 +320,7 @@ prot_segid_3:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_4:
   default: D
   type: string
@@ -330,7 +330,7 @@ prot_segid_4:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_5:
   default: E
   type: string
@@ -340,7 +340,7 @@ prot_segid_5:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_6:
   default: F
   type: string
@@ -350,7 +350,7 @@ prot_segid_6:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_7:
   default: G
   type: string
@@ -360,7 +360,7 @@ prot_segid_7:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_8:
   default: H
   type: string
@@ -370,7 +370,7 @@ prot_segid_8:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_9:
   default: I
   type: string
@@ -380,7 +380,7 @@ prot_segid_9:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_10:
   default: J
   type: string
@@ -390,7 +390,7 @@ prot_segid_10:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_11:
   default: K
   type: string
@@ -400,7 +400,7 @@ prot_segid_11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_12:
   default: L
   type: string
@@ -410,7 +410,7 @@ prot_segid_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_13:
   default: M
   type: string
@@ -420,7 +420,7 @@ prot_segid_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_14:
   default: N
   type: string
@@ -430,7 +430,7 @@ prot_segid_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_15:
   default: O
   type: string
@@ -440,7 +440,7 @@ prot_segid_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_16:
   default: P
   type: string
@@ -450,7 +450,7 @@ prot_segid_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_17:
   default: Q
   type: string
@@ -460,7 +460,7 @@ prot_segid_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_18:
   default: R
   type: string
@@ -470,7 +470,7 @@ prot_segid_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_19:
   default: S
   type: string
@@ -480,7 +480,7 @@ prot_segid_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_20:
   default: T
   type: string
@@ -490,7 +490,7 @@ prot_segid_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_1:
   default: false
   type: boolean
@@ -498,7 +498,7 @@ shape_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_2:
   default: false
   type: boolean
@@ -506,7 +506,7 @@ shape_2:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_3:
   default: false
   type: boolean
@@ -514,7 +514,7 @@ shape_3:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_4:
   default: false
   type: boolean
@@ -522,7 +522,7 @@ shape_4:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_5:
   default: false
   type: boolean
@@ -530,7 +530,7 @@ shape_5:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_6:
   default: false
   type: boolean
@@ -538,7 +538,7 @@ shape_6:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_7:
   default: false
   type: boolean
@@ -546,7 +546,7 @@ shape_7:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_8:
   default: false
   type: boolean
@@ -554,7 +554,7 @@ shape_8:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_9:
   default: false
   type: boolean
@@ -562,7 +562,7 @@ shape_9:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_10:
   default: false
   type: boolean
@@ -570,7 +570,7 @@ shape_10:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_11:
   default: false
   type: boolean
@@ -578,7 +578,7 @@ shape_11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_12:
   default: false
   type: boolean
@@ -586,7 +586,7 @@ shape_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_13:
   default: false
   type: boolean
@@ -594,7 +594,7 @@ shape_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_14:
   default: false
   type: boolean
@@ -602,7 +602,7 @@ shape_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_15:
   default: false
   type: boolean
@@ -610,7 +610,7 @@ shape_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_16:
   default: false
   type: boolean
@@ -618,7 +618,7 @@ shape_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_17:
   default: false
   type: boolean
@@ -626,7 +626,7 @@ shape_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_18:
   default: false
   type: boolean
@@ -634,7 +634,7 @@ shape_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_19:
   default: false
   type: boolean
@@ -642,7 +642,7 @@ shape_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_20:
   default: false
   type: boolean
@@ -650,7 +650,7 @@ shape_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 amb_hot:
   default: 10
   type: integer
@@ -660,7 +660,7 @@ amb_hot:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 amb_cool1:
   default: 10
   type: integer
@@ -670,7 +670,7 @@ amb_cool1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 amb_cool2:
   default: 50
   type: integer
@@ -680,7 +680,7 @@ amb_cool2:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 amb_cool3:
   default: 50
   type: integer
@@ -690,7 +690,7 @@ amb_cool3:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 unamb_hot:
   default: 10
   type: integer
@@ -700,7 +700,7 @@ unamb_hot:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 unamb_cool1:
   default: 10
   type: integer
@@ -710,7 +710,7 @@ unamb_cool1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 unamb_cool2:
   default: 50
   type: integer
@@ -720,7 +720,7 @@ unamb_cool2:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 unamb_cool3:
   default: 50
   type: integer
@@ -730,7 +730,7 @@ unamb_cool3:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 hbond_hot:
   default: 10
   type: integer
@@ -740,7 +740,7 @@ hbond_hot:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 hbond_cool1:
   default: 10
   type: integer
@@ -750,7 +750,7 @@ hbond_cool1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 hbond_cool2:
   default: 50
   type: integer
@@ -760,7 +760,7 @@ hbond_cool2:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 hbond_cool3:
   default: 50
   type: integer
@@ -770,7 +770,7 @@ hbond_cool3:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 hbonds_on:
   default: false
   type: boolean
@@ -778,7 +778,7 @@ hbonds_on:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 noecv:
   default: false
   type: boolean
@@ -786,7 +786,7 @@ noecv:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ncvpart:
   default: 2
   type: integer
@@ -796,7 +796,7 @@ ncvpart:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 mrswi_hot:
   default: 0.5
   type: float
@@ -807,7 +807,7 @@ mrswi_hot:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 mrswi_cool1:
   default: 0.5
   type: float
@@ -818,7 +818,7 @@ mrswi_cool1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 mrswi_cool2:
   default: 0.5
   type: float
@@ -829,7 +829,7 @@ mrswi_cool2:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 mrswi_cool3:
   default: 0.5
   type: float
@@ -840,7 +840,7 @@ mrswi_cool3:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 rswi_hot:
   default: 0.5
   type: float
@@ -851,7 +851,7 @@ rswi_hot:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 rswi_cool1:
   default: 0.5
   type: float
@@ -862,7 +862,7 @@ rswi_cool1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 rswi_cool2:
   default: 0.5
   type: float
@@ -873,7 +873,7 @@ rswi_cool2:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 rswi_cool3:
   default: 0.5
   type: float
@@ -884,7 +884,7 @@ rswi_cool3:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 masy_hot:
   default: -1.0
   type: float
@@ -895,7 +895,7 @@ masy_hot:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 masy_cool1:
   default: -1.0
   type: float
@@ -906,7 +906,7 @@ masy_cool1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 masy_cool2:
   default: -0.1
   type: float
@@ -917,7 +917,7 @@ masy_cool2:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 masy_cool3:
   default: -0.1
   type: float
@@ -928,7 +928,7 @@ masy_cool3:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 asy_hot:
   default: 1.0
   type: float
@@ -939,7 +939,7 @@ asy_hot:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 asy_cool1:
   default: 1.0
   type: float
@@ -950,7 +950,7 @@ asy_cool1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 asy_cool2:
   default: 0.1
   type: float
@@ -961,7 +961,7 @@ asy_cool2:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 asy_cool3:
   default: 0.1
   type: float
@@ -972,7 +972,7 @@ asy_cool3:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 cmrest:
   default: false
   type: boolean
@@ -980,7 +980,7 @@ cmrest:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 cmtight:
   default: false
   type: boolean
@@ -988,7 +988,7 @@ cmtight:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ranair:
   default: false
   type: boolean
@@ -996,7 +996,7 @@ ranair:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 kcont:
   default: 1.0
   type: float
@@ -1007,7 +1007,7 @@ kcont:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ksurf:
   default: 1.0
   type: float
@@ -1018,7 +1018,7 @@ ksurf:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 surfrest:
   default: false
   type: boolean
@@ -1026,7 +1026,7 @@ surfrest:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 dihedrals_on:
   default: false
   type: boolean
@@ -1034,7 +1034,7 @@ dihedrals_on:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 dihedrals_hot:
   default: 5
   type: integer
@@ -1044,7 +1044,7 @@ dihedrals_hot:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 dihedrals_cool1:
   default: 5
   type: integer
@@ -1054,7 +1054,7 @@ dihedrals_cool1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 dihedrals_cool2:
   default: 50
   type: integer
@@ -1064,7 +1064,7 @@ dihedrals_cool2:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 dihedrals_cool3:
   default: 200
   type: integer
@@ -1074,7 +1074,7 @@ dihedrals_cool3:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ssdihed:
   default: none
   type: string
@@ -1084,7 +1084,7 @@ ssdihed:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 error_dih:
   default: 10
   type: integer
@@ -1094,7 +1094,7 @@ error_dih:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 dnarest_on:
   default: false
   type: boolean
@@ -1102,7 +1102,7 @@ dnarest_on:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 sym_on:
   default: false
   type: boolean
@@ -1110,7 +1110,7 @@ sym_on:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ksym:
   default: 10.0
   type: float
@@ -1121,7 +1121,7 @@ ksym:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 numc2sym:
   default: 0
   type: integer
@@ -1131,7 +1131,7 @@ numc2sym:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c2sym_sta1_1:
   default: .nan
   type: float
@@ -1142,7 +1142,7 @@ c2sym_sta1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c2sym_end1_1:
   default: .nan
   type: float
@@ -1153,7 +1153,7 @@ c2sym_end1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c2sym_seg1_1:
   default: ''
   type: string
@@ -1163,7 +1163,7 @@ c2sym_seg1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c2sym_sta2_1:
   default: .nan
   type: float
@@ -1174,7 +1174,7 @@ c2sym_sta2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c2sym_end2_1:
   default: .nan
   type: float
@@ -1185,7 +1185,7 @@ c2sym_end2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c2sym_seg2_1:
   default: ''
   type: string
@@ -1195,7 +1195,7 @@ c2sym_seg2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 numc3sym:
   default: 0
   type: integer
@@ -1205,7 +1205,7 @@ numc3sym:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c3sym_sta1_1:
   default: .nan
   type: float
@@ -1216,7 +1216,7 @@ c3sym_sta1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c3sym_end1_1:
   default: .nan
   type: float
@@ -1227,7 +1227,7 @@ c3sym_end1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c3sym_seg1_1:
   default: ''
   type: string
@@ -1237,7 +1237,7 @@ c3sym_seg1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c3sym_sta2_1:
   default: .nan
   type: float
@@ -1248,7 +1248,7 @@ c3sym_sta2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c3sym_end2_1:
   default: .nan
   type: float
@@ -1259,7 +1259,7 @@ c3sym_end2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c3sym_seg2_1:
   default: ''
   type: string
@@ -1269,7 +1269,7 @@ c3sym_seg2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c3sym_sta3_1:
   default: .nan
   type: float
@@ -1280,7 +1280,7 @@ c3sym_sta3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c3sym_end3_1:
   default: .nan
   type: float
@@ -1291,7 +1291,7 @@ c3sym_end3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c3sym_seg3_1:
   default: ''
   type: string
@@ -1301,7 +1301,7 @@ c3sym_seg3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 numc4sym:
   default: 0
   type: integer
@@ -1311,7 +1311,7 @@ numc4sym:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c4sym_sta1_1:
   default: .nan
   type: float
@@ -1322,7 +1322,7 @@ c4sym_sta1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c4sym_end1_1:
   default: .nan
   type: float
@@ -1333,7 +1333,7 @@ c4sym_end1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c4sym_seg1_1:
   default: ''
   type: string
@@ -1343,7 +1343,7 @@ c4sym_seg1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c4sym_sta2_1:
   default: .nan
   type: float
@@ -1354,7 +1354,7 @@ c4sym_sta2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c4sym_end2_1:
   default: .nan
   type: float
@@ -1365,7 +1365,7 @@ c4sym_end2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c4sym_seg2_1:
   default: ''
   type: string
@@ -1375,7 +1375,7 @@ c4sym_seg2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c4sym_sta3_1:
   default: .nan
   type: float
@@ -1386,7 +1386,7 @@ c4sym_sta3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c4sym_end3_1:
   default: .nan
   type: float
@@ -1397,7 +1397,7 @@ c4sym_end3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c4sym_seg3_1:
   default: ''
   type: string
@@ -1407,7 +1407,7 @@ c4sym_seg3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c4sym_sta4_1:
   default: .nan
   type: float
@@ -1418,7 +1418,7 @@ c4sym_sta4_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c4sym_end4_1:
   default: .nan
   type: float
@@ -1429,7 +1429,7 @@ c4sym_end4_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c4sym_seg4_1:
   default: ''
   type: string
@@ -1439,7 +1439,7 @@ c4sym_seg4_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 numc5sym:
   default: 0
   type: integer
@@ -1449,7 +1449,7 @@ numc5sym:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c5sym_sta1_1:
   default: .nan
   type: float
@@ -1460,7 +1460,7 @@ c5sym_sta1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c5sym_end1_1:
   default: .nan
   type: float
@@ -1471,7 +1471,7 @@ c5sym_end1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c5sym_seg1_1:
   default: ''
   type: string
@@ -1481,7 +1481,7 @@ c5sym_seg1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c5sym_sta2_1:
   default: .nan
   type: float
@@ -1492,7 +1492,7 @@ c5sym_sta2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c5sym_end2_1:
   default: .nan
   type: float
@@ -1503,7 +1503,7 @@ c5sym_end2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c5sym_seg2_1:
   default: ''
   type: string
@@ -1513,7 +1513,7 @@ c5sym_seg2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c5sym_sta3_1:
   default: .nan
   type: float
@@ -1524,7 +1524,7 @@ c5sym_sta3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c5sym_end3_1:
   default: .nan
   type: float
@@ -1535,7 +1535,7 @@ c5sym_end3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c5sym_seg3_1:
   default: ''
   type: string
@@ -1545,7 +1545,7 @@ c5sym_seg3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c5sym_sta4_1:
   default: .nan
   type: float
@@ -1556,7 +1556,7 @@ c5sym_sta4_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c5sym_end4_1:
   default: .nan
   type: float
@@ -1567,7 +1567,7 @@ c5sym_end4_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c5sym_seg4_1:
   default: ''
   type: string
@@ -1577,7 +1577,7 @@ c5sym_seg4_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c5sym_sta5_1:
   default: .nan
   type: float
@@ -1588,7 +1588,7 @@ c5sym_sta5_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c5sym_end5_1:
   default: .nan
   type: float
@@ -1599,7 +1599,7 @@ c5sym_end5_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c5sym_seg5_1:
   default: ''
   type: string
@@ -1609,7 +1609,7 @@ c5sym_seg5_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 numc6sym:
   default: 0
   type: integer
@@ -1619,7 +1619,7 @@ numc6sym:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_sta1_1:
   default: .nan
   type: float
@@ -1630,7 +1630,7 @@ c6sym_sta1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_end1_1:
   default: .nan
   type: float
@@ -1641,7 +1641,7 @@ c6sym_end1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_seg1_1:
   default: ''
   type: string
@@ -1651,7 +1651,7 @@ c6sym_seg1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_sta2_1:
   default: .nan
   type: float
@@ -1662,7 +1662,7 @@ c6sym_sta2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_end2_1:
   default: .nan
   type: float
@@ -1673,7 +1673,7 @@ c6sym_end2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_seg2_1:
   default: ''
   type: string
@@ -1683,7 +1683,7 @@ c6sym_seg2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_sta3_1:
   default: .nan
   type: float
@@ -1694,7 +1694,7 @@ c6sym_sta3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_end3_1:
   default: .nan
   type: float
@@ -1705,7 +1705,7 @@ c6sym_end3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_seg3_1:
   default: ''
   type: string
@@ -1715,7 +1715,7 @@ c6sym_seg3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_sta4_1:
   default: .nan
   type: float
@@ -1726,7 +1726,7 @@ c6sym_sta4_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_end4_1:
   default: .nan
   type: float
@@ -1737,7 +1737,7 @@ c6sym_end4_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_seg4_1:
   default: ''
   type: string
@@ -1747,7 +1747,7 @@ c6sym_seg4_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_sta5_1:
   default: .nan
   type: float
@@ -1758,7 +1758,7 @@ c6sym_sta5_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_end5_1:
   default: .nan
   type: float
@@ -1769,7 +1769,7 @@ c6sym_end5_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_seg5_1:
   default: ''
   type: string
@@ -1779,7 +1779,7 @@ c6sym_seg5_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_sta6_1:
   default: .nan
   type: float
@@ -1790,7 +1790,7 @@ c6sym_sta6_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_end6_1:
   default: .nan
   type: float
@@ -1801,7 +1801,7 @@ c6sym_end6_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_seg6_1:
   default: ''
   type: string
@@ -1811,7 +1811,7 @@ c6sym_seg6_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nums3sym:
   default: 0
   type: integer
@@ -1821,7 +1821,7 @@ nums3sym:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 s3sym_sta1_1:
   default: .nan
   type: float
@@ -1832,7 +1832,7 @@ s3sym_sta1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 s3sym_end1_1:
   default: .nan
   type: float
@@ -1843,7 +1843,7 @@ s3sym_end1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 s3sym_seg1_1:
   default: ''
   type: string
@@ -1853,7 +1853,7 @@ s3sym_seg1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 s3sym_sta2_1:
   default: .nan
   type: float
@@ -1864,7 +1864,7 @@ s3sym_sta2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 s3sym_end2_1:
   default: .nan
   type: float
@@ -1875,7 +1875,7 @@ s3sym_end2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 s3sym_seg2_1:
   default: ''
   type: string
@@ -1885,7 +1885,7 @@ s3sym_seg2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 s3sym_sta3_1:
   default: .nan
   type: float
@@ -1896,7 +1896,7 @@ s3sym_sta3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 s3sym_end3_1:
   default: .nan
   type: float
@@ -1907,7 +1907,7 @@ s3sym_end3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 s3sym_seg3_1:
   default: ''
   type: string
@@ -1917,7 +1917,7 @@ s3sym_seg3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ncs_on:
   default: false
   type: boolean
@@ -1925,7 +1925,7 @@ ncs_on:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 kncs:
   default: 1.0
   type: float
@@ -1936,7 +1936,7 @@ kncs:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 numncs:
   default: 0
   type: integer
@@ -1946,7 +1946,7 @@ numncs:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ncs_sta1_1:
   default: .nan
   type: float
@@ -1957,7 +1957,7 @@ ncs_sta1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ncs_end1_1:
   default: .nan
   type: float
@@ -1968,7 +1968,7 @@ ncs_end1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ncs_seg1_1:
   default: ''
   type: string
@@ -1978,7 +1978,7 @@ ncs_seg1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ncs_sta2_1:
   default: .nan
   type: float
@@ -1989,7 +1989,7 @@ ncs_sta2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ncs_end2_1:
   default: .nan
   type: float
@@ -2000,7 +2000,7 @@ ncs_end2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ncs_seg2_1:
   default: ''
   type: string
@@ -2010,7 +2010,7 @@ ncs_seg2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_1:
   default: false
   type: boolean
@@ -2018,7 +2018,7 @@ fix_origin_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_2:
   default: false
   type: boolean
@@ -2026,7 +2026,7 @@ fix_origin_2:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_3:
   default: false
   type: boolean
@@ -2034,7 +2034,7 @@ fix_origin_3:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_4:
   default: false
   type: boolean
@@ -2042,7 +2042,7 @@ fix_origin_4:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_5:
   default: false
   type: boolean
@@ -2050,7 +2050,7 @@ fix_origin_5:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_6:
   default: false
   type: boolean
@@ -2058,7 +2058,7 @@ fix_origin_6:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_7:
   default: false
   type: boolean
@@ -2066,7 +2066,7 @@ fix_origin_7:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_8:
   default: false
   type: boolean
@@ -2074,7 +2074,7 @@ fix_origin_8:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_9:
   default: false
   type: boolean
@@ -2082,7 +2082,7 @@ fix_origin_9:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_10:
   default: false
   type: boolean
@@ -2090,7 +2090,7 @@ fix_origin_10:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_11:
   default: false
   type: boolean
@@ -2098,7 +2098,7 @@ fix_origin_11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_12:
   default: false
   type: boolean
@@ -2106,7 +2106,7 @@ fix_origin_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_13:
   default: false
   type: boolean
@@ -2114,7 +2114,7 @@ fix_origin_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_14:
   default: false
   type: boolean
@@ -2122,7 +2122,7 @@ fix_origin_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_15:
   default: false
   type: boolean
@@ -2130,7 +2130,7 @@ fix_origin_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_16:
   default: false
   type: boolean
@@ -2138,7 +2138,7 @@ fix_origin_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_17:
   default: false
   type: boolean
@@ -2146,7 +2146,7 @@ fix_origin_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_18:
   default: false
   type: boolean
@@ -2154,7 +2154,7 @@ fix_origin_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_19:
   default: false
   type: boolean
@@ -2162,7 +2162,7 @@ fix_origin_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_20:
   default: false
   type: boolean
@@ -2170,7 +2170,7 @@ fix_origin_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nfle1:
   default: 0
   type: integer
@@ -2180,7 +2180,7 @@ nfle1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 flesta1_1:
   default: .nan
   type: float
@@ -2191,7 +2191,7 @@ flesta1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fleend1_1:
   default: .nan
   type: float
@@ -2202,7 +2202,7 @@ fleend1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nfle2:
   default: 0
   type: integer
@@ -2212,7 +2212,7 @@ nfle2:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 flesta2_1:
   default: .nan
   type: float
@@ -2223,7 +2223,7 @@ flesta2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fleend2_1:
   default: .nan
   type: float
@@ -2234,7 +2234,7 @@ fleend2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nfle3:
   default: 0
   type: integer
@@ -2244,7 +2244,7 @@ nfle3:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 flesta3_1:
   default: .nan
   type: float
@@ -2255,7 +2255,7 @@ flesta3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fleend3_1:
   default: .nan
   type: float
@@ -2266,7 +2266,7 @@ fleend3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nfle4:
   default: 0
   type: integer
@@ -2276,7 +2276,7 @@ nfle4:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 flesta4_1:
   default: .nan
   type: float
@@ -2287,7 +2287,7 @@ flesta4_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fleend4_1:
   default: .nan
   type: float
@@ -2298,7 +2298,7 @@ fleend4_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nfle5:
   default: 0
   type: integer
@@ -2308,7 +2308,7 @@ nfle5:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 flesta5_1:
   default: .nan
   type: float
@@ -2319,7 +2319,7 @@ flesta5_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fleend5_1:
   default: .nan
   type: float
@@ -2330,7 +2330,7 @@ fleend5_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nfle6:
   default: 0
   type: integer
@@ -2340,7 +2340,7 @@ nfle6:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 flesta6_1:
   default: .nan
   type: float
@@ -2351,7 +2351,7 @@ flesta6_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fleend6_1:
   default: .nan
   type: float
@@ -2362,7 +2362,7 @@ fleend6_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nfle7:
   default: 0
   type: integer
@@ -2372,7 +2372,7 @@ nfle7:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 flesta7_1:
   default: .nan
   type: float
@@ -2383,7 +2383,7 @@ flesta7_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fleend7_1:
   default: .nan
   type: float
@@ -2394,7 +2394,7 @@ fleend7_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nfle8:
   default: 0
   type: integer
@@ -2404,7 +2404,7 @@ nfle8:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 flesta8_1:
   default: .nan
   type: float
@@ -2415,7 +2415,7 @@ flesta8_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fleend8_1:
   default: .nan
   type: float
@@ -2426,7 +2426,7 @@ fleend8_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nfle9:
   default: 0
   type: integer
@@ -2436,7 +2436,7 @@ nfle9:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 flesta9_1:
   default: .nan
   type: float
@@ -2447,7 +2447,7 @@ flesta9_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fleend9_1:
   default: .nan
   type: float
@@ -2458,7 +2458,7 @@ fleend9_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nfle10:
   default: 0
   type: integer
@@ -2468,7 +2468,7 @@ nfle10:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 flesta10_1:
   default: .nan
   type: float
@@ -2479,7 +2479,7 @@ flesta10_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fleend10_1:
   default: .nan
   type: float
@@ -2490,7 +2490,7 @@ fleend10_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nfle11:
   default: 0
   type: integer
@@ -2500,7 +2500,7 @@ nfle11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 flesta11_1:
   default: .nan
   type: float
@@ -2511,7 +2511,7 @@ flesta11_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fleend11_1:
   default: .nan
   type: float
@@ -2522,7 +2522,7 @@ fleend11_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nfle12:
   default: 0
   type: integer
@@ -2532,7 +2532,7 @@ nfle12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 flesta12_1:
   default: .nan
   type: float
@@ -2543,7 +2543,7 @@ flesta12_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fleend12_1:
   default: .nan
   type: float
@@ -2554,7 +2554,7 @@ fleend12_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nfle13:
   default: 0
   type: integer
@@ -2564,7 +2564,7 @@ nfle13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 flesta13_1:
   default: .nan
   type: float
@@ -2575,7 +2575,7 @@ flesta13_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fleend13_1:
   default: .nan
   type: float
@@ -2586,7 +2586,7 @@ fleend13_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nfle14:
   default: 0
   type: integer
@@ -2596,7 +2596,7 @@ nfle14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 flesta14_1:
   default: .nan
   type: float
@@ -2607,7 +2607,7 @@ flesta14_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fleend14_1:
   default: .nan
   type: float
@@ -2618,7 +2618,7 @@ fleend14_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nfle15:
   default: 0
   type: integer
@@ -2628,7 +2628,7 @@ nfle15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 flesta15_1:
   default: .nan
   type: float
@@ -2639,7 +2639,7 @@ flesta15_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fleend15_1:
   default: .nan
   type: float
@@ -2650,7 +2650,7 @@ fleend15_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nfle16:
   default: 0
   type: integer
@@ -2660,7 +2660,7 @@ nfle16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 flesta16_1:
   default: .nan
   type: float
@@ -2671,7 +2671,7 @@ flesta16_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fleend16_1:
   default: .nan
   type: float
@@ -2682,7 +2682,7 @@ fleend16_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nfle17:
   default: 0
   type: integer
@@ -2692,7 +2692,7 @@ nfle17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 flesta17_1:
   default: .nan
   type: float
@@ -2703,7 +2703,7 @@ flesta17_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fleend17_1:
   default: .nan
   type: float
@@ -2714,7 +2714,7 @@ fleend17_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nfle18:
   default: 0
   type: integer
@@ -2724,7 +2724,7 @@ nfle18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 flesta18_1:
   default: .nan
   type: float
@@ -2735,7 +2735,7 @@ flesta18_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fleend18_1:
   default: .nan
   type: float
@@ -2746,7 +2746,7 @@ fleend18_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nfle19:
   default: 0
   type: integer
@@ -2756,7 +2756,7 @@ nfle19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 flesta19_1:
   default: .nan
   type: float
@@ -2767,7 +2767,7 @@ flesta19_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fleend19_1:
   default: .nan
   type: float
@@ -2778,7 +2778,7 @@ fleend19_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nfle20:
   default: 0
   type: integer
@@ -2788,7 +2788,7 @@ nfle20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 flesta20_1:
   default: .nan
   type: float
@@ -2799,7 +2799,7 @@ flesta20_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fleend20_1:
   default: .nan
   type: float
@@ -2810,7 +2810,7 @@ fleend20_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nseg1:
   default: -1
   type: integer
@@ -2820,7 +2820,7 @@ nseg1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segsta1_1:
   default: .nan
   type: float
@@ -2831,7 +2831,7 @@ segsta1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segend1_1:
   default: .nan
   type: float
@@ -2842,7 +2842,7 @@ segend1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nseg2:
   default: -1
   type: integer
@@ -2852,7 +2852,7 @@ nseg2:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segsta2_1:
   default: .nan
   type: float
@@ -2863,7 +2863,7 @@ segsta2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segend2_1:
   default: .nan
   type: float
@@ -2874,7 +2874,7 @@ segend2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nseg3:
   default: -1
   type: integer
@@ -2884,7 +2884,7 @@ nseg3:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segsta3_1:
   default: .nan
   type: float
@@ -2895,7 +2895,7 @@ segsta3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segend3_1:
   default: .nan
   type: float
@@ -2906,7 +2906,7 @@ segend3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nseg4:
   default: -1
   type: integer
@@ -2916,7 +2916,7 @@ nseg4:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segsta4_1:
   default: .nan
   type: float
@@ -2927,7 +2927,7 @@ segsta4_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segend4_1:
   default: .nan
   type: float
@@ -2938,7 +2938,7 @@ segend4_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nseg5:
   default: -1
   type: integer
@@ -2948,7 +2948,7 @@ nseg5:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segsta5_1:
   default: .nan
   type: float
@@ -2959,7 +2959,7 @@ segsta5_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segend5_1:
   default: .nan
   type: float
@@ -2970,7 +2970,7 @@ segend5_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nseg6:
   default: -1
   type: integer
@@ -2980,7 +2980,7 @@ nseg6:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segsta6_1:
   default: .nan
   type: float
@@ -2991,7 +2991,7 @@ segsta6_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segend6_1:
   default: .nan
   type: float
@@ -3002,7 +3002,7 @@ segend6_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nseg7:
   default: -1
   type: integer
@@ -3012,7 +3012,7 @@ nseg7:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segsta7_1:
   default: .nan
   type: float
@@ -3023,7 +3023,7 @@ segsta7_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segend7_1:
   default: .nan
   type: float
@@ -3034,7 +3034,7 @@ segend7_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nseg8:
   default: -1
   type: integer
@@ -3044,7 +3044,7 @@ nseg8:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segsta8_1:
   default: .nan
   type: float
@@ -3055,7 +3055,7 @@ segsta8_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segend8_1:
   default: .nan
   type: float
@@ -3066,7 +3066,7 @@ segend8_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nseg9:
   default: -1
   type: integer
@@ -3076,7 +3076,7 @@ nseg9:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segsta9_1:
   default: .nan
   type: float
@@ -3087,7 +3087,7 @@ segsta9_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segend9_1:
   default: .nan
   type: float
@@ -3098,7 +3098,7 @@ segend9_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nseg10:
   default: -1
   type: integer
@@ -3108,7 +3108,7 @@ nseg10:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segsta10_1:
   default: .nan
   type: float
@@ -3119,7 +3119,7 @@ segsta10_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segend10_1:
   default: .nan
   type: float
@@ -3130,7 +3130,7 @@ segend10_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nseg11:
   default: -1
   type: integer
@@ -3140,7 +3140,7 @@ nseg11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segsta11_1:
   default: .nan
   type: float
@@ -3151,7 +3151,7 @@ segsta11_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segend11_1:
   default: .nan
   type: float
@@ -3162,7 +3162,7 @@ segend11_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nseg12:
   default: -1
   type: integer
@@ -3172,7 +3172,7 @@ nseg12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segsta12_1:
   default: .nan
   type: float
@@ -3183,7 +3183,7 @@ segsta12_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segend12_1:
   default: .nan
   type: float
@@ -3194,7 +3194,7 @@ segend12_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nseg13:
   default: -1
   type: integer
@@ -3204,7 +3204,7 @@ nseg13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segsta13_1:
   default: .nan
   type: float
@@ -3215,7 +3215,7 @@ segsta13_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segend13_1:
   default: .nan
   type: float
@@ -3226,7 +3226,7 @@ segend13_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nseg14:
   default: -1
   type: integer
@@ -3236,7 +3236,7 @@ nseg14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segsta14_1:
   default: .nan
   type: float
@@ -3247,7 +3247,7 @@ segsta14_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segend14_1:
   default: .nan
   type: float
@@ -3258,7 +3258,7 @@ segend14_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nseg15:
   default: -1
   type: integer
@@ -3268,7 +3268,7 @@ nseg15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segsta15_1:
   default: .nan
   type: float
@@ -3279,7 +3279,7 @@ segsta15_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segend15_1:
   default: .nan
   type: float
@@ -3290,7 +3290,7 @@ segend15_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nseg16:
   default: -1
   type: integer
@@ -3300,7 +3300,7 @@ nseg16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segsta16_1:
   default: .nan
   type: float
@@ -3311,7 +3311,7 @@ segsta16_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segend16_1:
   default: .nan
   type: float
@@ -3322,7 +3322,7 @@ segend16_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nseg17:
   default: -1
   type: integer
@@ -3332,7 +3332,7 @@ nseg17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segsta17_1:
   default: .nan
   type: float
@@ -3343,7 +3343,7 @@ segsta17_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segend17_1:
   default: .nan
   type: float
@@ -3354,7 +3354,7 @@ segend17_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nseg18:
   default: -1
   type: integer
@@ -3364,7 +3364,7 @@ nseg18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segsta18_1:
   default: .nan
   type: float
@@ -3375,7 +3375,7 @@ segsta18_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segend18_1:
   default: .nan
   type: float
@@ -3386,7 +3386,7 @@ segend18_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nseg19:
   default: -1
   type: integer
@@ -3396,7 +3396,7 @@ nseg19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segsta19_1:
   default: .nan
   type: float
@@ -3407,7 +3407,7 @@ segsta19_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segend19_1:
   default: .nan
   type: float
@@ -3418,7 +3418,7 @@ segend19_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nseg20:
   default: -1
   type: integer
@@ -3428,7 +3428,7 @@ nseg20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segsta20_1:
   default: .nan
   type: float
@@ -3439,7 +3439,7 @@ segsta20_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segend20_1:
   default: .nan
   type: float
@@ -3450,7 +3450,7 @@ segend20_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_air:
   default: 0.1
   type: float
@@ -3461,7 +3461,7 @@ w_air:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_bsa:
   default: -0.01
   type: float
@@ -3472,7 +3472,7 @@ w_bsa:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_cdih:
   default: 0.0
   type: float
@@ -3483,7 +3483,7 @@ w_cdih:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_dani:
   default: 0.1
   type: float
@@ -3494,7 +3494,7 @@ w_dani:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_deint:
   default: 0.0
   type: float
@@ -3505,7 +3505,7 @@ w_deint:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_desolv:
   default: 1.0
   type: float
@@ -3516,7 +3516,7 @@ w_desolv:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_dist:
   default: 0.1
   type: float
@@ -3527,7 +3527,7 @@ w_dist:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_elec:
   default: 1.0
   type: float
@@ -3538,7 +3538,7 @@ w_elec:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_lcc:
   default: -10000.0
   type: float
@@ -3549,7 +3549,7 @@ w_lcc:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_rg:
   default: 1.0
   type: float
@@ -3560,7 +3560,7 @@ w_rg:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_sani:
   default: 0.1
   type: float
@@ -3571,7 +3571,7 @@ w_sani:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_sym:
   default: 0.1
   type: float
@@ -3582,7 +3582,7 @@ w_sym:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_vdw:
   default: 1.0
   type: float
@@ -3593,7 +3593,7 @@ w_vdw:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_vean:
   default: 0.1
   type: float
@@ -3604,7 +3604,7 @@ w_vean:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_xpcs:
   default: 0.1
   type: float
@@ -3615,7 +3615,7 @@ w_xpcs:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_xrdc:
   default: 0.1
   type: float
@@ -3626,7 +3626,7 @@ w_xrdc:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_zres:
   default: 0.1
   type: float
@@ -3637,7 +3637,7 @@ w_zres:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 elecflag:
   default: true
   type: boolean
@@ -3645,7 +3645,7 @@ elecflag:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 dielec:
   default: rdie
   type: string
@@ -3655,7 +3655,7 @@ dielec:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 epsilon:
   default: 1.0
   type: float
@@ -3666,7 +3666,7 @@ epsilon:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 dihedflag:
   default: true
   type: boolean
@@ -3674,7 +3674,7 @@ dihedflag:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 par_nonbonded:
   default: OPLSX
   type: string
@@ -3684,7 +3684,7 @@ par_nonbonded:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_1:
   default: 1.0
   type: float
@@ -3695,7 +3695,7 @@ int_1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_2:
   default: 1.0
   type: float
@@ -3706,7 +3706,7 @@ int_1_2:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_3:
   default: 1.0
   type: float
@@ -3717,7 +3717,7 @@ int_1_3:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_4:
   default: 1.0
   type: float
@@ -3728,7 +3728,7 @@ int_1_4:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_5:
   default: 1.0
   type: float
@@ -3739,7 +3739,7 @@ int_1_5:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_6:
   default: 1.0
   type: float
@@ -3750,7 +3750,7 @@ int_1_6:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_7:
   default: 1.0
   type: float
@@ -3761,7 +3761,7 @@ int_1_7:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_8:
   default: 1.0
   type: float
@@ -3772,7 +3772,7 @@ int_1_8:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_9:
   default: 1.0
   type: float
@@ -3783,7 +3783,7 @@ int_1_9:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_10:
   default: 1.0
   type: float
@@ -3794,7 +3794,7 @@ int_1_10:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_11:
   default: 1.0
   type: float
@@ -3805,7 +3805,7 @@ int_1_11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_12:
   default: 1.0
   type: float
@@ -3816,7 +3816,7 @@ int_1_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_13:
   default: 1.0
   type: float
@@ -3827,7 +3827,7 @@ int_1_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_14:
   default: 1.0
   type: float
@@ -3838,7 +3838,7 @@ int_1_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_15:
   default: 1.0
   type: float
@@ -3849,7 +3849,7 @@ int_1_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_16:
   default: 1.0
   type: float
@@ -3860,7 +3860,7 @@ int_1_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_17:
   default: 1.0
   type: float
@@ -3871,7 +3871,7 @@ int_1_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_18:
   default: 1.0
   type: float
@@ -3882,7 +3882,7 @@ int_1_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_19:
   default: 1.0
   type: float
@@ -3893,7 +3893,7 @@ int_1_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_20:
   default: 1.0
   type: float
@@ -3904,7 +3904,7 @@ int_1_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_2:
   default: 1.0
   type: float
@@ -3915,7 +3915,7 @@ int_2_2:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_3:
   default: 1.0
   type: float
@@ -3926,7 +3926,7 @@ int_2_3:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_4:
   default: 1.0
   type: float
@@ -3937,7 +3937,7 @@ int_2_4:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_5:
   default: 1.0
   type: float
@@ -3948,7 +3948,7 @@ int_2_5:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_6:
   default: 1.0
   type: float
@@ -3959,7 +3959,7 @@ int_2_6:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_7:
   default: 1.0
   type: float
@@ -3970,7 +3970,7 @@ int_2_7:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_8:
   default: 1.0
   type: float
@@ -3981,7 +3981,7 @@ int_2_8:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_9:
   default: 1.0
   type: float
@@ -3992,7 +3992,7 @@ int_2_9:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_10:
   default: 1.0
   type: float
@@ -4003,7 +4003,7 @@ int_2_10:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_11:
   default: 1.0
   type: float
@@ -4014,7 +4014,7 @@ int_2_11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_12:
   default: 1.0
   type: float
@@ -4025,7 +4025,7 @@ int_2_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_13:
   default: 1.0
   type: float
@@ -4036,7 +4036,7 @@ int_2_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_14:
   default: 1.0
   type: float
@@ -4047,7 +4047,7 @@ int_2_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_15:
   default: 1.0
   type: float
@@ -4058,7 +4058,7 @@ int_2_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_16:
   default: 1.0
   type: float
@@ -4069,7 +4069,7 @@ int_2_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_17:
   default: 1.0
   type: float
@@ -4080,7 +4080,7 @@ int_2_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_18:
   default: 1.0
   type: float
@@ -4091,7 +4091,7 @@ int_2_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_19:
   default: 1.0
   type: float
@@ -4102,7 +4102,7 @@ int_2_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_20:
   default: 1.0
   type: float
@@ -4113,7 +4113,7 @@ int_2_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_3:
   default: 1.0
   type: float
@@ -4124,7 +4124,7 @@ int_3_3:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_4:
   default: 1.0
   type: float
@@ -4135,7 +4135,7 @@ int_3_4:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_5:
   default: 1.0
   type: float
@@ -4146,7 +4146,7 @@ int_3_5:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_6:
   default: 1.0
   type: float
@@ -4157,7 +4157,7 @@ int_3_6:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_7:
   default: 1.0
   type: float
@@ -4168,7 +4168,7 @@ int_3_7:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_8:
   default: 1.0
   type: float
@@ -4179,7 +4179,7 @@ int_3_8:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_9:
   default: 1.0
   type: float
@@ -4190,7 +4190,7 @@ int_3_9:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_10:
   default: 1.0
   type: float
@@ -4201,7 +4201,7 @@ int_3_10:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_11:
   default: 1.0
   type: float
@@ -4212,7 +4212,7 @@ int_3_11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_12:
   default: 1.0
   type: float
@@ -4223,7 +4223,7 @@ int_3_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_13:
   default: 1.0
   type: float
@@ -4234,7 +4234,7 @@ int_3_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_14:
   default: 1.0
   type: float
@@ -4245,7 +4245,7 @@ int_3_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_15:
   default: 1.0
   type: float
@@ -4256,7 +4256,7 @@ int_3_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_16:
   default: 1.0
   type: float
@@ -4267,7 +4267,7 @@ int_3_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_17:
   default: 1.0
   type: float
@@ -4278,7 +4278,7 @@ int_3_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_18:
   default: 1.0
   type: float
@@ -4289,7 +4289,7 @@ int_3_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_19:
   default: 1.0
   type: float
@@ -4300,7 +4300,7 @@ int_3_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_20:
   default: 1.0
   type: float
@@ -4311,7 +4311,7 @@ int_3_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_4:
   default: 1.0
   type: float
@@ -4322,7 +4322,7 @@ int_4_4:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_5:
   default: 1.0
   type: float
@@ -4333,7 +4333,7 @@ int_4_5:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_6:
   default: 1.0
   type: float
@@ -4344,7 +4344,7 @@ int_4_6:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_7:
   default: 1.0
   type: float
@@ -4355,7 +4355,7 @@ int_4_7:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_8:
   default: 1.0
   type: float
@@ -4366,7 +4366,7 @@ int_4_8:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_9:
   default: 1.0
   type: float
@@ -4377,7 +4377,7 @@ int_4_9:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_10:
   default: 1.0
   type: float
@@ -4388,7 +4388,7 @@ int_4_10:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_11:
   default: 1.0
   type: float
@@ -4399,7 +4399,7 @@ int_4_11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_12:
   default: 1.0
   type: float
@@ -4410,7 +4410,7 @@ int_4_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_13:
   default: 1.0
   type: float
@@ -4421,7 +4421,7 @@ int_4_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_14:
   default: 1.0
   type: float
@@ -4432,7 +4432,7 @@ int_4_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_15:
   default: 1.0
   type: float
@@ -4443,7 +4443,7 @@ int_4_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_16:
   default: 1.0
   type: float
@@ -4454,7 +4454,7 @@ int_4_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_17:
   default: 1.0
   type: float
@@ -4465,7 +4465,7 @@ int_4_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_18:
   default: 1.0
   type: float
@@ -4476,7 +4476,7 @@ int_4_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_19:
   default: 1.0
   type: float
@@ -4487,7 +4487,7 @@ int_4_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_20:
   default: 1.0
   type: float
@@ -4498,7 +4498,7 @@ int_4_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_5:
   default: 1.0
   type: float
@@ -4509,7 +4509,7 @@ int_5_5:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_6:
   default: 1.0
   type: float
@@ -4520,7 +4520,7 @@ int_5_6:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_7:
   default: 1.0
   type: float
@@ -4531,7 +4531,7 @@ int_5_7:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_8:
   default: 1.0
   type: float
@@ -4542,7 +4542,7 @@ int_5_8:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_9:
   default: 1.0
   type: float
@@ -4553,7 +4553,7 @@ int_5_9:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_10:
   default: 1.0
   type: float
@@ -4564,7 +4564,7 @@ int_5_10:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_11:
   default: 1.0
   type: float
@@ -4575,7 +4575,7 @@ int_5_11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_12:
   default: 1.0
   type: float
@@ -4586,7 +4586,7 @@ int_5_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_13:
   default: 1.0
   type: float
@@ -4597,7 +4597,7 @@ int_5_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_14:
   default: 1.0
   type: float
@@ -4608,7 +4608,7 @@ int_5_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_15:
   default: 1.0
   type: float
@@ -4619,7 +4619,7 @@ int_5_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_16:
   default: 1.0
   type: float
@@ -4630,7 +4630,7 @@ int_5_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_17:
   default: 1.0
   type: float
@@ -4641,7 +4641,7 @@ int_5_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_18:
   default: 1.0
   type: float
@@ -4652,7 +4652,7 @@ int_5_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_19:
   default: 1.0
   type: float
@@ -4663,7 +4663,7 @@ int_5_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_20:
   default: 1.0
   type: float
@@ -4674,7 +4674,7 @@ int_5_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_6_6:
   default: 1.0
   type: float
@@ -4685,7 +4685,7 @@ int_6_6:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_6_7:
   default: 1.0
   type: float
@@ -4696,7 +4696,7 @@ int_6_7:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_6_8:
   default: 1.0
   type: float
@@ -4707,7 +4707,7 @@ int_6_8:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_6_9:
   default: 1.0
   type: float
@@ -4718,7 +4718,7 @@ int_6_9:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_6_10:
   default: 1.0
   type: float
@@ -4729,7 +4729,7 @@ int_6_10:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_6_11:
   default: 1.0
   type: float
@@ -4740,7 +4740,7 @@ int_6_11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_6_12:
   default: 1.0
   type: float
@@ -4751,7 +4751,7 @@ int_6_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_6_13:
   default: 1.0
   type: float
@@ -4762,7 +4762,7 @@ int_6_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_6_14:
   default: 1.0
   type: float
@@ -4773,7 +4773,7 @@ int_6_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_6_15:
   default: 1.0
   type: float
@@ -4784,7 +4784,7 @@ int_6_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_6_16:
   default: 1.0
   type: float
@@ -4795,7 +4795,7 @@ int_6_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_6_17:
   default: 1.0
   type: float
@@ -4806,7 +4806,7 @@ int_6_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_6_18:
   default: 1.0
   type: float
@@ -4817,7 +4817,7 @@ int_6_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_6_19:
   default: 1.0
   type: float
@@ -4828,7 +4828,7 @@ int_6_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_6_20:
   default: 1.0
   type: float
@@ -4839,7 +4839,7 @@ int_6_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_7_7:
   default: 1.0
   type: float
@@ -4850,7 +4850,7 @@ int_7_7:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_7_8:
   default: 1.0
   type: float
@@ -4861,7 +4861,7 @@ int_7_8:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_7_9:
   default: 1.0
   type: float
@@ -4872,7 +4872,7 @@ int_7_9:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_7_10:
   default: 1.0
   type: float
@@ -4883,7 +4883,7 @@ int_7_10:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_7_11:
   default: 1.0
   type: float
@@ -4894,7 +4894,7 @@ int_7_11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_7_12:
   default: 1.0
   type: float
@@ -4905,7 +4905,7 @@ int_7_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_7_13:
   default: 1.0
   type: float
@@ -4916,7 +4916,7 @@ int_7_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_7_14:
   default: 1.0
   type: float
@@ -4927,7 +4927,7 @@ int_7_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_7_15:
   default: 1.0
   type: float
@@ -4938,7 +4938,7 @@ int_7_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_7_16:
   default: 1.0
   type: float
@@ -4949,7 +4949,7 @@ int_7_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_7_17:
   default: 1.0
   type: float
@@ -4960,7 +4960,7 @@ int_7_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_7_18:
   default: 1.0
   type: float
@@ -4971,7 +4971,7 @@ int_7_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_7_19:
   default: 1.0
   type: float
@@ -4982,7 +4982,7 @@ int_7_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_8_8:
   default: 1.0
   type: float
@@ -4993,7 +4993,7 @@ int_8_8:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_8_9:
   default: 1.0
   type: float
@@ -5004,7 +5004,7 @@ int_8_9:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_7_20:
   default: 1.0
   type: float
@@ -5015,7 +5015,7 @@ int_7_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_8_10:
   default: 1.0
   type: float
@@ -5026,7 +5026,7 @@ int_8_10:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_8_11:
   default: 1.0
   type: float
@@ -5037,7 +5037,7 @@ int_8_11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_8_12:
   default: 1.0
   type: float
@@ -5048,7 +5048,7 @@ int_8_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_8_13:
   default: 1.0
   type: float
@@ -5059,7 +5059,7 @@ int_8_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_8_14:
   default: 1.0
   type: float
@@ -5070,7 +5070,7 @@ int_8_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_8_15:
   default: 1.0
   type: float
@@ -5081,7 +5081,7 @@ int_8_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_8_16:
   default: 1.0
   type: float
@@ -5092,7 +5092,7 @@ int_8_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_8_17:
   default: 1.0
   type: float
@@ -5103,7 +5103,7 @@ int_8_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_8_18:
   default: 1.0
   type: float
@@ -5114,7 +5114,7 @@ int_8_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_8_19:
   default: 1.0
   type: float
@@ -5125,7 +5125,7 @@ int_8_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_8_20:
   default: 1.0
   type: float
@@ -5136,7 +5136,7 @@ int_8_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_9_11:
   default: 1.0
   type: float
@@ -5147,7 +5147,7 @@ int_9_11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_9_12:
   default: 1.0
   type: float
@@ -5158,7 +5158,7 @@ int_9_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_9_13:
   default: 1.0
   type: float
@@ -5169,7 +5169,7 @@ int_9_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_9_14:
   default: 1.0
   type: float
@@ -5180,7 +5180,7 @@ int_9_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_9_15:
   default: 1.0
   type: float
@@ -5191,7 +5191,7 @@ int_9_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_9_16:
   default: 1.0
   type: float
@@ -5202,7 +5202,7 @@ int_9_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_9_17:
   default: 1.0
   type: float
@@ -5213,7 +5213,7 @@ int_9_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_9_18:
   default: 1.0
   type: float
@@ -5224,7 +5224,7 @@ int_9_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_9_19:
   default: 1.0
   type: float
@@ -5235,7 +5235,7 @@ int_9_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_9_20:
   default: 1.0
   type: float
@@ -5246,7 +5246,7 @@ int_9_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_9_9:
   default: 1.0
   type: float
@@ -5257,7 +5257,7 @@ int_9_9:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_9_10:
   default: 1.0
   type: float
@@ -5268,7 +5268,7 @@ int_9_10:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_10_10:
   default: 1.0
   type: float
@@ -5279,7 +5279,7 @@ int_10_10:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_10_11:
   default: 1.0
   type: float
@@ -5290,7 +5290,7 @@ int_10_11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_10_12:
   default: 1.0
   type: float
@@ -5301,7 +5301,7 @@ int_10_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_10_13:
   default: 1.0
   type: float
@@ -5312,7 +5312,7 @@ int_10_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_10_14:
   default: 1.0
   type: float
@@ -5323,7 +5323,7 @@ int_10_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_10_15:
   default: 1.0
   type: float
@@ -5334,7 +5334,7 @@ int_10_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_10_16:
   default: 1.0
   type: float
@@ -5345,7 +5345,7 @@ int_10_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_10_17:
   default: 1.0
   type: float
@@ -5356,7 +5356,7 @@ int_10_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_10_18:
   default: 1.0
   type: float
@@ -5367,7 +5367,7 @@ int_10_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_10_19:
   default: 1.0
   type: float
@@ -5378,7 +5378,7 @@ int_10_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_10_20:
   default: 1.0
   type: float
@@ -5389,7 +5389,7 @@ int_10_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_11_11:
   default: 1.0
   type: float
@@ -5400,7 +5400,7 @@ int_11_11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_11_12:
   default: 1.0
   type: float
@@ -5411,7 +5411,7 @@ int_11_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_11_13:
   default: 1.0
   type: float
@@ -5422,7 +5422,7 @@ int_11_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_11_14:
   default: 1.0
   type: float
@@ -5433,7 +5433,7 @@ int_11_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_11_15:
   default: 1.0
   type: float
@@ -5444,7 +5444,7 @@ int_11_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_11_16:
   default: 1.0
   type: float
@@ -5455,7 +5455,7 @@ int_11_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_11_17:
   default: 1.0
   type: float
@@ -5466,7 +5466,7 @@ int_11_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_11_18:
   default: 1.0
   type: float
@@ -5477,7 +5477,7 @@ int_11_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_11_19:
   default: 1.0
   type: float
@@ -5488,7 +5488,7 @@ int_11_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_11_20:
   default: 1.0
   type: float
@@ -5499,7 +5499,7 @@ int_11_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_12_12:
   default: 1.0
   type: float
@@ -5510,7 +5510,7 @@ int_12_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_12_13:
   default: 1.0
   type: float
@@ -5521,7 +5521,7 @@ int_12_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_12_14:
   default: 1.0
   type: float
@@ -5532,7 +5532,7 @@ int_12_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_12_15:
   default: 1.0
   type: float
@@ -5543,7 +5543,7 @@ int_12_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_12_16:
   default: 1.0
   type: float
@@ -5554,7 +5554,7 @@ int_12_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_12_17:
   default: 1.0
   type: float
@@ -5565,7 +5565,7 @@ int_12_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_12_18:
   default: 1.0
   type: float
@@ -5576,7 +5576,7 @@ int_12_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_12_19:
   default: 1.0
   type: float
@@ -5587,7 +5587,7 @@ int_12_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_12_20:
   default: 1.0
   type: float
@@ -5598,7 +5598,7 @@ int_12_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_13_13:
   default: 1.0
   type: float
@@ -5609,7 +5609,7 @@ int_13_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_13_14:
   default: 1.0
   type: float
@@ -5620,7 +5620,7 @@ int_13_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_13_15:
   default: 1.0
   type: float
@@ -5631,7 +5631,7 @@ int_13_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_13_16:
   default: 1.0
   type: float
@@ -5642,7 +5642,7 @@ int_13_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_13_17:
   default: 1.0
   type: float
@@ -5653,7 +5653,7 @@ int_13_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_13_18:
   default: 1.0
   type: float
@@ -5664,7 +5664,7 @@ int_13_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_13_19:
   default: 1.0
   type: float
@@ -5675,7 +5675,7 @@ int_13_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_13_20:
   default: 1.0
   type: float
@@ -5686,7 +5686,7 @@ int_13_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_14_14:
   default: 1.0
   type: float
@@ -5697,7 +5697,7 @@ int_14_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_14_15:
   default: 1.0
   type: float
@@ -5708,7 +5708,7 @@ int_14_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_14_16:
   default: 1.0
   type: float
@@ -5719,7 +5719,7 @@ int_14_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_14_17:
   default: 1.0
   type: float
@@ -5730,7 +5730,7 @@ int_14_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_14_18:
   default: 1.0
   type: float
@@ -5741,7 +5741,7 @@ int_14_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_14_19:
   default: 1.0
   type: float
@@ -5752,7 +5752,7 @@ int_14_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_14_20:
   default: 1.0
   type: float
@@ -5763,7 +5763,7 @@ int_14_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_15_15:
   default: 1.0
   type: float
@@ -5774,7 +5774,7 @@ int_15_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_15_16:
   default: 1.0
   type: float
@@ -5785,7 +5785,7 @@ int_15_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_15_17:
   default: 1.0
   type: float
@@ -5796,7 +5796,7 @@ int_15_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_15_18:
   default: 1.0
   type: float
@@ -5807,7 +5807,7 @@ int_15_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_15_19:
   default: 1.0
   type: float
@@ -5818,7 +5818,7 @@ int_15_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_15_20:
   default: 1.0
   type: float
@@ -5829,7 +5829,7 @@ int_15_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_16_16:
   default: 1.0
   type: float
@@ -5840,7 +5840,7 @@ int_16_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_16_17:
   default: 1.0
   type: float
@@ -5851,7 +5851,7 @@ int_16_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_16_18:
   default: 1.0
   type: float
@@ -5862,7 +5862,7 @@ int_16_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_16_19:
   default: 1.0
   type: float
@@ -5873,7 +5873,7 @@ int_16_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_16_20:
   default: 1.0
   type: float
@@ -5884,7 +5884,7 @@ int_16_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_17_17:
   default: 1.0
   type: float
@@ -5895,7 +5895,7 @@ int_17_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_17_18:
   default: 1.0
   type: float
@@ -5906,7 +5906,7 @@ int_17_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_17_19:
   default: 1.0
   type: float
@@ -5917,7 +5917,7 @@ int_17_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_17_20:
   default: 1.0
   type: float
@@ -5928,7 +5928,7 @@ int_17_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_18_18:
   default: 1.0
   type: float
@@ -5939,7 +5939,7 @@ int_18_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_18_19:
   default: 1.0
   type: float
@@ -5950,7 +5950,7 @@ int_18_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_18_20:
   default: 1.0
   type: float
@@ -5961,7 +5961,7 @@ int_18_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_19_19:
   default: 1.0
   type: float
@@ -5972,7 +5972,7 @@ int_19_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_19_20:
   default: 1.0
   type: float
@@ -5983,7 +5983,7 @@ int_19_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_20_20:
   default: 1.0
   type: float
@@ -5994,4 +5994,4 @@ int_20_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy

--- a/src/haddock/modules/refinement/mdref/defaults.yaml
+++ b/src/haddock/modules/refinement/mdref/defaults.yaml
@@ -7,7 +7,7 @@ tolerance:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 log_level:
   default: verbose
   type: string
@@ -17,7 +17,7 @@ log_level:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ambig_fname:
   default: ''
   type: file
@@ -25,7 +25,7 @@ ambig_fname:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 unambig_fname:
   default: ''
   type: file
@@ -33,7 +33,7 @@ unambig_fname:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 dihe_fname:
   default: ''
   type: file
@@ -41,7 +41,7 @@ dihe_fname:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 hbond_fname:
   default: ''
   type: file
@@ -49,7 +49,7 @@ hbond_fname:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ligand_param_fname:
   default: ''
   type: file
@@ -57,7 +57,7 @@ ligand_param_fname:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ligand_top_fname:
   default: ''
   type: file
@@ -65,7 +65,7 @@ ligand_top_fname:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 sampling_factor:
   default: 1
   type: integer
@@ -75,7 +75,7 @@ sampling_factor:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 iniseed:
   default: 917
   type: integer
@@ -85,7 +85,7 @@ iniseed:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 keepwater:
   default: false
   type: boolean
@@ -93,7 +93,7 @@ keepwater:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 solvent:
   default: water
   type: string
@@ -103,7 +103,7 @@ solvent:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 timestep:
   default: 0.002
   type: float
@@ -114,7 +114,7 @@ timestep:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 waterheatsteps:
   default: 100
   type: integer
@@ -124,7 +124,7 @@ waterheatsteps:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 watersteps:
   default: 1250
   type: integer
@@ -134,7 +134,7 @@ watersteps:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 watercoolsteps:
   default: 500
   type: integer
@@ -144,7 +144,7 @@ watercoolsteps:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_1:
   default: A
   type: string
@@ -154,7 +154,7 @@ prot_segid_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_2:
   default: B
   type: string
@@ -164,7 +164,7 @@ prot_segid_2:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_3:
   default: C
   type: string
@@ -174,7 +174,7 @@ prot_segid_3:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_4:
   default: D
   type: string
@@ -184,7 +184,7 @@ prot_segid_4:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_5:
   default: E
   type: string
@@ -194,7 +194,7 @@ prot_segid_5:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_6:
   default: F
   type: string
@@ -204,7 +204,7 @@ prot_segid_6:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_7:
   default: G
   type: string
@@ -214,7 +214,7 @@ prot_segid_7:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_8:
   default: H
   type: string
@@ -224,7 +224,7 @@ prot_segid_8:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_9:
   default: I
   type: string
@@ -234,7 +234,7 @@ prot_segid_9:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_10:
   default: J
   type: string
@@ -244,7 +244,7 @@ prot_segid_10:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_11:
   default: K
   type: string
@@ -254,7 +254,7 @@ prot_segid_11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_12:
   default: L
   type: string
@@ -264,7 +264,7 @@ prot_segid_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_13:
   default: M
   type: string
@@ -274,7 +274,7 @@ prot_segid_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_14:
   default: N
   type: string
@@ -284,7 +284,7 @@ prot_segid_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_15:
   default: O
   type: string
@@ -294,7 +294,7 @@ prot_segid_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_16:
   default: P
   type: string
@@ -304,7 +304,7 @@ prot_segid_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_17:
   default: Q
   type: string
@@ -314,7 +314,7 @@ prot_segid_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_18:
   default: R
   type: string
@@ -324,7 +324,7 @@ prot_segid_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_19:
   default: S
   type: string
@@ -334,7 +334,7 @@ prot_segid_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_20:
   default: T
   type: string
@@ -344,7 +344,7 @@ prot_segid_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_1:
   default: false
   type: boolean
@@ -352,7 +352,7 @@ shape_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_2:
   default: false
   type: boolean
@@ -360,7 +360,7 @@ shape_2:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_3:
   default: false
   type: boolean
@@ -368,7 +368,7 @@ shape_3:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_4:
   default: false
   type: boolean
@@ -376,7 +376,7 @@ shape_4:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_5:
   default: false
   type: boolean
@@ -384,7 +384,7 @@ shape_5:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_6:
   default: false
   type: boolean
@@ -392,7 +392,7 @@ shape_6:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_7:
   default: false
   type: boolean
@@ -400,7 +400,7 @@ shape_7:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_8:
   default: false
   type: boolean
@@ -408,7 +408,7 @@ shape_8:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_9:
   default: false
   type: boolean
@@ -416,7 +416,7 @@ shape_9:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_10:
   default: false
   type: boolean
@@ -424,7 +424,7 @@ shape_10:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_11:
   default: false
   type: boolean
@@ -432,7 +432,7 @@ shape_11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_12:
   default: false
   type: boolean
@@ -440,7 +440,7 @@ shape_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_13:
   default: false
   type: boolean
@@ -448,7 +448,7 @@ shape_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_14:
   default: false
   type: boolean
@@ -456,7 +456,7 @@ shape_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_15:
   default: false
   type: boolean
@@ -464,7 +464,7 @@ shape_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_16:
   default: false
   type: boolean
@@ -472,7 +472,7 @@ shape_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_17:
   default: false
   type: boolean
@@ -480,7 +480,7 @@ shape_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_18:
   default: false
   type: boolean
@@ -488,7 +488,7 @@ shape_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_19:
   default: false
   type: boolean
@@ -496,7 +496,7 @@ shape_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_20:
   default: false
   type: boolean
@@ -504,7 +504,7 @@ shape_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 amb_scale:
   default: 50
   type: integer
@@ -514,7 +514,7 @@ amb_scale:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 unamb_scale:
   default: 50
   type: integer
@@ -524,7 +524,7 @@ unamb_scale:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 hbond_scale:
   default: 50
   type: integer
@@ -534,7 +534,7 @@ hbond_scale:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 hbonds_on:
   default: false
   type: boolean
@@ -542,7 +542,7 @@ hbonds_on:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 noecv:
   default: false
   type: boolean
@@ -550,7 +550,7 @@ noecv:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ncvpart:
   default: 2
   type: integer
@@ -560,7 +560,7 @@ ncvpart:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 cmrest:
   default: false
   type: boolean
@@ -568,7 +568,7 @@ cmrest:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 cmtight:
   default: false
   type: boolean
@@ -576,7 +576,7 @@ cmtight:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ranair:
   default: false
   type: boolean
@@ -584,7 +584,7 @@ ranair:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 kcont:
   default: 1.0
   type: float
@@ -595,7 +595,7 @@ kcont:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ksurf:
   default: 1.0
   type: float
@@ -606,7 +606,7 @@ ksurf:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 surfrest:
   default: false
   type: boolean
@@ -614,7 +614,7 @@ surfrest:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 dihedrals_scale:
   default: 200
   type: integer
@@ -624,7 +624,7 @@ dihedrals_scale:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 dihedrals_on:
   default: false
   type: boolean
@@ -632,7 +632,7 @@ dihedrals_on:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ssdihed:
   default: none
   type: string
@@ -642,7 +642,7 @@ ssdihed:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 error_dih:
   default: 10
   type: integer
@@ -652,7 +652,7 @@ error_dih:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 dnarest_on:
   default: false
   type: boolean
@@ -660,7 +660,7 @@ dnarest_on:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 sym_on:
   default: false
   type: boolean
@@ -668,7 +668,7 @@ sym_on:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ksym:
   default: 10.0
   type: float
@@ -679,7 +679,7 @@ ksym:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 numc2sym:
   default: 0
   type: integer
@@ -689,7 +689,7 @@ numc2sym:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c2sym_sta1_1:
   default: .nan
   type: float
@@ -700,7 +700,7 @@ c2sym_sta1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c2sym_end1_1:
   default: .nan
   type: float
@@ -711,7 +711,7 @@ c2sym_end1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c2sym_seg1_1:
   default: ''
   type: string
@@ -721,7 +721,7 @@ c2sym_seg1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c2sym_sta2_1:
   default: .nan
   type: float
@@ -732,7 +732,7 @@ c2sym_sta2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c2sym_end2_1:
   default: .nan
   type: float
@@ -743,7 +743,7 @@ c2sym_end2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c2sym_seg2_1:
   default: ''
   type: string
@@ -753,7 +753,7 @@ c2sym_seg2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 numc3sym:
   default: 0
   type: integer
@@ -763,7 +763,7 @@ numc3sym:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c3sym_sta1_1:
   default: .nan
   type: float
@@ -774,7 +774,7 @@ c3sym_sta1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c3sym_end1_1:
   default: .nan
   type: float
@@ -785,7 +785,7 @@ c3sym_end1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c3sym_seg1_1:
   default: ''
   type: string
@@ -795,7 +795,7 @@ c3sym_seg1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c3sym_sta2_1:
   default: .nan
   type: float
@@ -806,7 +806,7 @@ c3sym_sta2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c3sym_end2_1:
   default: .nan
   type: float
@@ -817,7 +817,7 @@ c3sym_end2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c3sym_seg2_1:
   default: ''
   type: string
@@ -827,7 +827,7 @@ c3sym_seg2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c3sym_sta3_1:
   default: .nan
   type: float
@@ -838,7 +838,7 @@ c3sym_sta3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c3sym_end3_1:
   default: .nan
   type: float
@@ -849,7 +849,7 @@ c3sym_end3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c3sym_seg3_1:
   default: ''
   type: string
@@ -859,7 +859,7 @@ c3sym_seg3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 numc4sym:
   default: 0
   type: integer
@@ -869,7 +869,7 @@ numc4sym:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c4sym_sta1_1:
   default: .nan
   type: float
@@ -880,7 +880,7 @@ c4sym_sta1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c4sym_end1_1:
   default: .nan
   type: float
@@ -891,7 +891,7 @@ c4sym_end1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c4sym_seg1_1:
   default: ''
   type: string
@@ -901,7 +901,7 @@ c4sym_seg1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c4sym_sta2_1:
   default: .nan
   type: float
@@ -912,7 +912,7 @@ c4sym_sta2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c4sym_end2_1:
   default: .nan
   type: float
@@ -923,7 +923,7 @@ c4sym_end2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c4sym_seg2_1:
   default: ''
   type: string
@@ -933,7 +933,7 @@ c4sym_seg2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c4sym_sta3_1:
   default: .nan
   type: float
@@ -944,7 +944,7 @@ c4sym_sta3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c4sym_end3_1:
   default: .nan
   type: float
@@ -955,7 +955,7 @@ c4sym_end3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c4sym_seg3_1:
   default: ''
   type: string
@@ -965,7 +965,7 @@ c4sym_seg3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c4sym_sta4_1:
   default: .nan
   type: float
@@ -976,7 +976,7 @@ c4sym_sta4_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c4sym_end4_1:
   default: .nan
   type: float
@@ -987,7 +987,7 @@ c4sym_end4_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c4sym_seg4_1:
   default: ''
   type: string
@@ -997,7 +997,7 @@ c4sym_seg4_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 numc5sym:
   default: 0
   type: integer
@@ -1007,7 +1007,7 @@ numc5sym:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c5sym_sta1_1:
   default: .nan
   type: float
@@ -1018,7 +1018,7 @@ c5sym_sta1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c5sym_end1_1:
   default: .nan
   type: float
@@ -1029,7 +1029,7 @@ c5sym_end1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c5sym_seg1_1:
   default: ''
   type: string
@@ -1039,7 +1039,7 @@ c5sym_seg1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c5sym_sta2_1:
   default: .nan
   type: float
@@ -1050,7 +1050,7 @@ c5sym_sta2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c5sym_end2_1:
   default: .nan
   type: float
@@ -1061,7 +1061,7 @@ c5sym_end2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c5sym_seg2_1:
   default: ''
   type: string
@@ -1071,7 +1071,7 @@ c5sym_seg2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c5sym_sta3_1:
   default: .nan
   type: float
@@ -1082,7 +1082,7 @@ c5sym_sta3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c5sym_end3_1:
   default: .nan
   type: float
@@ -1093,7 +1093,7 @@ c5sym_end3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c5sym_seg3_1:
   default: ''
   type: string
@@ -1103,7 +1103,7 @@ c5sym_seg3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c5sym_sta4_1:
   default: .nan
   type: float
@@ -1114,7 +1114,7 @@ c5sym_sta4_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c5sym_end4_1:
   default: .nan
   type: float
@@ -1125,7 +1125,7 @@ c5sym_end4_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c5sym_seg4_1:
   default: ''
   type: string
@@ -1135,7 +1135,7 @@ c5sym_seg4_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c5sym_sta5_1:
   default: .nan
   type: float
@@ -1146,7 +1146,7 @@ c5sym_sta5_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c5sym_end5_1:
   default: .nan
   type: float
@@ -1157,7 +1157,7 @@ c5sym_end5_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c5sym_seg5_1:
   default: ''
   type: string
@@ -1167,7 +1167,7 @@ c5sym_seg5_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 numc6sym:
   default: 0
   type: integer
@@ -1177,7 +1177,7 @@ numc6sym:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_sta1_1:
   default: .nan
   type: float
@@ -1188,7 +1188,7 @@ c6sym_sta1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_end1_1:
   default: .nan
   type: float
@@ -1199,7 +1199,7 @@ c6sym_end1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_seg1_1:
   default: ''
   type: string
@@ -1209,7 +1209,7 @@ c6sym_seg1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_sta2_1:
   default: .nan
   type: float
@@ -1220,7 +1220,7 @@ c6sym_sta2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_end2_1:
   default: .nan
   type: float
@@ -1231,7 +1231,7 @@ c6sym_end2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_seg2_1:
   default: ''
   type: string
@@ -1241,7 +1241,7 @@ c6sym_seg2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_sta3_1:
   default: .nan
   type: float
@@ -1252,7 +1252,7 @@ c6sym_sta3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_end3_1:
   default: .nan
   type: float
@@ -1263,7 +1263,7 @@ c6sym_end3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_seg3_1:
   default: ''
   type: string
@@ -1273,7 +1273,7 @@ c6sym_seg3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_sta4_1:
   default: .nan
   type: float
@@ -1284,7 +1284,7 @@ c6sym_sta4_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_end4_1:
   default: .nan
   type: float
@@ -1295,7 +1295,7 @@ c6sym_end4_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_seg4_1:
   default: ''
   type: string
@@ -1305,7 +1305,7 @@ c6sym_seg4_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_sta5_1:
   default: .nan
   type: float
@@ -1316,7 +1316,7 @@ c6sym_sta5_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_end5_1:
   default: .nan
   type: float
@@ -1327,7 +1327,7 @@ c6sym_end5_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_seg5_1:
   default: ''
   type: string
@@ -1337,7 +1337,7 @@ c6sym_seg5_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_sta6_1:
   default: .nan
   type: float
@@ -1348,7 +1348,7 @@ c6sym_sta6_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_end6_1:
   default: .nan
   type: float
@@ -1359,7 +1359,7 @@ c6sym_end6_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_seg6_1:
   default: ''
   type: string
@@ -1369,7 +1369,7 @@ c6sym_seg6_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nums3sym:
   default: 0
   type: integer
@@ -1379,7 +1379,7 @@ nums3sym:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 s3sym_sta1_1:
   default: .nan
   type: float
@@ -1390,7 +1390,7 @@ s3sym_sta1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 s3sym_end1_1:
   default: .nan
   type: float
@@ -1401,7 +1401,7 @@ s3sym_end1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 s3sym_seg1_1:
   default: ''
   type: string
@@ -1411,7 +1411,7 @@ s3sym_seg1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 s3sym_sta2_1:
   default: .nan
   type: float
@@ -1422,7 +1422,7 @@ s3sym_sta2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 s3sym_end2_1:
   default: .nan
   type: float
@@ -1433,7 +1433,7 @@ s3sym_end2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 s3sym_seg2_1:
   default: ''
   type: string
@@ -1443,7 +1443,7 @@ s3sym_seg2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 s3sym_sta3_1:
   default: .nan
   type: float
@@ -1454,7 +1454,7 @@ s3sym_sta3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 s3sym_end3_1:
   default: .nan
   type: float
@@ -1465,7 +1465,7 @@ s3sym_end3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 s3sym_seg3_1:
   default: ''
   type: string
@@ -1475,7 +1475,7 @@ s3sym_seg3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ncs_on:
   default: false
   type: boolean
@@ -1483,7 +1483,7 @@ ncs_on:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 kncs:
   default: 1.0
   type: float
@@ -1494,7 +1494,7 @@ kncs:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 numncs:
   default: 0
   type: integer
@@ -1504,7 +1504,7 @@ numncs:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ncs_sta1_1:
   default: .nan
   type: float
@@ -1515,7 +1515,7 @@ ncs_sta1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ncs_end1_1:
   default: .nan
   type: float
@@ -1526,7 +1526,7 @@ ncs_end1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ncs_seg1_1:
   default: ''
   type: string
@@ -1536,7 +1536,7 @@ ncs_seg1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ncs_sta2_1:
   default: .nan
   type: float
@@ -1547,7 +1547,7 @@ ncs_sta2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ncs_end2_1:
   default: .nan
   type: float
@@ -1558,7 +1558,7 @@ ncs_end2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ncs_seg2_1:
   default: ''
   type: string
@@ -1568,7 +1568,7 @@ ncs_seg2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_1:
   default: false
   type: boolean
@@ -1576,7 +1576,7 @@ fix_origin_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_2:
   default: false
   type: boolean
@@ -1584,7 +1584,7 @@ fix_origin_2:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_3:
   default: false
   type: boolean
@@ -1592,7 +1592,7 @@ fix_origin_3:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_4:
   default: false
   type: boolean
@@ -1600,7 +1600,7 @@ fix_origin_4:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_5:
   default: false
   type: boolean
@@ -1608,7 +1608,7 @@ fix_origin_5:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_6:
   default: false
   type: boolean
@@ -1616,7 +1616,7 @@ fix_origin_6:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_7:
   default: false
   type: boolean
@@ -1624,7 +1624,7 @@ fix_origin_7:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_8:
   default: false
   type: boolean
@@ -1632,7 +1632,7 @@ fix_origin_8:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_9:
   default: false
   type: boolean
@@ -1640,7 +1640,7 @@ fix_origin_9:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_10:
   default: false
   type: boolean
@@ -1648,7 +1648,7 @@ fix_origin_10:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_11:
   default: false
   type: boolean
@@ -1656,7 +1656,7 @@ fix_origin_11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_12:
   default: false
   type: boolean
@@ -1664,7 +1664,7 @@ fix_origin_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_13:
   default: false
   type: boolean
@@ -1672,7 +1672,7 @@ fix_origin_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_14:
   default: false
   type: boolean
@@ -1680,7 +1680,7 @@ fix_origin_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_15:
   default: false
   type: boolean
@@ -1688,7 +1688,7 @@ fix_origin_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_16:
   default: false
   type: boolean
@@ -1696,7 +1696,7 @@ fix_origin_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_17:
   default: false
   type: boolean
@@ -1704,7 +1704,7 @@ fix_origin_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_18:
   default: false
   type: boolean
@@ -1712,7 +1712,7 @@ fix_origin_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_19:
   default: false
   type: boolean
@@ -1720,7 +1720,7 @@ fix_origin_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_20:
   default: false
   type: boolean
@@ -1728,7 +1728,7 @@ fix_origin_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nfle1:
   default: 0
   type: integer
@@ -1738,7 +1738,7 @@ nfle1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 flesta1_1:
   default: .nan
   type: float
@@ -1749,7 +1749,7 @@ flesta1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fleend1_1:
   default: .nan
   type: float
@@ -1760,7 +1760,7 @@ fleend1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nfle2:
   default: 0
   type: integer
@@ -1770,7 +1770,7 @@ nfle2:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 flesta2_1:
   default: .nan
   type: float
@@ -1781,7 +1781,7 @@ flesta2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fleend2_1:
   default: .nan
   type: float
@@ -1792,7 +1792,7 @@ fleend2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nfle3:
   default: 0
   type: integer
@@ -1802,7 +1802,7 @@ nfle3:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 flesta3_1:
   default: .nan
   type: float
@@ -1813,7 +1813,7 @@ flesta3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fleend3_1:
   default: .nan
   type: float
@@ -1824,7 +1824,7 @@ fleend3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nfle4:
   default: 0
   type: integer
@@ -1834,7 +1834,7 @@ nfle4:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 flesta4_1:
   default: .nan
   type: float
@@ -1845,7 +1845,7 @@ flesta4_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fleend4_1:
   default: .nan
   type: float
@@ -1856,7 +1856,7 @@ fleend4_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nfle5:
   default: 0
   type: integer
@@ -1866,7 +1866,7 @@ nfle5:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 flesta5_1:
   default: .nan
   type: float
@@ -1877,7 +1877,7 @@ flesta5_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fleend5_1:
   default: .nan
   type: float
@@ -1888,7 +1888,7 @@ fleend5_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nfle6:
   default: 0
   type: integer
@@ -1898,7 +1898,7 @@ nfle6:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 flesta6_1:
   default: .nan
   type: float
@@ -1909,7 +1909,7 @@ flesta6_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fleend6_1:
   default: .nan
   type: float
@@ -1920,7 +1920,7 @@ fleend6_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nfle7:
   default: 0
   type: integer
@@ -1930,7 +1930,7 @@ nfle7:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 flesta7_1:
   default: .nan
   type: float
@@ -1941,7 +1941,7 @@ flesta7_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fleend7_1:
   default: .nan
   type: float
@@ -1952,7 +1952,7 @@ fleend7_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nfle8:
   default: 0
   type: integer
@@ -1962,7 +1962,7 @@ nfle8:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 flesta8_1:
   default: .nan
   type: float
@@ -1973,7 +1973,7 @@ flesta8_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fleend8_1:
   default: .nan
   type: float
@@ -1984,7 +1984,7 @@ fleend8_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nfle9:
   default: 0
   type: integer
@@ -1994,7 +1994,7 @@ nfle9:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 flesta9_1:
   default: .nan
   type: float
@@ -2005,7 +2005,7 @@ flesta9_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fleend9_1:
   default: .nan
   type: float
@@ -2016,7 +2016,7 @@ fleend9_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nfle10:
   default: 0
   type: integer
@@ -2026,7 +2026,7 @@ nfle10:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 flesta10_1:
   default: .nan
   type: float
@@ -2037,7 +2037,7 @@ flesta10_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fleend10_1:
   default: .nan
   type: float
@@ -2048,7 +2048,7 @@ fleend10_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nfle11:
   default: 0
   type: integer
@@ -2058,7 +2058,7 @@ nfle11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 flesta11_1:
   default: .nan
   type: float
@@ -2069,7 +2069,7 @@ flesta11_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fleend11_1:
   default: .nan
   type: float
@@ -2080,7 +2080,7 @@ fleend11_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nfle12:
   default: 0
   type: integer
@@ -2090,7 +2090,7 @@ nfle12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 flesta12_1:
   default: .nan
   type: float
@@ -2101,7 +2101,7 @@ flesta12_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fleend12_1:
   default: .nan
   type: float
@@ -2112,7 +2112,7 @@ fleend12_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nfle13:
   default: 0
   type: integer
@@ -2122,7 +2122,7 @@ nfle13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 flesta13_1:
   default: .nan
   type: float
@@ -2133,7 +2133,7 @@ flesta13_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fleend13_1:
   default: .nan
   type: float
@@ -2144,7 +2144,7 @@ fleend13_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nfle14:
   default: 0
   type: integer
@@ -2154,7 +2154,7 @@ nfle14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 flesta14_1:
   default: .nan
   type: float
@@ -2165,7 +2165,7 @@ flesta14_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fleend14_1:
   default: .nan
   type: float
@@ -2176,7 +2176,7 @@ fleend14_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nfle15:
   default: 0
   type: integer
@@ -2186,7 +2186,7 @@ nfle15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 flesta15_1:
   default: .nan
   type: float
@@ -2197,7 +2197,7 @@ flesta15_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fleend15_1:
   default: .nan
   type: float
@@ -2208,7 +2208,7 @@ fleend15_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nfle16:
   default: 0
   type: integer
@@ -2218,7 +2218,7 @@ nfle16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 flesta16_1:
   default: .nan
   type: float
@@ -2229,7 +2229,7 @@ flesta16_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fleend16_1:
   default: .nan
   type: float
@@ -2240,7 +2240,7 @@ fleend16_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nfle17:
   default: 0
   type: integer
@@ -2250,7 +2250,7 @@ nfle17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 flesta17_1:
   default: .nan
   type: float
@@ -2261,7 +2261,7 @@ flesta17_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fleend17_1:
   default: .nan
   type: float
@@ -2272,7 +2272,7 @@ fleend17_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nfle18:
   default: 0
   type: integer
@@ -2282,7 +2282,7 @@ nfle18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 flesta18_1:
   default: .nan
   type: float
@@ -2293,7 +2293,7 @@ flesta18_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fleend18_1:
   default: .nan
   type: float
@@ -2304,7 +2304,7 @@ fleend18_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nfle19:
   default: 0
   type: integer
@@ -2314,7 +2314,7 @@ nfle19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 flesta19_1:
   default: .nan
   type: float
@@ -2325,7 +2325,7 @@ flesta19_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fleend19_1:
   default: .nan
   type: float
@@ -2336,7 +2336,7 @@ fleend19_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nfle20:
   default: 0
   type: integer
@@ -2346,7 +2346,7 @@ nfle20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 flesta20_1:
   default: .nan
   type: float
@@ -2357,7 +2357,7 @@ flesta20_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fleend20_1:
   default: .nan
   type: float
@@ -2368,7 +2368,7 @@ fleend20_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nseg1:
   default: -1
   type: integer
@@ -2378,7 +2378,7 @@ nseg1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segsta1_1:
   default: .nan
   type: float
@@ -2389,7 +2389,7 @@ segsta1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segend1_1:
   default: .nan
   type: float
@@ -2400,7 +2400,7 @@ segend1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nseg2:
   default: -1
   type: integer
@@ -2410,7 +2410,7 @@ nseg2:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segsta2_1:
   default: .nan
   type: float
@@ -2421,7 +2421,7 @@ segsta2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segend2_1:
   default: .nan
   type: float
@@ -2432,7 +2432,7 @@ segend2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nseg3:
   default: -1
   type: integer
@@ -2442,7 +2442,7 @@ nseg3:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segsta3_1:
   default: .nan
   type: float
@@ -2453,7 +2453,7 @@ segsta3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segend3_1:
   default: .nan
   type: float
@@ -2464,7 +2464,7 @@ segend3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nseg4:
   default: -1
   type: integer
@@ -2474,7 +2474,7 @@ nseg4:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segsta4_1:
   default: .nan
   type: float
@@ -2485,7 +2485,7 @@ segsta4_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segend4_1:
   default: .nan
   type: float
@@ -2496,7 +2496,7 @@ segend4_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nseg5:
   default: -1
   type: integer
@@ -2506,7 +2506,7 @@ nseg5:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segsta5_1:
   default: .nan
   type: float
@@ -2517,7 +2517,7 @@ segsta5_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segend5_1:
   default: .nan
   type: float
@@ -2528,7 +2528,7 @@ segend5_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nseg6:
   default: -1
   type: integer
@@ -2538,7 +2538,7 @@ nseg6:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segsta6_1:
   default: .nan
   type: float
@@ -2549,7 +2549,7 @@ segsta6_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segend6_1:
   default: .nan
   type: float
@@ -2560,7 +2560,7 @@ segend6_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nseg7:
   default: -1
   type: integer
@@ -2570,7 +2570,7 @@ nseg7:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segsta7_1:
   default: .nan
   type: float
@@ -2581,7 +2581,7 @@ segsta7_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segend7_1:
   default: .nan
   type: float
@@ -2592,7 +2592,7 @@ segend7_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nseg8:
   default: -1
   type: integer
@@ -2602,7 +2602,7 @@ nseg8:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segsta8_1:
   default: .nan
   type: float
@@ -2613,7 +2613,7 @@ segsta8_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segend8_1:
   default: .nan
   type: float
@@ -2624,7 +2624,7 @@ segend8_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nseg9:
   default: -1
   type: integer
@@ -2634,7 +2634,7 @@ nseg9:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segsta9_1:
   default: .nan
   type: float
@@ -2645,7 +2645,7 @@ segsta9_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segend9_1:
   default: .nan
   type: float
@@ -2656,7 +2656,7 @@ segend9_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nseg10:
   default: -1
   type: integer
@@ -2666,7 +2666,7 @@ nseg10:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segsta10_1:
   default: .nan
   type: float
@@ -2677,7 +2677,7 @@ segsta10_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segend10_1:
   default: .nan
   type: float
@@ -2688,7 +2688,7 @@ segend10_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nseg11:
   default: -1
   type: integer
@@ -2698,7 +2698,7 @@ nseg11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segsta11_1:
   default: .nan
   type: float
@@ -2709,7 +2709,7 @@ segsta11_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segend11_1:
   default: .nan
   type: float
@@ -2720,7 +2720,7 @@ segend11_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nseg12:
   default: -1
   type: integer
@@ -2730,7 +2730,7 @@ nseg12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segsta12_1:
   default: .nan
   type: float
@@ -2741,7 +2741,7 @@ segsta12_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segend12_1:
   default: .nan
   type: float
@@ -2752,7 +2752,7 @@ segend12_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nseg13:
   default: -1
   type: integer
@@ -2762,7 +2762,7 @@ nseg13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segsta13_1:
   default: .nan
   type: float
@@ -2773,7 +2773,7 @@ segsta13_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segend13_1:
   default: .nan
   type: float
@@ -2784,7 +2784,7 @@ segend13_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nseg14:
   default: -1
   type: integer
@@ -2794,7 +2794,7 @@ nseg14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segsta14_1:
   default: .nan
   type: float
@@ -2805,7 +2805,7 @@ segsta14_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segend14_1:
   default: .nan
   type: float
@@ -2816,7 +2816,7 @@ segend14_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nseg15:
   default: -1
   type: integer
@@ -2826,7 +2826,7 @@ nseg15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segsta15_1:
   default: .nan
   type: float
@@ -2837,7 +2837,7 @@ segsta15_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segend15_1:
   default: .nan
   type: float
@@ -2848,7 +2848,7 @@ segend15_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nseg16:
   default: -1
   type: integer
@@ -2858,7 +2858,7 @@ nseg16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segsta16_1:
   default: .nan
   type: float
@@ -2869,7 +2869,7 @@ segsta16_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segend16_1:
   default: .nan
   type: float
@@ -2880,7 +2880,7 @@ segend16_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nseg17:
   default: -1
   type: integer
@@ -2890,7 +2890,7 @@ nseg17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segsta17_1:
   default: .nan
   type: float
@@ -2901,7 +2901,7 @@ segsta17_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segend17_1:
   default: .nan
   type: float
@@ -2912,7 +2912,7 @@ segend17_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nseg18:
   default: -1
   type: integer
@@ -2922,7 +2922,7 @@ nseg18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segsta18_1:
   default: .nan
   type: float
@@ -2933,7 +2933,7 @@ segsta18_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segend18_1:
   default: .nan
   type: float
@@ -2944,7 +2944,7 @@ segend18_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nseg19:
   default: -1
   type: integer
@@ -2954,7 +2954,7 @@ nseg19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segsta19_1:
   default: .nan
   type: float
@@ -2965,7 +2965,7 @@ segsta19_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segend19_1:
   default: .nan
   type: float
@@ -2976,7 +2976,7 @@ segend19_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nseg20:
   default: -1
   type: integer
@@ -2986,7 +2986,7 @@ nseg20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segsta20_1:
   default: .nan
   type: float
@@ -2997,7 +2997,7 @@ segsta20_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 segend20_1:
   default: .nan
   type: float
@@ -3008,7 +3008,7 @@ segend20_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_air:
   default: 0.1
   type: float
@@ -3019,7 +3019,7 @@ w_air:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_bsa:
   default: 0.0
   type: float
@@ -3030,7 +3030,7 @@ w_bsa:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_cdih:
   default: 0.0
   type: float
@@ -3041,7 +3041,7 @@ w_cdih:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_dani:
   default: 0.1
   type: float
@@ -3052,7 +3052,7 @@ w_dani:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_deint:
   default: 0.0
   type: float
@@ -3063,7 +3063,7 @@ w_deint:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_desolv:
   default: 1.0
   type: float
@@ -3074,7 +3074,7 @@ w_desolv:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_dist:
   default: 0.1
   type: float
@@ -3085,7 +3085,7 @@ w_dist:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_elec:
   default: 0.2
   type: float
@@ -3096,7 +3096,7 @@ w_elec:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_lcc:
   default: -10000.0
   type: float
@@ -3107,7 +3107,7 @@ w_lcc:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_rg:
   default: 1.0
   type: float
@@ -3118,7 +3118,7 @@ w_rg:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_sani:
   default: 0.1
   type: float
@@ -3129,7 +3129,7 @@ w_sani:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_sym:
   default: 0.1
   type: float
@@ -3140,7 +3140,7 @@ w_sym:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_vdw:
   default: 1.0
   type: float
@@ -3151,7 +3151,7 @@ w_vdw:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_vean:
   default: 0.1
   type: float
@@ -3162,7 +3162,7 @@ w_vean:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_xpcs:
   default: 0.1
   type: float
@@ -3173,7 +3173,7 @@ w_xpcs:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_xrdc:
   default: 0.1
   type: float
@@ -3184,7 +3184,7 @@ w_xrdc:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_zres:
   default: 0.1
   type: float
@@ -3195,7 +3195,7 @@ w_zres:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 elecflag:
   default: true
   type: boolean
@@ -3203,7 +3203,7 @@ elecflag:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 dielec:
   default: cdie
   type: string
@@ -3213,7 +3213,7 @@ dielec:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 epsilon:
   default: 1.0
   type: float
@@ -3224,7 +3224,7 @@ epsilon:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 dihedflag:
   default: true
   type: boolean
@@ -3232,7 +3232,7 @@ dihedflag:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 par_nonbonded:
   default: OPLSX
   type: string
@@ -3242,7 +3242,7 @@ par_nonbonded:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_1:
   default: 1.0
   type: float
@@ -3253,7 +3253,7 @@ int_1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_2:
   default: 1.0
   type: float
@@ -3264,7 +3264,7 @@ int_1_2:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_3:
   default: 1.0
   type: float
@@ -3275,7 +3275,7 @@ int_1_3:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_4:
   default: 1.0
   type: float
@@ -3286,7 +3286,7 @@ int_1_4:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_5:
   default: 1.0
   type: float
@@ -3297,7 +3297,7 @@ int_1_5:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_6:
   default: 1.0
   type: float
@@ -3308,7 +3308,7 @@ int_1_6:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_7:
   default: 1.0
   type: float
@@ -3319,7 +3319,7 @@ int_1_7:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_8:
   default: 1.0
   type: float
@@ -3330,7 +3330,7 @@ int_1_8:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_9:
   default: 1.0
   type: float
@@ -3341,7 +3341,7 @@ int_1_9:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_10:
   default: 1.0
   type: float
@@ -3352,7 +3352,7 @@ int_1_10:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_11:
   default: 1.0
   type: float
@@ -3363,7 +3363,7 @@ int_1_11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_12:
   default: 1.0
   type: float
@@ -3374,7 +3374,7 @@ int_1_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_13:
   default: 1.0
   type: float
@@ -3385,7 +3385,7 @@ int_1_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_14:
   default: 1.0
   type: float
@@ -3396,7 +3396,7 @@ int_1_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_15:
   default: 1.0
   type: float
@@ -3407,7 +3407,7 @@ int_1_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_16:
   default: 1.0
   type: float
@@ -3418,7 +3418,7 @@ int_1_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_17:
   default: 1.0
   type: float
@@ -3429,7 +3429,7 @@ int_1_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_18:
   default: 1.0
   type: float
@@ -3440,7 +3440,7 @@ int_1_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_19:
   default: 1.0
   type: float
@@ -3451,7 +3451,7 @@ int_1_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_20:
   default: 1.0
   type: float
@@ -3462,7 +3462,7 @@ int_1_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_2:
   default: 1.0
   type: float
@@ -3473,7 +3473,7 @@ int_2_2:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_3:
   default: 1.0
   type: float
@@ -3484,7 +3484,7 @@ int_2_3:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_4:
   default: 1.0
   type: float
@@ -3495,7 +3495,7 @@ int_2_4:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_5:
   default: 1.0
   type: float
@@ -3506,7 +3506,7 @@ int_2_5:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_6:
   default: 1.0
   type: float
@@ -3517,7 +3517,7 @@ int_2_6:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_7:
   default: 1.0
   type: float
@@ -3528,7 +3528,7 @@ int_2_7:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_8:
   default: 1.0
   type: float
@@ -3539,7 +3539,7 @@ int_2_8:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_9:
   default: 1.0
   type: float
@@ -3550,7 +3550,7 @@ int_2_9:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_10:
   default: 1.0
   type: float
@@ -3561,7 +3561,7 @@ int_2_10:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_11:
   default: 1.0
   type: float
@@ -3572,7 +3572,7 @@ int_2_11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_12:
   default: 1.0
   type: float
@@ -3583,7 +3583,7 @@ int_2_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_13:
   default: 1.0
   type: float
@@ -3594,7 +3594,7 @@ int_2_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_14:
   default: 1.0
   type: float
@@ -3605,7 +3605,7 @@ int_2_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_15:
   default: 1.0
   type: float
@@ -3616,7 +3616,7 @@ int_2_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_16:
   default: 1.0
   type: float
@@ -3627,7 +3627,7 @@ int_2_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_17:
   default: 1.0
   type: float
@@ -3638,7 +3638,7 @@ int_2_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_18:
   default: 1.0
   type: float
@@ -3649,7 +3649,7 @@ int_2_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_19:
   default: 1.0
   type: float
@@ -3660,7 +3660,7 @@ int_2_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_20:
   default: 1.0
   type: float
@@ -3671,7 +3671,7 @@ int_2_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_3:
   default: 1.0
   type: float
@@ -3682,7 +3682,7 @@ int_3_3:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_4:
   default: 1.0
   type: float
@@ -3693,7 +3693,7 @@ int_3_4:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_5:
   default: 1.0
   type: float
@@ -3704,7 +3704,7 @@ int_3_5:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_6:
   default: 1.0
   type: float
@@ -3715,7 +3715,7 @@ int_3_6:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_7:
   default: 1.0
   type: float
@@ -3726,7 +3726,7 @@ int_3_7:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_8:
   default: 1.0
   type: float
@@ -3737,7 +3737,7 @@ int_3_8:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_9:
   default: 1.0
   type: float
@@ -3748,7 +3748,7 @@ int_3_9:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_10:
   default: 1.0
   type: float
@@ -3759,7 +3759,7 @@ int_3_10:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_11:
   default: 1.0
   type: float
@@ -3770,7 +3770,7 @@ int_3_11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_12:
   default: 1.0
   type: float
@@ -3781,7 +3781,7 @@ int_3_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_13:
   default: 1.0
   type: float
@@ -3792,7 +3792,7 @@ int_3_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_14:
   default: 1.0
   type: float
@@ -3803,7 +3803,7 @@ int_3_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_15:
   default: 1.0
   type: float
@@ -3814,7 +3814,7 @@ int_3_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_16:
   default: 1.0
   type: float
@@ -3825,7 +3825,7 @@ int_3_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_17:
   default: 1.0
   type: float
@@ -3836,7 +3836,7 @@ int_3_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_18:
   default: 1.0
   type: float
@@ -3847,7 +3847,7 @@ int_3_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_19:
   default: 1.0
   type: float
@@ -3858,7 +3858,7 @@ int_3_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_20:
   default: 1.0
   type: float
@@ -3869,7 +3869,7 @@ int_3_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_4:
   default: 1.0
   type: float
@@ -3880,7 +3880,7 @@ int_4_4:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_5:
   default: 1.0
   type: float
@@ -3891,7 +3891,7 @@ int_4_5:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_6:
   default: 1.0
   type: float
@@ -3902,7 +3902,7 @@ int_4_6:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_7:
   default: 1.0
   type: float
@@ -3913,7 +3913,7 @@ int_4_7:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_8:
   default: 1.0
   type: float
@@ -3924,7 +3924,7 @@ int_4_8:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_9:
   default: 1.0
   type: float
@@ -3935,7 +3935,7 @@ int_4_9:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_10:
   default: 1.0
   type: float
@@ -3946,7 +3946,7 @@ int_4_10:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_11:
   default: 1.0
   type: float
@@ -3957,7 +3957,7 @@ int_4_11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_12:
   default: 1.0
   type: float
@@ -3968,7 +3968,7 @@ int_4_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_13:
   default: 1.0
   type: float
@@ -3979,7 +3979,7 @@ int_4_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_14:
   default: 1.0
   type: float
@@ -3990,7 +3990,7 @@ int_4_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_15:
   default: 1.0
   type: float
@@ -4001,7 +4001,7 @@ int_4_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_16:
   default: 1.0
   type: float
@@ -4012,7 +4012,7 @@ int_4_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_17:
   default: 1.0
   type: float
@@ -4023,7 +4023,7 @@ int_4_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_18:
   default: 1.0
   type: float
@@ -4034,7 +4034,7 @@ int_4_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_19:
   default: 1.0
   type: float
@@ -4045,7 +4045,7 @@ int_4_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_20:
   default: 1.0
   type: float
@@ -4056,7 +4056,7 @@ int_4_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_5:
   default: 1.0
   type: float
@@ -4067,7 +4067,7 @@ int_5_5:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_6:
   default: 1.0
   type: float
@@ -4078,7 +4078,7 @@ int_5_6:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_7:
   default: 1.0
   type: float
@@ -4089,7 +4089,7 @@ int_5_7:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_8:
   default: 1.0
   type: float
@@ -4100,7 +4100,7 @@ int_5_8:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_9:
   default: 1.0
   type: float
@@ -4111,7 +4111,7 @@ int_5_9:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_10:
   default: 1.0
   type: float
@@ -4122,7 +4122,7 @@ int_5_10:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_11:
   default: 1.0
   type: float
@@ -4133,7 +4133,7 @@ int_5_11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_12:
   default: 1.0
   type: float
@@ -4144,7 +4144,7 @@ int_5_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_13:
   default: 1.0
   type: float
@@ -4155,7 +4155,7 @@ int_5_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_14:
   default: 1.0
   type: float
@@ -4166,7 +4166,7 @@ int_5_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_15:
   default: 1.0
   type: float
@@ -4177,7 +4177,7 @@ int_5_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_16:
   default: 1.0
   type: float
@@ -4188,7 +4188,7 @@ int_5_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_17:
   default: 1.0
   type: float
@@ -4199,7 +4199,7 @@ int_5_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_18:
   default: 1.0
   type: float
@@ -4210,7 +4210,7 @@ int_5_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_19:
   default: 1.0
   type: float
@@ -4221,7 +4221,7 @@ int_5_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_20:
   default: 1.0
   type: float
@@ -4232,7 +4232,7 @@ int_5_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_6_6:
   default: 1.0
   type: float
@@ -4243,7 +4243,7 @@ int_6_6:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_6_7:
   default: 1.0
   type: float
@@ -4254,7 +4254,7 @@ int_6_7:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_6_8:
   default: 1.0
   type: float
@@ -4265,7 +4265,7 @@ int_6_8:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_6_9:
   default: 1.0
   type: float
@@ -4276,7 +4276,7 @@ int_6_9:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_6_10:
   default: 1.0
   type: float
@@ -4287,7 +4287,7 @@ int_6_10:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_6_11:
   default: 1.0
   type: float
@@ -4298,7 +4298,7 @@ int_6_11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_6_12:
   default: 1.0
   type: float
@@ -4309,7 +4309,7 @@ int_6_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_6_13:
   default: 1.0
   type: float
@@ -4320,7 +4320,7 @@ int_6_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_6_14:
   default: 1.0
   type: float
@@ -4331,7 +4331,7 @@ int_6_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_6_15:
   default: 1.0
   type: float
@@ -4342,7 +4342,7 @@ int_6_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_6_16:
   default: 1.0
   type: float
@@ -4353,7 +4353,7 @@ int_6_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_6_17:
   default: 1.0
   type: float
@@ -4364,7 +4364,7 @@ int_6_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_6_18:
   default: 1.0
   type: float
@@ -4375,7 +4375,7 @@ int_6_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_6_19:
   default: 1.0
   type: float
@@ -4386,7 +4386,7 @@ int_6_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_6_20:
   default: 1.0
   type: float
@@ -4397,7 +4397,7 @@ int_6_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_7_7:
   default: 1.0
   type: float
@@ -4408,7 +4408,7 @@ int_7_7:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_7_8:
   default: 1.0
   type: float
@@ -4419,7 +4419,7 @@ int_7_8:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_7_9:
   default: 1.0
   type: float
@@ -4430,7 +4430,7 @@ int_7_9:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_7_10:
   default: 1.0
   type: float
@@ -4441,7 +4441,7 @@ int_7_10:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_7_11:
   default: 1.0
   type: float
@@ -4452,7 +4452,7 @@ int_7_11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_7_12:
   default: 1.0
   type: float
@@ -4463,7 +4463,7 @@ int_7_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_7_13:
   default: 1.0
   type: float
@@ -4474,7 +4474,7 @@ int_7_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_7_14:
   default: 1.0
   type: float
@@ -4485,7 +4485,7 @@ int_7_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_7_15:
   default: 1.0
   type: float
@@ -4496,7 +4496,7 @@ int_7_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_7_16:
   default: 1.0
   type: float
@@ -4507,7 +4507,7 @@ int_7_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_7_17:
   default: 1.0
   type: float
@@ -4518,7 +4518,7 @@ int_7_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_7_18:
   default: 1.0
   type: float
@@ -4529,7 +4529,7 @@ int_7_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_7_19:
   default: 1.0
   type: float
@@ -4540,7 +4540,7 @@ int_7_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_8_8:
   default: 1.0
   type: float
@@ -4551,7 +4551,7 @@ int_8_8:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_8_9:
   default: 1.0
   type: float
@@ -4562,7 +4562,7 @@ int_8_9:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_7_20:
   default: 1.0
   type: float
@@ -4573,7 +4573,7 @@ int_7_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_8_10:
   default: 1.0
   type: float
@@ -4584,7 +4584,7 @@ int_8_10:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_8_11:
   default: 1.0
   type: float
@@ -4595,7 +4595,7 @@ int_8_11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_8_12:
   default: 1.0
   type: float
@@ -4606,7 +4606,7 @@ int_8_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_8_13:
   default: 1.0
   type: float
@@ -4617,7 +4617,7 @@ int_8_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_8_14:
   default: 1.0
   type: float
@@ -4628,7 +4628,7 @@ int_8_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_8_15:
   default: 1.0
   type: float
@@ -4639,7 +4639,7 @@ int_8_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_8_16:
   default: 1.0
   type: float
@@ -4650,7 +4650,7 @@ int_8_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_8_17:
   default: 1.0
   type: float
@@ -4661,7 +4661,7 @@ int_8_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_8_18:
   default: 1.0
   type: float
@@ -4672,7 +4672,7 @@ int_8_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_8_19:
   default: 1.0
   type: float
@@ -4683,7 +4683,7 @@ int_8_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_8_20:
   default: 1.0
   type: float
@@ -4694,7 +4694,7 @@ int_8_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_9_11:
   default: 1.0
   type: float
@@ -4705,7 +4705,7 @@ int_9_11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_9_12:
   default: 1.0
   type: float
@@ -4716,7 +4716,7 @@ int_9_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_9_13:
   default: 1.0
   type: float
@@ -4727,7 +4727,7 @@ int_9_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_9_14:
   default: 1.0
   type: float
@@ -4738,7 +4738,7 @@ int_9_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_9_15:
   default: 1.0
   type: float
@@ -4749,7 +4749,7 @@ int_9_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_9_16:
   default: 1.0
   type: float
@@ -4760,7 +4760,7 @@ int_9_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_9_17:
   default: 1.0
   type: float
@@ -4771,7 +4771,7 @@ int_9_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_9_18:
   default: 1.0
   type: float
@@ -4782,7 +4782,7 @@ int_9_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_9_19:
   default: 1.0
   type: float
@@ -4793,7 +4793,7 @@ int_9_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_9_20:
   default: 1.0
   type: float
@@ -4804,7 +4804,7 @@ int_9_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_9_9:
   default: 1.0
   type: float
@@ -4815,7 +4815,7 @@ int_9_9:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_9_10:
   default: 1.0
   type: float
@@ -4826,7 +4826,7 @@ int_9_10:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_10_10:
   default: 1.0
   type: float
@@ -4837,7 +4837,7 @@ int_10_10:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_10_11:
   default: 1.0
   type: float
@@ -4848,7 +4848,7 @@ int_10_11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_10_12:
   default: 1.0
   type: float
@@ -4859,7 +4859,7 @@ int_10_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_10_13:
   default: 1.0
   type: float
@@ -4870,7 +4870,7 @@ int_10_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_10_14:
   default: 1.0
   type: float
@@ -4881,7 +4881,7 @@ int_10_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_10_15:
   default: 1.0
   type: float
@@ -4892,7 +4892,7 @@ int_10_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_10_16:
   default: 1.0
   type: float
@@ -4903,7 +4903,7 @@ int_10_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_10_17:
   default: 1.0
   type: float
@@ -4914,7 +4914,7 @@ int_10_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_10_18:
   default: 1.0
   type: float
@@ -4925,7 +4925,7 @@ int_10_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_10_19:
   default: 1.0
   type: float
@@ -4936,7 +4936,7 @@ int_10_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_10_20:
   default: 1.0
   type: float
@@ -4947,7 +4947,7 @@ int_10_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_11_11:
   default: 1.0
   type: float
@@ -4958,7 +4958,7 @@ int_11_11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_11_12:
   default: 1.0
   type: float
@@ -4969,7 +4969,7 @@ int_11_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_11_13:
   default: 1.0
   type: float
@@ -4980,7 +4980,7 @@ int_11_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_11_14:
   default: 1.0
   type: float
@@ -4991,7 +4991,7 @@ int_11_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_11_15:
   default: 1.0
   type: float
@@ -5002,7 +5002,7 @@ int_11_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_11_16:
   default: 1.0
   type: float
@@ -5013,7 +5013,7 @@ int_11_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_11_17:
   default: 1.0
   type: float
@@ -5024,7 +5024,7 @@ int_11_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_11_18:
   default: 1.0
   type: float
@@ -5035,7 +5035,7 @@ int_11_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_11_19:
   default: 1.0
   type: float
@@ -5046,7 +5046,7 @@ int_11_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_11_20:
   default: 1.0
   type: float
@@ -5057,7 +5057,7 @@ int_11_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_12_12:
   default: 1.0
   type: float
@@ -5068,7 +5068,7 @@ int_12_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_12_13:
   default: 1.0
   type: float
@@ -5079,7 +5079,7 @@ int_12_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_12_14:
   default: 1.0
   type: float
@@ -5090,7 +5090,7 @@ int_12_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_12_15:
   default: 1.0
   type: float
@@ -5101,7 +5101,7 @@ int_12_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_12_16:
   default: 1.0
   type: float
@@ -5112,7 +5112,7 @@ int_12_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_12_17:
   default: 1.0
   type: float
@@ -5123,7 +5123,7 @@ int_12_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_12_18:
   default: 1.0
   type: float
@@ -5134,7 +5134,7 @@ int_12_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_12_19:
   default: 1.0
   type: float
@@ -5145,7 +5145,7 @@ int_12_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_12_20:
   default: 1.0
   type: float
@@ -5156,7 +5156,7 @@ int_12_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_13_13:
   default: 1.0
   type: float
@@ -5167,7 +5167,7 @@ int_13_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_13_14:
   default: 1.0
   type: float
@@ -5178,7 +5178,7 @@ int_13_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_13_15:
   default: 1.0
   type: float
@@ -5189,7 +5189,7 @@ int_13_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_13_16:
   default: 1.0
   type: float
@@ -5200,7 +5200,7 @@ int_13_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_13_17:
   default: 1.0
   type: float
@@ -5211,7 +5211,7 @@ int_13_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_13_18:
   default: 1.0
   type: float
@@ -5222,7 +5222,7 @@ int_13_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_13_19:
   default: 1.0
   type: float
@@ -5233,7 +5233,7 @@ int_13_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_13_20:
   default: 1.0
   type: float
@@ -5244,7 +5244,7 @@ int_13_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_14_14:
   default: 1.0
   type: float
@@ -5255,7 +5255,7 @@ int_14_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_14_15:
   default: 1.0
   type: float
@@ -5266,7 +5266,7 @@ int_14_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_14_16:
   default: 1.0
   type: float
@@ -5277,7 +5277,7 @@ int_14_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_14_17:
   default: 1.0
   type: float
@@ -5288,7 +5288,7 @@ int_14_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_14_18:
   default: 1.0
   type: float
@@ -5299,7 +5299,7 @@ int_14_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_14_19:
   default: 1.0
   type: float
@@ -5310,7 +5310,7 @@ int_14_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_14_20:
   default: 1.0
   type: float
@@ -5321,7 +5321,7 @@ int_14_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_15_15:
   default: 1.0
   type: float
@@ -5332,7 +5332,7 @@ int_15_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_15_16:
   default: 1.0
   type: float
@@ -5343,7 +5343,7 @@ int_15_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_15_17:
   default: 1.0
   type: float
@@ -5354,7 +5354,7 @@ int_15_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_15_18:
   default: 1.0
   type: float
@@ -5365,7 +5365,7 @@ int_15_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_15_19:
   default: 1.0
   type: float
@@ -5376,7 +5376,7 @@ int_15_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_15_20:
   default: 1.0
   type: float
@@ -5387,7 +5387,7 @@ int_15_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_16_16:
   default: 1.0
   type: float
@@ -5398,7 +5398,7 @@ int_16_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_16_17:
   default: 1.0
   type: float
@@ -5409,7 +5409,7 @@ int_16_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_16_18:
   default: 1.0
   type: float
@@ -5420,7 +5420,7 @@ int_16_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_16_19:
   default: 1.0
   type: float
@@ -5431,7 +5431,7 @@ int_16_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_16_20:
   default: 1.0
   type: float
@@ -5442,7 +5442,7 @@ int_16_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_17_17:
   default: 1.0
   type: float
@@ -5453,7 +5453,7 @@ int_17_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_17_18:
   default: 1.0
   type: float
@@ -5464,7 +5464,7 @@ int_17_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_17_19:
   default: 1.0
   type: float
@@ -5475,7 +5475,7 @@ int_17_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_17_20:
   default: 1.0
   type: float
@@ -5486,7 +5486,7 @@ int_17_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_18_18:
   default: 1.0
   type: float
@@ -5497,7 +5497,7 @@ int_18_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_18_19:
   default: 1.0
   type: float
@@ -5508,7 +5508,7 @@ int_18_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_18_20:
   default: 1.0
   type: float
@@ -5519,7 +5519,7 @@ int_18_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_19_19:
   default: 1.0
   type: float
@@ -5530,7 +5530,7 @@ int_19_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_19_20:
   default: 1.0
   type: float
@@ -5541,7 +5541,7 @@ int_19_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_20_20:
   default: 1.0
   type: float
@@ -5552,4 +5552,4 @@ int_20_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy

--- a/src/haddock/modules/sampling/gdock/defaults.yaml
+++ b/src/haddock/modules/sampling/gdock/defaults.yaml
@@ -5,4 +5,4 @@ ambig_fname:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy

--- a/src/haddock/modules/sampling/lightdock/defaults.yaml
+++ b/src/haddock/modules/sampling/lightdock/defaults.yaml
@@ -7,7 +7,7 @@ glowworms:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 steps:
   default: 100
   type: integer
@@ -17,7 +17,7 @@ steps:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 swarms:
   default: 400
   type: integer
@@ -27,7 +27,7 @@ swarms:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 scoring:
   default: fastdfire
   type: string
@@ -37,7 +37,7 @@ scoring:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 top:
   default: 10
   type: integer
@@ -47,7 +47,7 @@ top:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 receptor_chains:
   default: A
   type: string
@@ -57,7 +57,7 @@ receptor_chains:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 receptor_active:
   default: ''
   type: string
@@ -67,7 +67,7 @@ receptor_active:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 receptor_passive:
   default: ''
   type: string
@@ -77,7 +77,7 @@ receptor_passive:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ligand_chains:
   default: B
   type: string
@@ -87,7 +87,7 @@ ligand_chains:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ligand_active:
   default: ''
   type: string
@@ -97,7 +97,7 @@ ligand_active:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ligand_passive:
   default: ''
   type: string
@@ -107,7 +107,7 @@ ligand_passive:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 noxt:
   default: true
   type: boolean
@@ -115,7 +115,7 @@ noxt:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 noh:
   default: true
   type: boolean
@@ -123,7 +123,7 @@ noh:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 restraints:
   default: false
   type: boolean
@@ -131,4 +131,4 @@ restraints:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy

--- a/src/haddock/modules/sampling/rigidbody/defaults.yaml
+++ b/src/haddock/modules/sampling/rigidbody/defaults.yaml
@@ -7,7 +7,7 @@ tolerance:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 log_level:
   default: verbose
   type: string
@@ -17,7 +17,7 @@ log_level:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ambig_fname:
   default: ''
   type: file
@@ -25,7 +25,7 @@ ambig_fname:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 unambig_fname:
   default: ''
   type: file
@@ -33,7 +33,7 @@ unambig_fname:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 hbond_fname:
   default: ''
   type: file
@@ -41,7 +41,7 @@ hbond_fname:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ligand_param_fname:
   default: ''
   type: file
@@ -49,7 +49,7 @@ ligand_param_fname:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ligand_top_fname:
   default: ''
   type: file
@@ -57,7 +57,7 @@ ligand_top_fname:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 sampling:
   default: 5
   type: integer
@@ -67,7 +67,7 @@ sampling:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 crossdock:
   default: true
   type: boolean
@@ -75,7 +75,7 @@ crossdock:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ntrials:
   default: 5
   type: integer
@@ -85,7 +85,7 @@ ntrials:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 rotate180:
   default: true
   type: boolean
@@ -93,7 +93,7 @@ rotate180:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 randorien:
   default: true
   type: boolean
@@ -101,7 +101,7 @@ randorien:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 rigidtrans:
   default: true
   type: boolean
@@ -109,7 +109,7 @@ rigidtrans:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 iniseed:
   default: 917
   type: integer
@@ -119,7 +119,7 @@ iniseed:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 keepwater:
   default: false
   type: boolean
@@ -127,7 +127,7 @@ keepwater:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_1:
   default: A
   type: string
@@ -137,7 +137,7 @@ prot_segid_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_2:
   default: B
   type: string
@@ -147,7 +147,7 @@ prot_segid_2:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_3:
   default: C
   type: string
@@ -157,7 +157,7 @@ prot_segid_3:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_4:
   default: D
   type: string
@@ -167,7 +167,7 @@ prot_segid_4:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_5:
   default: E
   type: string
@@ -177,7 +177,7 @@ prot_segid_5:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_6:
   default: F
   type: string
@@ -187,7 +187,7 @@ prot_segid_6:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_7:
   default: G
   type: string
@@ -197,7 +197,7 @@ prot_segid_7:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_8:
   default: H
   type: string
@@ -207,7 +207,7 @@ prot_segid_8:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_9:
   default: I
   type: string
@@ -217,7 +217,7 @@ prot_segid_9:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_10:
   default: J
   type: string
@@ -227,7 +227,7 @@ prot_segid_10:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_11:
   default: K
   type: string
@@ -237,7 +237,7 @@ prot_segid_11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_12:
   default: L
   type: string
@@ -247,7 +247,7 @@ prot_segid_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_13:
   default: M
   type: string
@@ -257,7 +257,7 @@ prot_segid_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_14:
   default: N
   type: string
@@ -267,7 +267,7 @@ prot_segid_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_15:
   default: O
   type: string
@@ -277,7 +277,7 @@ prot_segid_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_16:
   default: P
   type: string
@@ -287,7 +287,7 @@ prot_segid_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_17:
   default: Q
   type: string
@@ -297,7 +297,7 @@ prot_segid_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_18:
   default: R
   type: string
@@ -307,7 +307,7 @@ prot_segid_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_19:
   default: S
   type: string
@@ -317,7 +317,7 @@ prot_segid_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 prot_segid_20:
   default: T
   type: string
@@ -327,7 +327,7 @@ prot_segid_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_1:
   default: false
   type: boolean
@@ -335,7 +335,7 @@ shape_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_2:
   default: false
   type: boolean
@@ -343,7 +343,7 @@ shape_2:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_3:
   default: false
   type: boolean
@@ -351,7 +351,7 @@ shape_3:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_4:
   default: false
   type: boolean
@@ -359,7 +359,7 @@ shape_4:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_5:
   default: false
   type: boolean
@@ -367,7 +367,7 @@ shape_5:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_6:
   default: false
   type: boolean
@@ -375,7 +375,7 @@ shape_6:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_7:
   default: false
   type: boolean
@@ -383,7 +383,7 @@ shape_7:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_8:
   default: false
   type: boolean
@@ -391,7 +391,7 @@ shape_8:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_9:
   default: false
   type: boolean
@@ -399,7 +399,7 @@ shape_9:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_10:
   default: false
   type: boolean
@@ -407,7 +407,7 @@ shape_10:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_11:
   default: false
   type: boolean
@@ -415,7 +415,7 @@ shape_11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_12:
   default: false
   type: boolean
@@ -423,7 +423,7 @@ shape_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_13:
   default: false
   type: boolean
@@ -431,7 +431,7 @@ shape_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_14:
   default: false
   type: boolean
@@ -439,7 +439,7 @@ shape_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_15:
   default: false
   type: boolean
@@ -447,7 +447,7 @@ shape_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_16:
   default: false
   type: boolean
@@ -455,7 +455,7 @@ shape_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_17:
   default: false
   type: boolean
@@ -463,7 +463,7 @@ shape_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_18:
   default: false
   type: boolean
@@ -471,7 +471,7 @@ shape_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_19:
   default: false
   type: boolean
@@ -479,7 +479,7 @@ shape_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_20:
   default: false
   type: boolean
@@ -487,7 +487,7 @@ shape_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 amb_cool1:
   default: 10
   type: integer
@@ -497,7 +497,7 @@ amb_cool1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 amb_cool2:
   default: 50
   type: integer
@@ -507,7 +507,7 @@ amb_cool2:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 amb_cool3:
   default: 50
   type: integer
@@ -517,7 +517,7 @@ amb_cool3:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 amb_hot:
   default: 10
   type: integer
@@ -527,7 +527,7 @@ amb_hot:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 unamb_cool1:
   default: 10
   type: integer
@@ -537,7 +537,7 @@ unamb_cool1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 unamb_cool2:
   default: 50
   type: integer
@@ -547,7 +547,7 @@ unamb_cool2:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 unamb_cool3:
   default: 50
   type: integer
@@ -557,7 +557,7 @@ unamb_cool3:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 unamb_hot:
   default: 10
   type: integer
@@ -567,7 +567,7 @@ unamb_hot:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 hbond_cool1:
   default: 10
   type: integer
@@ -577,7 +577,7 @@ hbond_cool1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 hbond_cool2:
   default: 50
   type: integer
@@ -587,7 +587,7 @@ hbond_cool2:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 hbond_cool3:
   default: 50
   type: integer
@@ -597,7 +597,7 @@ hbond_cool3:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 hbond_hot:
   default: 10
   type: integer
@@ -607,7 +607,7 @@ hbond_hot:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 noecv:
   default: false
   type: boolean
@@ -615,7 +615,7 @@ noecv:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ncvpart:
   default: 2
   type: integer
@@ -625,7 +625,7 @@ ncvpart:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 mrswi_hot:
   default: 0.5
   type: float
@@ -636,7 +636,7 @@ mrswi_hot:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 mrswi_cool1:
   default: 0.5
   type: float
@@ -647,7 +647,7 @@ mrswi_cool1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 mrswi_cool2:
   default: 0.5
   type: float
@@ -658,7 +658,7 @@ mrswi_cool2:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 mrswi_cool3:
   default: 0.5
   type: float
@@ -669,7 +669,7 @@ mrswi_cool3:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 rswi_hot:
   default: 0.5
   type: float
@@ -680,7 +680,7 @@ rswi_hot:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 rswi_cool1:
   default: 0.5
   type: float
@@ -691,7 +691,7 @@ rswi_cool1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 rswi_cool2:
   default: 0.5
   type: float
@@ -702,7 +702,7 @@ rswi_cool2:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 rswi_cool3:
   default: 0.5
   type: float
@@ -713,7 +713,7 @@ rswi_cool3:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 masy_hot:
   default: -1.0
   type: float
@@ -724,7 +724,7 @@ masy_hot:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 masy_cool1:
   default: -1.0
   type: float
@@ -735,7 +735,7 @@ masy_cool1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 masy_cool2:
   default: -0.1
   type: float
@@ -746,7 +746,7 @@ masy_cool2:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 masy_cool3:
   default: -0.1
   type: float
@@ -757,7 +757,7 @@ masy_cool3:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 asy_hot:
   default: 1.0
   type: float
@@ -768,7 +768,7 @@ asy_hot:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 asy_cool1:
   default: 1.0
   type: float
@@ -779,7 +779,7 @@ asy_cool1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 asy_cool2:
   default: 0.1
   type: float
@@ -790,7 +790,7 @@ asy_cool2:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 asy_cool3:
   default: 0.1
   type: float
@@ -801,7 +801,7 @@ asy_cool3:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 cmrest:
   default: false
   type: boolean
@@ -809,7 +809,7 @@ cmrest:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 cmtight:
   default: false
   type: boolean
@@ -817,7 +817,7 @@ cmtight:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ranair:
   default: false
   type: boolean
@@ -825,7 +825,7 @@ ranair:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ksurf:
   default: 1.0
   type: float
@@ -836,7 +836,7 @@ ksurf:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 kcont:
   default: 1.0
   type: float
@@ -847,7 +847,7 @@ kcont:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 surfrest:
   default: false
   type: boolean
@@ -855,7 +855,7 @@ surfrest:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 sym_on:
   default: false
   type: boolean
@@ -863,7 +863,7 @@ sym_on:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ksym:
   default: 10.0
   type: float
@@ -874,7 +874,7 @@ ksym:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 numc2sym:
   default: 0
   type: integer
@@ -884,7 +884,7 @@ numc2sym:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c2sym_sta1_1:
   default: .nan
   type: float
@@ -895,7 +895,7 @@ c2sym_sta1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c2sym_end1_1:
   default: .nan
   type: float
@@ -906,7 +906,7 @@ c2sym_end1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c2sym_seg1_1:
   default: ''
   type: string
@@ -916,7 +916,7 @@ c2sym_seg1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c2sym_sta2_1:
   default: .nan
   type: float
@@ -927,7 +927,7 @@ c2sym_sta2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c2sym_end2_1:
   default: .nan
   type: float
@@ -938,7 +938,7 @@ c2sym_end2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c2sym_seg2_1:
   default: ''
   type: string
@@ -948,7 +948,7 @@ c2sym_seg2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 numc3sym:
   default: 0
   type: integer
@@ -958,7 +958,7 @@ numc3sym:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c3sym_sta1_1:
   default: .nan
   type: float
@@ -969,7 +969,7 @@ c3sym_sta1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c3sym_end1_1:
   default: .nan
   type: float
@@ -980,7 +980,7 @@ c3sym_end1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c3sym_seg1_1:
   default: ''
   type: string
@@ -990,7 +990,7 @@ c3sym_seg1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c3sym_sta2_1:
   default: .nan
   type: float
@@ -1001,7 +1001,7 @@ c3sym_sta2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c3sym_end2_1:
   default: .nan
   type: float
@@ -1012,7 +1012,7 @@ c3sym_end2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c3sym_seg2_1:
   default: ''
   type: string
@@ -1022,7 +1022,7 @@ c3sym_seg2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c3sym_sta3_1:
   default: .nan
   type: float
@@ -1033,7 +1033,7 @@ c3sym_sta3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c3sym_end3_1:
   default: .nan
   type: float
@@ -1044,7 +1044,7 @@ c3sym_end3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c3sym_seg3_1:
   default: ''
   type: string
@@ -1054,7 +1054,7 @@ c3sym_seg3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 numc4sym:
   default: 0
   type: integer
@@ -1064,7 +1064,7 @@ numc4sym:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c4sym_sta1_1:
   default: .nan
   type: float
@@ -1075,7 +1075,7 @@ c4sym_sta1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c4sym_end1_1:
   default: .nan
   type: float
@@ -1086,7 +1086,7 @@ c4sym_end1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c4sym_seg1_1:
   default: ''
   type: string
@@ -1096,7 +1096,7 @@ c4sym_seg1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c4sym_sta2_1:
   default: .nan
   type: float
@@ -1107,7 +1107,7 @@ c4sym_sta2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c4sym_end2_1:
   default: .nan
   type: float
@@ -1118,7 +1118,7 @@ c4sym_end2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c4sym_seg2_1:
   default: ''
   type: string
@@ -1128,7 +1128,7 @@ c4sym_seg2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c4sym_sta3_1:
   default: .nan
   type: float
@@ -1139,7 +1139,7 @@ c4sym_sta3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c4sym_end3_1:
   default: .nan
   type: float
@@ -1150,7 +1150,7 @@ c4sym_end3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c4sym_seg3_1:
   default: ''
   type: string
@@ -1160,7 +1160,7 @@ c4sym_seg3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c4sym_sta4_1:
   default: .nan
   type: float
@@ -1171,7 +1171,7 @@ c4sym_sta4_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c4sym_end4_1:
   default: .nan
   type: float
@@ -1182,7 +1182,7 @@ c4sym_end4_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c4sym_seg4_1:
   default: ''
   type: string
@@ -1192,7 +1192,7 @@ c4sym_seg4_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 numc5sym:
   default: 0
   type: integer
@@ -1202,7 +1202,7 @@ numc5sym:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c5sym_sta1_1:
   default: .nan
   type: float
@@ -1213,7 +1213,7 @@ c5sym_sta1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c5sym_end1_1:
   default: .nan
   type: float
@@ -1224,7 +1224,7 @@ c5sym_end1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c5sym_seg1_1:
   default: ''
   type: string
@@ -1234,7 +1234,7 @@ c5sym_seg1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c5sym_sta2_1:
   default: .nan
   type: float
@@ -1245,7 +1245,7 @@ c5sym_sta2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c5sym_end2_1:
   default: .nan
   type: float
@@ -1256,7 +1256,7 @@ c5sym_end2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c5sym_seg2_1:
   default: ''
   type: string
@@ -1266,7 +1266,7 @@ c5sym_seg2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c5sym_sta3_1:
   default: .nan
   type: float
@@ -1277,7 +1277,7 @@ c5sym_sta3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c5sym_end3_1:
   default: .nan
   type: float
@@ -1288,7 +1288,7 @@ c5sym_end3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c5sym_seg3_1:
   default: ''
   type: string
@@ -1298,7 +1298,7 @@ c5sym_seg3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c5sym_sta4_1:
   default: .nan
   type: float
@@ -1309,7 +1309,7 @@ c5sym_sta4_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c5sym_end4_1:
   default: .nan
   type: float
@@ -1320,7 +1320,7 @@ c5sym_end4_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c5sym_seg4_1:
   default: ''
   type: string
@@ -1330,7 +1330,7 @@ c5sym_seg4_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c5sym_sta5_1:
   default: .nan
   type: float
@@ -1341,7 +1341,7 @@ c5sym_sta5_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c5sym_end5_1:
   default: .nan
   type: float
@@ -1352,7 +1352,7 @@ c5sym_end5_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c5sym_seg5_1:
   default: ''
   type: string
@@ -1362,7 +1362,7 @@ c5sym_seg5_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 numc6sym:
   default: 0
   type: integer
@@ -1372,7 +1372,7 @@ numc6sym:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_sta1_1:
   default: .nan
   type: float
@@ -1383,7 +1383,7 @@ c6sym_sta1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_end1_1:
   default: .nan
   type: float
@@ -1394,7 +1394,7 @@ c6sym_end1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_seg1_1:
   default: ''
   type: string
@@ -1404,7 +1404,7 @@ c6sym_seg1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_sta2_1:
   default: .nan
   type: float
@@ -1415,7 +1415,7 @@ c6sym_sta2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_end2_1:
   default: .nan
   type: float
@@ -1426,7 +1426,7 @@ c6sym_end2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_seg2_1:
   default: ''
   type: string
@@ -1436,7 +1436,7 @@ c6sym_seg2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_sta3_1:
   default: .nan
   type: float
@@ -1447,7 +1447,7 @@ c6sym_sta3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_end3_1:
   default: .nan
   type: float
@@ -1458,7 +1458,7 @@ c6sym_end3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_seg3_1:
   default: ''
   type: string
@@ -1468,7 +1468,7 @@ c6sym_seg3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_sta4_1:
   default: .nan
   type: float
@@ -1479,7 +1479,7 @@ c6sym_sta4_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_end4_1:
   default: .nan
   type: float
@@ -1490,7 +1490,7 @@ c6sym_end4_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_seg4_1:
   default: ''
   type: string
@@ -1500,7 +1500,7 @@ c6sym_seg4_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_sta5_1:
   default: .nan
   type: float
@@ -1511,7 +1511,7 @@ c6sym_sta5_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_end5_1:
   default: .nan
   type: float
@@ -1522,7 +1522,7 @@ c6sym_end5_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_seg5_1:
   default: ''
   type: string
@@ -1532,7 +1532,7 @@ c6sym_seg5_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_sta6_1:
   default: .nan
   type: float
@@ -1543,7 +1543,7 @@ c6sym_sta6_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_end6_1:
   default: .nan
   type: float
@@ -1554,7 +1554,7 @@ c6sym_end6_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 c6sym_seg6_1:
   default: ''
   type: string
@@ -1564,7 +1564,7 @@ c6sym_seg6_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nums3sym:
   default: 0
   type: integer
@@ -1574,7 +1574,7 @@ nums3sym:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 s3sym_sta1_1:
   default: .nan
   type: float
@@ -1585,7 +1585,7 @@ s3sym_sta1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 s3sym_end1_1:
   default: .nan
   type: float
@@ -1596,7 +1596,7 @@ s3sym_end1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 s3sym_seg1_1:
   default: ''
   type: string
@@ -1606,7 +1606,7 @@ s3sym_seg1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 s3sym_sta2_1:
   default: .nan
   type: float
@@ -1617,7 +1617,7 @@ s3sym_sta2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 s3sym_end2_1:
   default: .nan
   type: float
@@ -1628,7 +1628,7 @@ s3sym_end2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 s3sym_seg2_1:
   default: ''
   type: string
@@ -1638,7 +1638,7 @@ s3sym_seg2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 s3sym_sta3_1:
   default: .nan
   type: float
@@ -1649,7 +1649,7 @@ s3sym_sta3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 s3sym_end3_1:
   default: .nan
   type: float
@@ -1660,7 +1660,7 @@ s3sym_end3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 s3sym_seg3_1:
   default: ''
   type: string
@@ -1670,7 +1670,7 @@ s3sym_seg3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ncs_on:
   default: false
   type: boolean
@@ -1678,7 +1678,7 @@ ncs_on:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 kncs:
   default: 1.0
   type: float
@@ -1689,7 +1689,7 @@ kncs:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 numncs:
   default: 0
   type: integer
@@ -1699,7 +1699,7 @@ numncs:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ncs_sta1_1:
   default: .nan
   type: float
@@ -1710,7 +1710,7 @@ ncs_sta1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ncs_end1_1:
   default: .nan
   type: float
@@ -1721,7 +1721,7 @@ ncs_end1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ncs_seg1_1:
   default: ''
   type: string
@@ -1731,7 +1731,7 @@ ncs_seg1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ncs_sta2_1:
   default: .nan
   type: float
@@ -1742,7 +1742,7 @@ ncs_sta2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ncs_end2_1:
   default: .nan
   type: float
@@ -1753,7 +1753,7 @@ ncs_end2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ncs_seg2_1:
   default: ''
   type: string
@@ -1763,7 +1763,7 @@ ncs_seg2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_1:
   default: false
   type: boolean
@@ -1771,7 +1771,7 @@ fix_origin_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_2:
   default: false
   type: boolean
@@ -1779,7 +1779,7 @@ fix_origin_2:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_3:
   default: false
   type: boolean
@@ -1787,7 +1787,7 @@ fix_origin_3:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_4:
   default: false
   type: boolean
@@ -1795,7 +1795,7 @@ fix_origin_4:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_5:
   default: false
   type: boolean
@@ -1803,7 +1803,7 @@ fix_origin_5:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_6:
   default: false
   type: boolean
@@ -1811,7 +1811,7 @@ fix_origin_6:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_7:
   default: false
   type: boolean
@@ -1819,7 +1819,7 @@ fix_origin_7:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_8:
   default: false
   type: boolean
@@ -1827,7 +1827,7 @@ fix_origin_8:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_9:
   default: false
   type: boolean
@@ -1835,7 +1835,7 @@ fix_origin_9:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_10:
   default: false
   type: boolean
@@ -1843,7 +1843,7 @@ fix_origin_10:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_11:
   default: false
   type: boolean
@@ -1851,7 +1851,7 @@ fix_origin_11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_12:
   default: false
   type: boolean
@@ -1859,7 +1859,7 @@ fix_origin_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_13:
   default: false
   type: boolean
@@ -1867,7 +1867,7 @@ fix_origin_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_14:
   default: false
   type: boolean
@@ -1875,7 +1875,7 @@ fix_origin_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_15:
   default: false
   type: boolean
@@ -1883,7 +1883,7 @@ fix_origin_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_16:
   default: false
   type: boolean
@@ -1891,7 +1891,7 @@ fix_origin_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_17:
   default: false
   type: boolean
@@ -1899,7 +1899,7 @@ fix_origin_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_18:
   default: false
   type: boolean
@@ -1907,7 +1907,7 @@ fix_origin_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_19:
   default: false
   type: boolean
@@ -1915,7 +1915,7 @@ fix_origin_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 fix_origin_20:
   default: false
   type: boolean
@@ -1923,7 +1923,7 @@ fix_origin_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nrair_1:
   default: 0
   type: integer
@@ -1933,7 +1933,7 @@ nrair_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 rair_start_1_1:
   default: .nan
   type: float
@@ -1944,7 +1944,7 @@ rair_start_1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 rair_end_1_1:
   default: .nan
   type: float
@@ -1955,7 +1955,7 @@ rair_end_1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nrair_2:
   default: 0
   type: integer
@@ -1965,7 +1965,7 @@ nrair_2:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 rair_start_2_1:
   default: .nan
   type: float
@@ -1976,7 +1976,7 @@ rair_start_2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 rair_end_2_1:
   default: .nan
   type: float
@@ -1987,7 +1987,7 @@ rair_end_2_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nrair_3:
   default: 0
   type: integer
@@ -1997,7 +1997,7 @@ nrair_3:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 rair_start_3_1:
   default: .nan
   type: float
@@ -2008,7 +2008,7 @@ rair_start_3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 rair_end_3_1:
   default: .nan
   type: float
@@ -2019,7 +2019,7 @@ rair_end_3_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nrair_4:
   default: 0
   type: integer
@@ -2029,7 +2029,7 @@ nrair_4:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 rair_start_4_1:
   default: .nan
   type: float
@@ -2040,7 +2040,7 @@ rair_start_4_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 rair_end_4_1:
   default: .nan
   type: float
@@ -2051,7 +2051,7 @@ rair_end_4_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nrair_5:
   default: 0
   type: integer
@@ -2061,7 +2061,7 @@ nrair_5:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 rair_start_5_1:
   default: .nan
   type: float
@@ -2072,7 +2072,7 @@ rair_start_5_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 rair_end_5_1:
   default: .nan
   type: float
@@ -2083,7 +2083,7 @@ rair_end_5_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nrair_6:
   default: 0
   type: integer
@@ -2093,7 +2093,7 @@ nrair_6:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 rair_start_6_1:
   default: .nan
   type: float
@@ -2104,7 +2104,7 @@ rair_start_6_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 rair_end_6_1:
   default: .nan
   type: float
@@ -2115,7 +2115,7 @@ rair_end_6_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nrair_7:
   default: 0
   type: integer
@@ -2125,7 +2125,7 @@ nrair_7:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 rair_start_7_1:
   default: .nan
   type: float
@@ -2136,7 +2136,7 @@ rair_start_7_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 rair_end_7_1:
   default: .nan
   type: float
@@ -2147,7 +2147,7 @@ rair_end_7_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nrair_8:
   default: 0
   type: integer
@@ -2157,7 +2157,7 @@ nrair_8:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 rair_start_8_1:
   default: .nan
   type: float
@@ -2168,7 +2168,7 @@ rair_start_8_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 rair_end_8_1:
   default: .nan
   type: float
@@ -2179,7 +2179,7 @@ rair_end_8_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nrair_9:
   default: 0
   type: integer
@@ -2189,7 +2189,7 @@ nrair_9:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 rair_start_9_1:
   default: .nan
   type: float
@@ -2200,7 +2200,7 @@ rair_start_9_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 rair_end_9_1:
   default: .nan
   type: float
@@ -2211,7 +2211,7 @@ rair_end_9_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nrair_10:
   default: 0
   type: integer
@@ -2221,7 +2221,7 @@ nrair_10:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 rair_start_10_1:
   default: .nan
   type: float
@@ -2232,7 +2232,7 @@ rair_start_10_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 rair_end_10_1:
   default: .nan
   type: float
@@ -2243,7 +2243,7 @@ rair_end_10_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nrair_11:
   default: 0
   type: integer
@@ -2253,7 +2253,7 @@ nrair_11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 rair_start_11_1:
   default: .nan
   type: float
@@ -2264,7 +2264,7 @@ rair_start_11_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 rair_end_11_1:
   default: .nan
   type: float
@@ -2275,7 +2275,7 @@ rair_end_11_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nrair_12:
   default: 0
   type: integer
@@ -2285,7 +2285,7 @@ nrair_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 rair_start_12_1:
   default: .nan
   type: float
@@ -2296,7 +2296,7 @@ rair_start_12_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 rair_end_12_1:
   default: .nan
   type: float
@@ -2307,7 +2307,7 @@ rair_end_12_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nrair_13:
   default: 0
   type: integer
@@ -2317,7 +2317,7 @@ nrair_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 rair_start_13_1:
   default: .nan
   type: float
@@ -2328,7 +2328,7 @@ rair_start_13_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 rair_end_13_1:
   default: .nan
   type: float
@@ -2339,7 +2339,7 @@ rair_end_13_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nrair_14:
   default: 0
   type: integer
@@ -2349,7 +2349,7 @@ nrair_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 rair_start_14_1:
   default: .nan
   type: float
@@ -2360,7 +2360,7 @@ rair_start_14_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 rair_end_14_1:
   default: .nan
   type: float
@@ -2371,7 +2371,7 @@ rair_end_14_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nrair_15:
   default: 0
   type: integer
@@ -2381,7 +2381,7 @@ nrair_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 rair_start_15_1:
   default: .nan
   type: float
@@ -2392,7 +2392,7 @@ rair_start_15_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 rair_end_15_1:
   default: .nan
   type: float
@@ -2403,7 +2403,7 @@ rair_end_15_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nrair_16:
   default: 0
   type: integer
@@ -2413,7 +2413,7 @@ nrair_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 rair_start_16_1:
   default: .nan
   type: float
@@ -2424,7 +2424,7 @@ rair_start_16_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 rair_end_16_1:
   default: .nan
   type: float
@@ -2435,7 +2435,7 @@ rair_end_16_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nrair_17:
   default: 0
   type: integer
@@ -2445,7 +2445,7 @@ nrair_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 rair_start_17_1:
   default: .nan
   type: float
@@ -2456,7 +2456,7 @@ rair_start_17_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 rair_end_17_1:
   default: .nan
   type: float
@@ -2467,7 +2467,7 @@ rair_end_17_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nrair_18:
   default: 0
   type: integer
@@ -2477,7 +2477,7 @@ nrair_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 rair_start_18_1:
   default: .nan
   type: float
@@ -2488,7 +2488,7 @@ rair_start_18_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 rair_end_18_1:
   default: .nan
   type: float
@@ -2499,7 +2499,7 @@ rair_end_18_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nrair_19:
   default: 0
   type: integer
@@ -2509,7 +2509,7 @@ nrair_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 rair_start_19_1:
   default: .nan
   type: float
@@ -2520,7 +2520,7 @@ rair_start_19_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 rair_end_19_1:
   default: .nan
   type: float
@@ -2531,7 +2531,7 @@ rair_end_19_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nrair_20:
   default: 0
   type: integer
@@ -2541,7 +2541,7 @@ nrair_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 rair_start_20_1:
   default: .nan
   type: float
@@ -2552,7 +2552,7 @@ rair_start_20_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 rair_end_20_1:
   default: .nan
   type: float
@@ -2563,7 +2563,7 @@ rair_end_20_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_air:
   default: 0.01
   type: float
@@ -2574,7 +2574,7 @@ w_air:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_bsa:
   default: -0.01
   type: float
@@ -2585,7 +2585,7 @@ w_bsa:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_cdih:
   default: 0.0
   type: float
@@ -2596,7 +2596,7 @@ w_cdih:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_dani:
   default: 0.01
   type: float
@@ -2607,7 +2607,7 @@ w_dani:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_deint:
   default: 0.0
   type: float
@@ -2618,7 +2618,7 @@ w_deint:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_desolv:
   default: 1.0
   type: float
@@ -2629,7 +2629,7 @@ w_desolv:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_dist:
   default: 0.01
   type: float
@@ -2640,7 +2640,7 @@ w_dist:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_elec:
   default: 1.0
   type: float
@@ -2651,7 +2651,7 @@ w_elec:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_lcc:
   default: -400.0
   type: float
@@ -2662,7 +2662,7 @@ w_lcc:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_rg:
   default: 0.1
   type: float
@@ -2673,7 +2673,7 @@ w_rg:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_sani:
   default: 0.1
   type: float
@@ -2684,7 +2684,7 @@ w_sani:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_sym:
   default: 0.1
   type: float
@@ -2695,7 +2695,7 @@ w_sym:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_vdw:
   default: 0.01
   type: float
@@ -2706,7 +2706,7 @@ w_vdw:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_vean:
   default: 0.1
   type: float
@@ -2717,7 +2717,7 @@ w_vean:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_xpcs:
   default: 0.1
   type: float
@@ -2728,7 +2728,7 @@ w_xpcs:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_xrdc:
   default: 0.1
   type: float
@@ -2739,7 +2739,7 @@ w_xrdc:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_zres:
   default: 0.1
   type: float
@@ -2750,7 +2750,7 @@ w_zres:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 elecflag:
   default: true
   type: boolean
@@ -2758,7 +2758,7 @@ elecflag:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 dielec:
   default: rdie
   type: string
@@ -2768,7 +2768,7 @@ dielec:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 epsilon:
   default: 10.0
   type: float
@@ -2779,7 +2779,7 @@ epsilon:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 inter_rigid:
   default: 1.0
   type: float
@@ -2790,7 +2790,7 @@ inter_rigid:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 par_nonbonded:
   default: OPLSX
   type: string
@@ -2800,7 +2800,7 @@ par_nonbonded:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_1:
   default: 1.0
   type: float
@@ -2811,7 +2811,7 @@ int_1_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_2:
   default: 1.0
   type: float
@@ -2822,7 +2822,7 @@ int_1_2:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_3:
   default: 1.0
   type: float
@@ -2833,7 +2833,7 @@ int_1_3:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_4:
   default: 1.0
   type: float
@@ -2844,7 +2844,7 @@ int_1_4:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_5:
   default: 1.0
   type: float
@@ -2855,7 +2855,7 @@ int_1_5:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_6:
   default: 1.0
   type: float
@@ -2866,7 +2866,7 @@ int_1_6:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_7:
   default: 1.0
   type: float
@@ -2877,7 +2877,7 @@ int_1_7:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_8:
   default: 1.0
   type: float
@@ -2888,7 +2888,7 @@ int_1_8:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_9:
   default: 1.0
   type: float
@@ -2899,7 +2899,7 @@ int_1_9:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_10:
   default: 1.0
   type: float
@@ -2910,7 +2910,7 @@ int_1_10:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_11:
   default: 1.0
   type: float
@@ -2921,7 +2921,7 @@ int_1_11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_12:
   default: 1.0
   type: float
@@ -2932,7 +2932,7 @@ int_1_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_13:
   default: 1.0
   type: float
@@ -2943,7 +2943,7 @@ int_1_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_14:
   default: 1.0
   type: float
@@ -2954,7 +2954,7 @@ int_1_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_15:
   default: 1.0
   type: float
@@ -2965,7 +2965,7 @@ int_1_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_16:
   default: 1.0
   type: float
@@ -2976,7 +2976,7 @@ int_1_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_17:
   default: 1.0
   type: float
@@ -2987,7 +2987,7 @@ int_1_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_18:
   default: 1.0
   type: float
@@ -2998,7 +2998,7 @@ int_1_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_19:
   default: 1.0
   type: float
@@ -3009,7 +3009,7 @@ int_1_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_1_20:
   default: 1.0
   type: float
@@ -3020,7 +3020,7 @@ int_1_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_2:
   default: 1.0
   type: float
@@ -3031,7 +3031,7 @@ int_2_2:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_3:
   default: 1.0
   type: float
@@ -3042,7 +3042,7 @@ int_2_3:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_4:
   default: 1.0
   type: float
@@ -3053,7 +3053,7 @@ int_2_4:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_5:
   default: 1.0
   type: float
@@ -3064,7 +3064,7 @@ int_2_5:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_6:
   default: 1.0
   type: float
@@ -3075,7 +3075,7 @@ int_2_6:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_7:
   default: 1.0
   type: float
@@ -3086,7 +3086,7 @@ int_2_7:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_8:
   default: 1.0
   type: float
@@ -3097,7 +3097,7 @@ int_2_8:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_9:
   default: 1.0
   type: float
@@ -3108,7 +3108,7 @@ int_2_9:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_10:
   default: 1.0
   type: float
@@ -3119,7 +3119,7 @@ int_2_10:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_11:
   default: 1.0
   type: float
@@ -3130,7 +3130,7 @@ int_2_11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_12:
   default: 1.0
   type: float
@@ -3141,7 +3141,7 @@ int_2_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_13:
   default: 1.0
   type: float
@@ -3152,7 +3152,7 @@ int_2_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_14:
   default: 1.0
   type: float
@@ -3163,7 +3163,7 @@ int_2_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_15:
   default: 1.0
   type: float
@@ -3174,7 +3174,7 @@ int_2_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_16:
   default: 1.0
   type: float
@@ -3185,7 +3185,7 @@ int_2_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_17:
   default: 1.0
   type: float
@@ -3196,7 +3196,7 @@ int_2_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_18:
   default: 1.0
   type: float
@@ -3207,7 +3207,7 @@ int_2_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_19:
   default: 1.0
   type: float
@@ -3218,7 +3218,7 @@ int_2_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_2_20:
   default: 1.0
   type: float
@@ -3229,7 +3229,7 @@ int_2_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_3:
   default: 1.0
   type: float
@@ -3240,7 +3240,7 @@ int_3_3:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_4:
   default: 1.0
   type: float
@@ -3251,7 +3251,7 @@ int_3_4:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_5:
   default: 1.0
   type: float
@@ -3262,7 +3262,7 @@ int_3_5:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_6:
   default: 1.0
   type: float
@@ -3273,7 +3273,7 @@ int_3_6:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_7:
   default: 1.0
   type: float
@@ -3284,7 +3284,7 @@ int_3_7:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_8:
   default: 1.0
   type: float
@@ -3295,7 +3295,7 @@ int_3_8:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_9:
   default: 1.0
   type: float
@@ -3306,7 +3306,7 @@ int_3_9:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_10:
   default: 1.0
   type: float
@@ -3317,7 +3317,7 @@ int_3_10:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_11:
   default: 1.0
   type: float
@@ -3328,7 +3328,7 @@ int_3_11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_12:
   default: 1.0
   type: float
@@ -3339,7 +3339,7 @@ int_3_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_13:
   default: 1.0
   type: float
@@ -3350,7 +3350,7 @@ int_3_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_14:
   default: 1.0
   type: float
@@ -3361,7 +3361,7 @@ int_3_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_15:
   default: 1.0
   type: float
@@ -3372,7 +3372,7 @@ int_3_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_16:
   default: 1.0
   type: float
@@ -3383,7 +3383,7 @@ int_3_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_17:
   default: 1.0
   type: float
@@ -3394,7 +3394,7 @@ int_3_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_18:
   default: 1.0
   type: float
@@ -3405,7 +3405,7 @@ int_3_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_19:
   default: 1.0
   type: float
@@ -3416,7 +3416,7 @@ int_3_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_3_20:
   default: 1.0
   type: float
@@ -3427,7 +3427,7 @@ int_3_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_4:
   default: 1.0
   type: float
@@ -3438,7 +3438,7 @@ int_4_4:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_5:
   default: 1.0
   type: float
@@ -3449,7 +3449,7 @@ int_4_5:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_6:
   default: 1.0
   type: float
@@ -3460,7 +3460,7 @@ int_4_6:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_7:
   default: 1.0
   type: float
@@ -3471,7 +3471,7 @@ int_4_7:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_8:
   default: 1.0
   type: float
@@ -3482,7 +3482,7 @@ int_4_8:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_9:
   default: 1.0
   type: float
@@ -3493,7 +3493,7 @@ int_4_9:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_10:
   default: 1.0
   type: float
@@ -3504,7 +3504,7 @@ int_4_10:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_11:
   default: 1.0
   type: float
@@ -3515,7 +3515,7 @@ int_4_11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_12:
   default: 1.0
   type: float
@@ -3526,7 +3526,7 @@ int_4_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_13:
   default: 1.0
   type: float
@@ -3537,7 +3537,7 @@ int_4_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_14:
   default: 1.0
   type: float
@@ -3548,7 +3548,7 @@ int_4_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_15:
   default: 1.0
   type: float
@@ -3559,7 +3559,7 @@ int_4_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_16:
   default: 1.0
   type: float
@@ -3570,7 +3570,7 @@ int_4_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_17:
   default: 1.0
   type: float
@@ -3581,7 +3581,7 @@ int_4_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_18:
   default: 1.0
   type: float
@@ -3592,7 +3592,7 @@ int_4_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_19:
   default: 1.0
   type: float
@@ -3603,7 +3603,7 @@ int_4_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_4_20:
   default: 1.0
   type: float
@@ -3614,7 +3614,7 @@ int_4_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_5:
   default: 1.0
   type: float
@@ -3625,7 +3625,7 @@ int_5_5:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_6:
   default: 1.0
   type: float
@@ -3636,7 +3636,7 @@ int_5_6:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_7:
   default: 1.0
   type: float
@@ -3647,7 +3647,7 @@ int_5_7:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_8:
   default: 1.0
   type: float
@@ -3658,7 +3658,7 @@ int_5_8:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_9:
   default: 1.0
   type: float
@@ -3669,7 +3669,7 @@ int_5_9:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_10:
   default: 1.0
   type: float
@@ -3680,7 +3680,7 @@ int_5_10:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_11:
   default: 1.0
   type: float
@@ -3691,7 +3691,7 @@ int_5_11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_12:
   default: 1.0
   type: float
@@ -3702,7 +3702,7 @@ int_5_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_13:
   default: 1.0
   type: float
@@ -3713,7 +3713,7 @@ int_5_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_14:
   default: 1.0
   type: float
@@ -3724,7 +3724,7 @@ int_5_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_15:
   default: 1.0
   type: float
@@ -3735,7 +3735,7 @@ int_5_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_16:
   default: 1.0
   type: float
@@ -3746,7 +3746,7 @@ int_5_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_17:
   default: 1.0
   type: float
@@ -3757,7 +3757,7 @@ int_5_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_18:
   default: 1.0
   type: float
@@ -3768,7 +3768,7 @@ int_5_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_19:
   default: 1.0
   type: float
@@ -3779,7 +3779,7 @@ int_5_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_5_20:
   default: 1.0
   type: float
@@ -3790,7 +3790,7 @@ int_5_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_6_6:
   default: 1.0
   type: float
@@ -3801,7 +3801,7 @@ int_6_6:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_6_7:
   default: 1.0
   type: float
@@ -3812,7 +3812,7 @@ int_6_7:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_6_8:
   default: 1.0
   type: float
@@ -3823,7 +3823,7 @@ int_6_8:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_6_9:
   default: 1.0
   type: float
@@ -3834,7 +3834,7 @@ int_6_9:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_6_10:
   default: 1.0
   type: float
@@ -3845,7 +3845,7 @@ int_6_10:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_6_11:
   default: 1.0
   type: float
@@ -3856,7 +3856,7 @@ int_6_11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_6_12:
   default: 1.0
   type: float
@@ -3867,7 +3867,7 @@ int_6_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_6_13:
   default: 1.0
   type: float
@@ -3878,7 +3878,7 @@ int_6_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_6_14:
   default: 1.0
   type: float
@@ -3889,7 +3889,7 @@ int_6_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_6_15:
   default: 1.0
   type: float
@@ -3900,7 +3900,7 @@ int_6_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_6_16:
   default: 1.0
   type: float
@@ -3911,7 +3911,7 @@ int_6_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_6_17:
   default: 1.0
   type: float
@@ -3922,7 +3922,7 @@ int_6_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_6_18:
   default: 1.0
   type: float
@@ -3933,7 +3933,7 @@ int_6_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_6_19:
   default: 1.0
   type: float
@@ -3944,7 +3944,7 @@ int_6_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_6_20:
   default: 1.0
   type: float
@@ -3955,7 +3955,7 @@ int_6_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_7_7:
   default: 1.0
   type: float
@@ -3966,7 +3966,7 @@ int_7_7:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_7_8:
   default: 1.0
   type: float
@@ -3977,7 +3977,7 @@ int_7_8:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_7_9:
   default: 1.0
   type: float
@@ -3988,7 +3988,7 @@ int_7_9:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_7_10:
   default: 1.0
   type: float
@@ -3999,7 +3999,7 @@ int_7_10:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_7_11:
   default: 1.0
   type: float
@@ -4010,7 +4010,7 @@ int_7_11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_7_12:
   default: 1.0
   type: float
@@ -4021,7 +4021,7 @@ int_7_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_7_13:
   default: 1.0
   type: float
@@ -4032,7 +4032,7 @@ int_7_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_7_14:
   default: 1.0
   type: float
@@ -4043,7 +4043,7 @@ int_7_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_7_15:
   default: 1.0
   type: float
@@ -4054,7 +4054,7 @@ int_7_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_7_16:
   default: 1.0
   type: float
@@ -4065,7 +4065,7 @@ int_7_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_7_17:
   default: 1.0
   type: float
@@ -4076,7 +4076,7 @@ int_7_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_7_18:
   default: 1.0
   type: float
@@ -4087,7 +4087,7 @@ int_7_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_7_19:
   default: 1.0
   type: float
@@ -4098,7 +4098,7 @@ int_7_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_8_8:
   default: 1.0
   type: float
@@ -4109,7 +4109,7 @@ int_8_8:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_8_9:
   default: 1.0
   type: float
@@ -4120,7 +4120,7 @@ int_8_9:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_7_20:
   default: 1.0
   type: float
@@ -4131,7 +4131,7 @@ int_7_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_8_10:
   default: 1.0
   type: float
@@ -4142,7 +4142,7 @@ int_8_10:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_8_11:
   default: 1.0
   type: float
@@ -4153,7 +4153,7 @@ int_8_11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_8_12:
   default: 1.0
   type: float
@@ -4164,7 +4164,7 @@ int_8_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_8_13:
   default: 1.0
   type: float
@@ -4175,7 +4175,7 @@ int_8_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_8_14:
   default: 1.0
   type: float
@@ -4186,7 +4186,7 @@ int_8_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_8_15:
   default: 1.0
   type: float
@@ -4197,7 +4197,7 @@ int_8_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_8_16:
   default: 1.0
   type: float
@@ -4208,7 +4208,7 @@ int_8_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_8_17:
   default: 1.0
   type: float
@@ -4219,7 +4219,7 @@ int_8_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_8_18:
   default: 1.0
   type: float
@@ -4230,7 +4230,7 @@ int_8_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_8_19:
   default: 1.0
   type: float
@@ -4241,7 +4241,7 @@ int_8_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_8_20:
   default: 1.0
   type: float
@@ -4252,7 +4252,7 @@ int_8_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_9_11:
   default: 1.0
   type: float
@@ -4263,7 +4263,7 @@ int_9_11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_9_12:
   default: 1.0
   type: float
@@ -4274,7 +4274,7 @@ int_9_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_9_13:
   default: 1.0
   type: float
@@ -4285,7 +4285,7 @@ int_9_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_9_14:
   default: 1.0
   type: float
@@ -4296,7 +4296,7 @@ int_9_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_9_15:
   default: 1.0
   type: float
@@ -4307,7 +4307,7 @@ int_9_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_9_16:
   default: 1.0
   type: float
@@ -4318,7 +4318,7 @@ int_9_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_9_17:
   default: 1.0
   type: float
@@ -4329,7 +4329,7 @@ int_9_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_9_18:
   default: 1.0
   type: float
@@ -4340,7 +4340,7 @@ int_9_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_9_19:
   default: 1.0
   type: float
@@ -4351,7 +4351,7 @@ int_9_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_9_20:
   default: 1.0
   type: float
@@ -4362,7 +4362,7 @@ int_9_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_9_9:
   default: 1.0
   type: float
@@ -4373,7 +4373,7 @@ int_9_9:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_9_10:
   default: 1.0
   type: float
@@ -4384,7 +4384,7 @@ int_9_10:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_10_10:
   default: 1.0
   type: float
@@ -4395,7 +4395,7 @@ int_10_10:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_10_11:
   default: 1.0
   type: float
@@ -4406,7 +4406,7 @@ int_10_11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_10_12:
   default: 1.0
   type: float
@@ -4417,7 +4417,7 @@ int_10_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_10_13:
   default: 1.0
   type: float
@@ -4428,7 +4428,7 @@ int_10_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_10_14:
   default: 1.0
   type: float
@@ -4439,7 +4439,7 @@ int_10_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_10_15:
   default: 1.0
   type: float
@@ -4450,7 +4450,7 @@ int_10_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_10_16:
   default: 1.0
   type: float
@@ -4461,7 +4461,7 @@ int_10_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_10_17:
   default: 1.0
   type: float
@@ -4472,7 +4472,7 @@ int_10_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_10_18:
   default: 1.0
   type: float
@@ -4483,7 +4483,7 @@ int_10_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_10_19:
   default: 1.0
   type: float
@@ -4494,7 +4494,7 @@ int_10_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_10_20:
   default: 1.0
   type: float
@@ -4505,7 +4505,7 @@ int_10_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_11_11:
   default: 1.0
   type: float
@@ -4516,7 +4516,7 @@ int_11_11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_11_12:
   default: 1.0
   type: float
@@ -4527,7 +4527,7 @@ int_11_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_11_13:
   default: 1.0
   type: float
@@ -4538,7 +4538,7 @@ int_11_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_11_14:
   default: 1.0
   type: float
@@ -4549,7 +4549,7 @@ int_11_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_11_15:
   default: 1.0
   type: float
@@ -4560,7 +4560,7 @@ int_11_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_11_16:
   default: 1.0
   type: float
@@ -4571,7 +4571,7 @@ int_11_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_11_17:
   default: 1.0
   type: float
@@ -4582,7 +4582,7 @@ int_11_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_11_18:
   default: 1.0
   type: float
@@ -4593,7 +4593,7 @@ int_11_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_11_19:
   default: 1.0
   type: float
@@ -4604,7 +4604,7 @@ int_11_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_11_20:
   default: 1.0
   type: float
@@ -4615,7 +4615,7 @@ int_11_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_12_12:
   default: 1.0
   type: float
@@ -4626,7 +4626,7 @@ int_12_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_12_13:
   default: 1.0
   type: float
@@ -4637,7 +4637,7 @@ int_12_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_12_14:
   default: 1.0
   type: float
@@ -4648,7 +4648,7 @@ int_12_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_12_15:
   default: 1.0
   type: float
@@ -4659,7 +4659,7 @@ int_12_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_12_16:
   default: 1.0
   type: float
@@ -4670,7 +4670,7 @@ int_12_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_12_17:
   default: 1.0
   type: float
@@ -4681,7 +4681,7 @@ int_12_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_12_18:
   default: 1.0
   type: float
@@ -4692,7 +4692,7 @@ int_12_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_12_19:
   default: 1.0
   type: float
@@ -4703,7 +4703,7 @@ int_12_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_12_20:
   default: 1.0
   type: float
@@ -4714,7 +4714,7 @@ int_12_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_13_13:
   default: 1.0
   type: float
@@ -4725,7 +4725,7 @@ int_13_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_13_14:
   default: 1.0
   type: float
@@ -4736,7 +4736,7 @@ int_13_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_13_15:
   default: 1.0
   type: float
@@ -4747,7 +4747,7 @@ int_13_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_13_16:
   default: 1.0
   type: float
@@ -4758,7 +4758,7 @@ int_13_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_13_17:
   default: 1.0
   type: float
@@ -4769,7 +4769,7 @@ int_13_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_13_18:
   default: 1.0
   type: float
@@ -4780,7 +4780,7 @@ int_13_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_13_19:
   default: 1.0
   type: float
@@ -4791,7 +4791,7 @@ int_13_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_13_20:
   default: 1.0
   type: float
@@ -4802,7 +4802,7 @@ int_13_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_14_14:
   default: 1.0
   type: float
@@ -4813,7 +4813,7 @@ int_14_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_14_15:
   default: 1.0
   type: float
@@ -4824,7 +4824,7 @@ int_14_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_14_16:
   default: 1.0
   type: float
@@ -4835,7 +4835,7 @@ int_14_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_14_17:
   default: 1.0
   type: float
@@ -4846,7 +4846,7 @@ int_14_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_14_18:
   default: 1.0
   type: float
@@ -4857,7 +4857,7 @@ int_14_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_14_19:
   default: 1.0
   type: float
@@ -4868,7 +4868,7 @@ int_14_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_14_20:
   default: 1.0
   type: float
@@ -4879,7 +4879,7 @@ int_14_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_15_15:
   default: 1.0
   type: float
@@ -4890,7 +4890,7 @@ int_15_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_15_16:
   default: 1.0
   type: float
@@ -4901,7 +4901,7 @@ int_15_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_15_17:
   default: 1.0
   type: float
@@ -4912,7 +4912,7 @@ int_15_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_15_18:
   default: 1.0
   type: float
@@ -4923,7 +4923,7 @@ int_15_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_15_19:
   default: 1.0
   type: float
@@ -4934,7 +4934,7 @@ int_15_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_15_20:
   default: 1.0
   type: float
@@ -4945,7 +4945,7 @@ int_15_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_16_16:
   default: 1.0
   type: float
@@ -4956,7 +4956,7 @@ int_16_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_16_17:
   default: 1.0
   type: float
@@ -4967,7 +4967,7 @@ int_16_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_16_18:
   default: 1.0
   type: float
@@ -4978,7 +4978,7 @@ int_16_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_16_19:
   default: 1.0
   type: float
@@ -4989,7 +4989,7 @@ int_16_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_16_20:
   default: 1.0
   type: float
@@ -5000,7 +5000,7 @@ int_16_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_17_17:
   default: 1.0
   type: float
@@ -5011,7 +5011,7 @@ int_17_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_17_18:
   default: 1.0
   type: float
@@ -5022,7 +5022,7 @@ int_17_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_17_19:
   default: 1.0
   type: float
@@ -5033,7 +5033,7 @@ int_17_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_17_20:
   default: 1.0
   type: float
@@ -5044,7 +5044,7 @@ int_17_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_18_18:
   default: 1.0
   type: float
@@ -5055,7 +5055,7 @@ int_18_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_18_19:
   default: 1.0
   type: float
@@ -5066,7 +5066,7 @@ int_18_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_18_20:
   default: 1.0
   type: float
@@ -5077,7 +5077,7 @@ int_18_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_19_19:
   default: 1.0
   type: float
@@ -5088,7 +5088,7 @@ int_19_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_19_20:
   default: 1.0
   type: float
@@ -5099,7 +5099,7 @@ int_19_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 int_20_20:
   default: 1.0
   type: float
@@ -5110,4 +5110,4 @@ int_20_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy

--- a/src/haddock/modules/scoring/emscoring/defaults.yaml
+++ b/src/haddock/modules/scoring/emscoring/defaults.yaml
@@ -7,7 +7,7 @@ tolerance:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 log_level:
   default: verbose
   type: string
@@ -17,7 +17,7 @@ log_level:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ligand_param_fname:
   default: ''
   type: file
@@ -25,7 +25,7 @@ ligand_param_fname:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ligand_top_fname:
   default: ''
   type: file
@@ -33,7 +33,7 @@ ligand_top_fname:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 individualize:
   default: true
   type: boolean
@@ -41,7 +41,7 @@ individualize:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 nemsteps:
   default: 40
   type: integer
@@ -51,7 +51,7 @@ nemsteps:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 elecflag:
   default: true
   type: boolean
@@ -59,7 +59,7 @@ elecflag:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 dielec:
   default: cdie
   type: string
@@ -69,7 +69,7 @@ dielec:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 epsilon:
   default: 1.0
   type: float
@@ -80,7 +80,7 @@ epsilon:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 dihedflag:
   default: true
   type: boolean
@@ -88,7 +88,7 @@ dihedflag:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 par_nonbonded:
   default: OPLSX
   type: string
@@ -98,7 +98,7 @@ par_nonbonded:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_air:
   default: 0.0
   type: float
@@ -109,7 +109,7 @@ w_air:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_bsa:
   default: 0.0
   type: float
@@ -120,7 +120,7 @@ w_bsa:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_cdih:
   default: 0.0
   type: float
@@ -131,7 +131,7 @@ w_cdih:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_dani:
   default: 0.0
   type: float
@@ -142,7 +142,7 @@ w_dani:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_deint:
   default: 0.0
   type: float
@@ -153,7 +153,7 @@ w_deint:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_desolv:
   default: 1.0
   type: float
@@ -164,7 +164,7 @@ w_desolv:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_dist:
   default: 0.0
   type: float
@@ -175,7 +175,7 @@ w_dist:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_elec:
   default: 0.2
   type: float
@@ -186,7 +186,7 @@ w_elec:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_lcc:
   default: 0.0
   type: float
@@ -197,7 +197,7 @@ w_lcc:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_rg:
   default: 0.0
   type: float
@@ -208,7 +208,7 @@ w_rg:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_sani:
   default: 0.0
   type: float
@@ -219,7 +219,7 @@ w_sani:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_sym:
   default: 0.0
   type: float
@@ -230,7 +230,7 @@ w_sym:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_vdw:
   default: 1.0
   type: float
@@ -241,7 +241,7 @@ w_vdw:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_vean:
   default: 0.0
   type: float
@@ -252,7 +252,7 @@ w_vean:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_xpcs:
   default: 0.0
   type: float
@@ -263,7 +263,7 @@ w_xpcs:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_xrdc:
   default: 0.0
   type: float
@@ -274,7 +274,7 @@ w_xrdc:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 w_zres:
   default: 0.0
   type: float
@@ -285,7 +285,7 @@ w_zres:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_1:
   default: false
   type: boolean
@@ -293,7 +293,7 @@ shape_1:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_2:
   default: false
   type: boolean
@@ -301,7 +301,7 @@ shape_2:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_3:
   default: false
   type: boolean
@@ -309,7 +309,7 @@ shape_3:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_4:
   default: false
   type: boolean
@@ -317,7 +317,7 @@ shape_4:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_5:
   default: false
   type: boolean
@@ -325,7 +325,7 @@ shape_5:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_6:
   default: false
   type: boolean
@@ -333,7 +333,7 @@ shape_6:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_7:
   default: false
   type: boolean
@@ -341,7 +341,7 @@ shape_7:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_8:
   default: false
   type: boolean
@@ -349,7 +349,7 @@ shape_8:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_9:
   default: false
   type: boolean
@@ -357,7 +357,7 @@ shape_9:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_10:
   default: false
   type: boolean
@@ -365,7 +365,7 @@ shape_10:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_11:
   default: false
   type: boolean
@@ -373,7 +373,7 @@ shape_11:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_12:
   default: false
   type: boolean
@@ -381,7 +381,7 @@ shape_12:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_13:
   default: false
   type: boolean
@@ -389,7 +389,7 @@ shape_13:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_14:
   default: false
   type: boolean
@@ -397,7 +397,7 @@ shape_14:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_15:
   default: false
   type: boolean
@@ -405,7 +405,7 @@ shape_15:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_16:
   default: false
   type: boolean
@@ -413,7 +413,7 @@ shape_16:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_17:
   default: false
   type: boolean
@@ -421,7 +421,7 @@ shape_17:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_18:
   default: false
   type: boolean
@@ -429,7 +429,7 @@ shape_18:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_19:
   default: false
   type: boolean
@@ -437,7 +437,7 @@ shape_19:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 shape_20:
   default: false
   type: boolean
@@ -445,4 +445,4 @@ shape_20:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy

--- a/src/haddock/modules/topology/topoaa/defaults.yaml
+++ b/src/haddock/modules/topology/topoaa/defaults.yaml
@@ -8,7 +8,7 @@ autohis:
     histidines ((+1: HIS or 0: HISD/HISE) by selecting the state leading to the lowest
     electrostatic energy'
   group: molecule
-  explevel: basic
+  explevel: easy
 delenph:
   default: true
   type: boolean
@@ -20,7 +20,7 @@ delenph:
     not be done if you are defining distance restraints to specific hydrogen atoms
     (e.g. when using NMR distance restraints).
   group: molecule
-  explevel: basic
+  explevel: easy
 log_level:
   default: verbose
   type: string
@@ -31,7 +31,7 @@ log_level:
   long: CNS, the computational engine used by HADDOCK can generate a lot of output
     messages. This parameter controls the verbosity of CNS (minimal or verbose)
   group: module
-  explevel: expert
+  explevel: guru
 iniseed:
   default: 917
   type: integer
@@ -41,7 +41,7 @@ iniseed:
   short: Random seed used in CNS to initialize the random seed function
   long: Random seed used in CNS to initialize the random seed function
   group: molecule
-  explevel: expert
+  explevel: guru
 ligand_param_fname:
   default: ''
   type: file
@@ -49,7 +49,7 @@ ligand_param_fname:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ligand_top_fname:
   default: ''
   type: file
@@ -57,7 +57,7 @@ ligand_top_fname:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 limit:
   default: true
   type: boolean
@@ -65,7 +65,7 @@ limit:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 tolerance:
   default: 0
   type: integer
@@ -75,7 +75,7 @@ tolerance:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 mol1:
   prot_segid:
     default: A
@@ -86,7 +86,7 @@ mol1:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   fix_origin:
     default: false
     type: boolean
@@ -94,7 +94,7 @@ mol1:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   dna:
     default: false
     type: boolean
@@ -102,7 +102,7 @@ mol1:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   shape:
     default: false
     type: boolean
@@ -110,7 +110,7 @@ mol1:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   cg:
     default: false
     type: boolean
@@ -118,7 +118,7 @@ mol1:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   cyclicpept:
     default: false
     type: boolean
@@ -126,7 +126,7 @@ mol1:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   nhisd:
     default: 0
     type: integer
@@ -136,7 +136,7 @@ mol1:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   hisd_1:
     default: .nan
     type: float
@@ -147,7 +147,7 @@ mol1:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   nhise:
     default: 0
     type: integer
@@ -157,7 +157,7 @@ mol1:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   hise_1:
     default: .nan
     type: float
@@ -168,8 +168,8 @@ mol1:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
-  explevel: basic
+    explevel: easy
+  explevel: easy
 mol2:
   prot_segid:
     default: B
@@ -180,7 +180,7 @@ mol2:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   fix_origin:
     default: false
     type: boolean
@@ -188,7 +188,7 @@ mol2:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   dna:
     default: false
     type: boolean
@@ -196,7 +196,7 @@ mol2:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   shape:
     default: false
     type: boolean
@@ -204,7 +204,7 @@ mol2:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   cg:
     default: false
     type: boolean
@@ -212,7 +212,7 @@ mol2:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   cyclicpept:
     default: false
     type: boolean
@@ -220,7 +220,7 @@ mol2:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   nhisd:
     default: 0
     type: integer
@@ -230,7 +230,7 @@ mol2:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   hisd_1:
     default: .nan
     type: float
@@ -241,7 +241,7 @@ mol2:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   nhise:
     default: 0
     type: integer
@@ -251,7 +251,7 @@ mol2:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   hise_1:
     default: .nan
     type: float
@@ -262,8 +262,8 @@ mol2:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
-  explevel: basic
+    explevel: easy
+  explevel: easy
 mol3:
   prot_segid:
     default: C
@@ -274,7 +274,7 @@ mol3:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   fix_origin:
     default: false
     type: boolean
@@ -282,7 +282,7 @@ mol3:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   dna:
     default: false
     type: boolean
@@ -290,7 +290,7 @@ mol3:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   shape:
     default: false
     type: boolean
@@ -298,7 +298,7 @@ mol3:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   cg:
     default: false
     type: boolean
@@ -306,7 +306,7 @@ mol3:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   cyclicpept:
     default: false
     type: boolean
@@ -314,7 +314,7 @@ mol3:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   nhisd:
     default: 0
     type: integer
@@ -324,7 +324,7 @@ mol3:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   hisd_1:
     default: .nan
     type: float
@@ -335,7 +335,7 @@ mol3:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   nhise:
     default: 0
     type: integer
@@ -345,7 +345,7 @@ mol3:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   hise_1:
     default: .nan
     type: float
@@ -356,8 +356,8 @@ mol3:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
-  explevel: basic
+    explevel: easy
+  explevel: easy
 mol4:
   prot_segid:
     default: D
@@ -368,7 +368,7 @@ mol4:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   fix_origin:
     default: false
     type: boolean
@@ -376,7 +376,7 @@ mol4:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   dna:
     default: false
     type: boolean
@@ -384,7 +384,7 @@ mol4:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   shape:
     default: false
     type: boolean
@@ -392,7 +392,7 @@ mol4:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   cg:
     default: false
     type: boolean
@@ -400,7 +400,7 @@ mol4:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   cyclicpept:
     default: false
     type: boolean
@@ -408,7 +408,7 @@ mol4:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   nhisd:
     default: 0
     type: integer
@@ -418,7 +418,7 @@ mol4:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   hisd_1:
     default: .nan
     type: float
@@ -429,7 +429,7 @@ mol4:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   nhise:
     default: 0
     type: integer
@@ -439,7 +439,7 @@ mol4:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   hise_1:
     default: .nan
     type: float
@@ -450,8 +450,8 @@ mol4:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
-  explevel: basic
+    explevel: easy
+  explevel: easy
 mol5:
   prot_segid:
     default: E
@@ -462,7 +462,7 @@ mol5:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   fix_origin:
     default: false
     type: boolean
@@ -470,7 +470,7 @@ mol5:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   dna:
     default: false
     type: boolean
@@ -478,7 +478,7 @@ mol5:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   shape:
     default: false
     type: boolean
@@ -486,7 +486,7 @@ mol5:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   cg:
     default: false
     type: boolean
@@ -494,7 +494,7 @@ mol5:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   cyclicpept:
     default: false
     type: boolean
@@ -502,7 +502,7 @@ mol5:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   nhisd:
     default: 0
     type: integer
@@ -512,7 +512,7 @@ mol5:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   hisd_1:
     default: .nan
     type: float
@@ -523,7 +523,7 @@ mol5:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   nhise:
     default: 0
     type: integer
@@ -533,7 +533,7 @@ mol5:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   hise_1:
     default: .nan
     type: float
@@ -544,8 +544,8 @@ mol5:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
-  explevel: basic
+    explevel: easy
+  explevel: easy
 mol6:
   prot_segid:
     default: F
@@ -556,7 +556,7 @@ mol6:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   fix_origin:
     default: false
     type: boolean
@@ -564,7 +564,7 @@ mol6:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   dna:
     default: false
     type: boolean
@@ -572,7 +572,7 @@ mol6:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   shape:
     default: false
     type: boolean
@@ -580,7 +580,7 @@ mol6:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   cg:
     default: false
     type: boolean
@@ -588,7 +588,7 @@ mol6:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   cyclicpept:
     default: false
     type: boolean
@@ -596,7 +596,7 @@ mol6:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   nhisd:
     default: 0
     type: integer
@@ -606,7 +606,7 @@ mol6:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   hisd_1:
     default: .nan
     type: float
@@ -617,7 +617,7 @@ mol6:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   nhise:
     default: 0
     type: integer
@@ -627,7 +627,7 @@ mol6:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   hise_1:
     default: .nan
     type: float
@@ -638,8 +638,8 @@ mol6:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
-  explevel: basic
+    explevel: easy
+  explevel: easy
 mol7:
   prot_segid:
     default: G
@@ -650,7 +650,7 @@ mol7:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   fix_origin:
     default: false
     type: boolean
@@ -658,7 +658,7 @@ mol7:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   dna:
     default: false
     type: boolean
@@ -666,7 +666,7 @@ mol7:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   shape:
     default: false
     type: boolean
@@ -674,7 +674,7 @@ mol7:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   cg:
     default: false
     type: boolean
@@ -682,7 +682,7 @@ mol7:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   cyclicpept:
     default: false
     type: boolean
@@ -690,7 +690,7 @@ mol7:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   nhisd:
     default: 0
     type: integer
@@ -700,7 +700,7 @@ mol7:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   hisd_1:
     default: .nan
     type: float
@@ -711,7 +711,7 @@ mol7:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   nhise:
     default: 0
     type: integer
@@ -721,7 +721,7 @@ mol7:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   hise_1:
     default: .nan
     type: float
@@ -732,8 +732,8 @@ mol7:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
-  explevel: basic
+    explevel: easy
+  explevel: easy
 mol8:
   prot_segid:
     default: H
@@ -744,7 +744,7 @@ mol8:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   fix_origin:
     default: false
     type: boolean
@@ -752,7 +752,7 @@ mol8:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   dna:
     default: false
     type: boolean
@@ -760,7 +760,7 @@ mol8:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   shape:
     default: false
     type: boolean
@@ -768,7 +768,7 @@ mol8:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   cg:
     default: false
     type: boolean
@@ -776,7 +776,7 @@ mol8:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   cyclicpept:
     default: false
     type: boolean
@@ -784,7 +784,7 @@ mol8:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   nhisd:
     default: 0
     type: integer
@@ -794,7 +794,7 @@ mol8:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   hisd_1:
     default: .nan
     type: float
@@ -805,7 +805,7 @@ mol8:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   nhise:
     default: 0
     type: integer
@@ -815,7 +815,7 @@ mol8:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   hise_1:
     default: .nan
     type: float
@@ -826,8 +826,8 @@ mol8:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
-  explevel: basic
+    explevel: easy
+  explevel: easy
 mol9:
   prot_segid:
     default: I
@@ -838,7 +838,7 @@ mol9:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   fix_origin:
     default: false
     type: boolean
@@ -846,7 +846,7 @@ mol9:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   dna:
     default: false
     type: boolean
@@ -854,7 +854,7 @@ mol9:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   shape:
     default: false
     type: boolean
@@ -862,7 +862,7 @@ mol9:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   cg:
     default: false
     type: boolean
@@ -870,7 +870,7 @@ mol9:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   cyclicpept:
     default: false
     type: boolean
@@ -878,7 +878,7 @@ mol9:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   nhisd:
     default: 0
     type: integer
@@ -888,7 +888,7 @@ mol9:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   hisd_1:
     default: .nan
     type: float
@@ -899,7 +899,7 @@ mol9:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   nhise:
     default: 0
     type: integer
@@ -909,7 +909,7 @@ mol9:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   hise_1:
     default: .nan
     type: float
@@ -920,8 +920,8 @@ mol9:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
-  explevel: basic
+    explevel: easy
+  explevel: easy
 mol10:
   prot_segid:
     default: J
@@ -932,7 +932,7 @@ mol10:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   fix_origin:
     default: false
     type: boolean
@@ -940,7 +940,7 @@ mol10:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   dna:
     default: false
     type: boolean
@@ -948,7 +948,7 @@ mol10:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   shape:
     default: false
     type: boolean
@@ -956,7 +956,7 @@ mol10:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   cg:
     default: false
     type: boolean
@@ -964,7 +964,7 @@ mol10:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   cyclicpept:
     default: false
     type: boolean
@@ -972,7 +972,7 @@ mol10:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   nhisd:
     default: 0
     type: integer
@@ -982,7 +982,7 @@ mol10:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   hisd_1:
     default: .nan
     type: float
@@ -993,7 +993,7 @@ mol10:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   nhise:
     default: 0
     type: integer
@@ -1003,7 +1003,7 @@ mol10:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   hise_1:
     default: .nan
     type: float
@@ -1014,8 +1014,8 @@ mol10:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
-  explevel: basic
+    explevel: easy
+  explevel: easy
 mol11:
   prot_segid:
     default: K
@@ -1026,7 +1026,7 @@ mol11:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   fix_origin:
     default: false
     type: boolean
@@ -1034,7 +1034,7 @@ mol11:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   dna:
     default: false
     type: boolean
@@ -1042,7 +1042,7 @@ mol11:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   shape:
     default: false
     type: boolean
@@ -1050,7 +1050,7 @@ mol11:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   cg:
     default: false
     type: boolean
@@ -1058,7 +1058,7 @@ mol11:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   cyclicpept:
     default: false
     type: boolean
@@ -1066,7 +1066,7 @@ mol11:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   nhisd:
     default: 0
     type: integer
@@ -1076,7 +1076,7 @@ mol11:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   hisd_1:
     default: .nan
     type: float
@@ -1087,7 +1087,7 @@ mol11:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   nhise:
     default: 0
     type: integer
@@ -1097,7 +1097,7 @@ mol11:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   hise_1:
     default: .nan
     type: float
@@ -1108,8 +1108,8 @@ mol11:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
-  explevel: basic
+    explevel: easy
+  explevel: easy
 mol12:
   prot_segid:
     default: L
@@ -1120,7 +1120,7 @@ mol12:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   fix_origin:
     default: false
     type: boolean
@@ -1128,7 +1128,7 @@ mol12:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   dna:
     default: false
     type: boolean
@@ -1136,7 +1136,7 @@ mol12:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   shape:
     default: false
     type: boolean
@@ -1144,7 +1144,7 @@ mol12:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   cg:
     default: false
     type: boolean
@@ -1152,7 +1152,7 @@ mol12:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   cyclicpept:
     default: false
     type: boolean
@@ -1160,7 +1160,7 @@ mol12:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   nhisd:
     default: 0
     type: integer
@@ -1170,7 +1170,7 @@ mol12:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   hisd_1:
     default: .nan
     type: float
@@ -1181,7 +1181,7 @@ mol12:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   nhise:
     default: 0
     type: integer
@@ -1191,7 +1191,7 @@ mol12:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   hise_1:
     default: .nan
     type: float
@@ -1202,8 +1202,8 @@ mol12:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
-  explevel: basic
+    explevel: easy
+  explevel: easy
 mol13:
   prot_segid:
     default: M
@@ -1214,7 +1214,7 @@ mol13:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   fix_origin:
     default: false
     type: boolean
@@ -1222,7 +1222,7 @@ mol13:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   dna:
     default: false
     type: boolean
@@ -1230,7 +1230,7 @@ mol13:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   shape:
     default: false
     type: boolean
@@ -1238,7 +1238,7 @@ mol13:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   cg:
     default: false
     type: boolean
@@ -1246,7 +1246,7 @@ mol13:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   cyclicpept:
     default: false
     type: boolean
@@ -1254,7 +1254,7 @@ mol13:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   nhisd:
     default: 0
     type: integer
@@ -1264,7 +1264,7 @@ mol13:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   hisd_1:
     default: .nan
     type: float
@@ -1275,7 +1275,7 @@ mol13:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   nhise:
     default: 0
     type: integer
@@ -1285,7 +1285,7 @@ mol13:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   hise_1:
     default: .nan
     type: float
@@ -1296,8 +1296,8 @@ mol13:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
-  explevel: basic
+    explevel: easy
+  explevel: easy
 mol14:
   prot_segid:
     default: N
@@ -1308,7 +1308,7 @@ mol14:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   fix_origin:
     default: false
     type: boolean
@@ -1316,7 +1316,7 @@ mol14:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   dna:
     default: false
     type: boolean
@@ -1324,7 +1324,7 @@ mol14:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   shape:
     default: false
     type: boolean
@@ -1332,7 +1332,7 @@ mol14:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   cg:
     default: false
     type: boolean
@@ -1340,7 +1340,7 @@ mol14:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   cyclicpept:
     default: false
     type: boolean
@@ -1348,7 +1348,7 @@ mol14:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   nhisd:
     default: 0
     type: integer
@@ -1358,7 +1358,7 @@ mol14:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   hisd_1:
     default: .nan
     type: float
@@ -1369,7 +1369,7 @@ mol14:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   nhise:
     default: 0
     type: integer
@@ -1379,7 +1379,7 @@ mol14:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   hise_1:
     default: .nan
     type: float
@@ -1390,8 +1390,8 @@ mol14:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
-  explevel: basic
+    explevel: easy
+  explevel: easy
 mol15:
   prot_segid:
     default: O
@@ -1402,7 +1402,7 @@ mol15:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   fix_origin:
     default: false
     type: boolean
@@ -1410,7 +1410,7 @@ mol15:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   dna:
     default: false
     type: boolean
@@ -1418,7 +1418,7 @@ mol15:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   shape:
     default: false
     type: boolean
@@ -1426,7 +1426,7 @@ mol15:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   cg:
     default: false
     type: boolean
@@ -1434,7 +1434,7 @@ mol15:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   cyclicpept:
     default: false
     type: boolean
@@ -1442,7 +1442,7 @@ mol15:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   nhisd:
     default: 0
     type: integer
@@ -1452,7 +1452,7 @@ mol15:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   hisd_1:
     default: .nan
     type: float
@@ -1463,7 +1463,7 @@ mol15:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   nhise:
     default: 0
     type: integer
@@ -1473,7 +1473,7 @@ mol15:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   hise_1:
     default: .nan
     type: float
@@ -1484,8 +1484,8 @@ mol15:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
-  explevel: basic
+    explevel: easy
+  explevel: easy
 mol16:
   prot_segid:
     default: P
@@ -1496,7 +1496,7 @@ mol16:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   fix_origin:
     default: false
     type: boolean
@@ -1504,7 +1504,7 @@ mol16:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   dna:
     default: false
     type: boolean
@@ -1512,7 +1512,7 @@ mol16:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   shape:
     default: false
     type: boolean
@@ -1520,7 +1520,7 @@ mol16:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   cg:
     default: false
     type: boolean
@@ -1528,7 +1528,7 @@ mol16:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   cyclicpept:
     default: false
     type: boolean
@@ -1536,7 +1536,7 @@ mol16:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   nhisd:
     default: 0
     type: integer
@@ -1546,7 +1546,7 @@ mol16:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   hisd_1:
     default: .nan
     type: float
@@ -1557,7 +1557,7 @@ mol16:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   nhise:
     default: 0
     type: integer
@@ -1567,7 +1567,7 @@ mol16:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   hise_1:
     default: .nan
     type: float
@@ -1578,8 +1578,8 @@ mol16:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
-  explevel: basic
+    explevel: easy
+  explevel: easy
 mol17:
   prot_segid:
     default: Q
@@ -1590,7 +1590,7 @@ mol17:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   fix_origin:
     default: false
     type: boolean
@@ -1598,7 +1598,7 @@ mol17:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   dna:
     default: false
     type: boolean
@@ -1606,7 +1606,7 @@ mol17:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   shape:
     default: false
     type: boolean
@@ -1614,7 +1614,7 @@ mol17:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   cg:
     default: false
     type: boolean
@@ -1622,7 +1622,7 @@ mol17:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   cyclicpept:
     default: false
     type: boolean
@@ -1630,7 +1630,7 @@ mol17:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   nhisd:
     default: 0
     type: integer
@@ -1640,7 +1640,7 @@ mol17:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   hisd_1:
     default: .nan
     type: float
@@ -1651,7 +1651,7 @@ mol17:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   nhise:
     default: 0
     type: integer
@@ -1661,7 +1661,7 @@ mol17:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   hise_1:
     default: .nan
     type: float
@@ -1672,8 +1672,8 @@ mol17:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
-  explevel: basic
+    explevel: easy
+  explevel: easy
 mol18:
   prot_segid:
     default: R
@@ -1684,7 +1684,7 @@ mol18:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   fix_origin:
     default: false
     type: boolean
@@ -1692,7 +1692,7 @@ mol18:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   dna:
     default: false
     type: boolean
@@ -1700,7 +1700,7 @@ mol18:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   shape:
     default: false
     type: boolean
@@ -1708,7 +1708,7 @@ mol18:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   cg:
     default: false
     type: boolean
@@ -1716,7 +1716,7 @@ mol18:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   cyclicpept:
     default: false
     type: boolean
@@ -1724,7 +1724,7 @@ mol18:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   nhisd:
     default: 0
     type: integer
@@ -1734,7 +1734,7 @@ mol18:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   hisd_1:
     default: .nan
     type: float
@@ -1745,7 +1745,7 @@ mol18:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   nhise:
     default: 0
     type: integer
@@ -1755,7 +1755,7 @@ mol18:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   hise_1:
     default: .nan
     type: float
@@ -1766,8 +1766,8 @@ mol18:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
-  explevel: basic
+    explevel: easy
+  explevel: easy
 mol19:
   prot_segid:
     default: S
@@ -1778,7 +1778,7 @@ mol19:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   fix_origin:
     default: false
     type: boolean
@@ -1786,7 +1786,7 @@ mol19:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   dna:
     default: false
     type: boolean
@@ -1794,7 +1794,7 @@ mol19:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   shape:
     default: false
     type: boolean
@@ -1802,7 +1802,7 @@ mol19:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   cg:
     default: false
     type: boolean
@@ -1810,7 +1810,7 @@ mol19:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   cyclicpept:
     default: false
     type: boolean
@@ -1818,7 +1818,7 @@ mol19:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   nhisd:
     default: 0
     type: integer
@@ -1828,7 +1828,7 @@ mol19:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   hisd_1:
     default: .nan
     type: float
@@ -1839,7 +1839,7 @@ mol19:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   nhise:
     default: 0
     type: integer
@@ -1849,7 +1849,7 @@ mol19:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   hise_1:
     default: .nan
     type: float
@@ -1860,8 +1860,8 @@ mol19:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
-  explevel: basic
+    explevel: easy
+  explevel: easy
 mol20:
   prot_segid:
     default: T
@@ -1872,7 +1872,7 @@ mol20:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   fix_origin:
     default: false
     type: boolean
@@ -1880,7 +1880,7 @@ mol20:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   dna:
     default: false
     type: boolean
@@ -1888,7 +1888,7 @@ mol20:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   shape:
     default: false
     type: boolean
@@ -1896,7 +1896,7 @@ mol20:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   cg:
     default: false
     type: boolean
@@ -1904,7 +1904,7 @@ mol20:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   cyclicpept:
     default: false
     type: boolean
@@ -1912,7 +1912,7 @@ mol20:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   nhisd:
     default: 0
     type: integer
@@ -1922,7 +1922,7 @@ mol20:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   hisd_1:
     default: .nan
     type: float
@@ -1933,7 +1933,7 @@ mol20:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   nhise:
     default: 0
     type: integer
@@ -1943,7 +1943,7 @@ mol20:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   hise_1:
     default: .nan
     type: float
@@ -1954,5 +1954,5 @@ mol20:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
-  explevel: basic
+    explevel: easy
+  explevel: easy


### PR DESCRIPTION
Correct `explevels` definitions in `defaults.yaml` to: `easy`, `expert`and `guru`.

Closes #305 

@sverhoeven please update your scripts accordingly.