### PR TITLE
update `pdbtools` dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pdb-tools>=2.4.1
+pdb-tools>=2.4.3
 jsonpickle==2.0.0
 numpy==1.20.2
 tox==3

--- a/requirements.yml
+++ b/requirements.yml
@@ -11,5 +11,5 @@ dependencies:
   - tox
   - biopython
   - pip:
-      - pdb-tools>=2.4.1
+      - pdb-tools>=2.4.3
       - git+https://github.com/joaorodrigues/fcc@fcc2


### PR DESCRIPTION
Updates `requirements` to the latest version of `pdb-tools` to ensure the latest is used. Comes after: https://github.com/haddocking/pdb-tools/pull/117 and https://github.com/haddocking/pdb-tools/pull/119

These are needed for #143 and #144