### PR TITLE
Update deps versions - forcing exact numbers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-pdb-tools>=2.4.3
-jsonpickle==2.0.0
-numpy==1.20.2
-tox==3
-pyyaml==6
+pdb-tools==2.4.3
+biopython==1.79
 git+git://github.com/joaorodrigues/fcc@fcc2
-biopython
+jsonpickle==2.1.0
+numpy==1.22.2
+pyyaml==6.0
+tox==3.24.5

--- a/requirements.yml
+++ b/requirements.yml
@@ -4,12 +4,12 @@ channels:
   - defaults
 dependencies:
   - python==3.9
-  - pyyaml==6
+  - biopython==1.79
+  - jsonpickle==2.1.0
+  - numpy==1.22.2
   - pip
-  - numpy
-  - jsonpickle
-  - tox
-  - biopython
+  - pyyaml==6.0
+  - tox==3.24.5
   - pip:
-      - pdb-tools>=2.4.3
+      - pdb-tools==2.4.3
       - git+https://github.com/joaorodrigues/fcc@fcc2


### PR DESCRIPTION
Update dependency versions, forcing exact numbers. This is important because for now, HADDOCK3 is *under development* but also in the future HADDOCK3 is mostly to be used as a program instead of a library, so enforcing exact dependency numbers avoids possible discrepancies between installations.

Because we have little dependencies, we can, once in a while, review the dependencies updates manually. I am looking for stability instead of cutting-edge.