### PR TITLE
Update install instructions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,9 +15,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      with:
-        repository: haddocking/fcc
-        path: src/fcc
+      #with:
+      #  repository: haddocking/fcc
+      #  path: src/fcc
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2.2.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        repository: haddocking/fcc
+        path: src/fcc
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2.2.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,8 +15,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      with:
-        submodules: recursive
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2.2.2

--- a/.github/workflows/py39.yml
+++ b/.github/workflows/py39.yml
@@ -14,7 +14,11 @@ jobs:
         platform: [ubuntu-latest, macos-latest]
 
     steps:
-    - uses: actions/checkout@v2
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Checkout FCC
+      uses: actions/checkout@v2
       with:
         repository: haddocking/fcc
         path: src/fcc
@@ -35,7 +39,6 @@ jobs:
         ls -lsa
         mkdir bin
         touch bin/cns
-        cd src
         cd src/fcc/src
         chmod u+x Makefile
         ./Makefile 2>%1 >/dev/null || true

--- a/.github/workflows/py39.yml
+++ b/.github/workflows/py39.yml
@@ -15,6 +15,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        repository: haddocking/fcc
+        path: src/fcc
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2.2.2
@@ -32,6 +35,7 @@ jobs:
         ls -lsa
         mkdir bin
         touch bin/cns
+        cd src
         cd src/fcc/src
         chmod u+x Makefile
         ./Makefile 2>%1 >/dev/null || true

--- a/.github/workflows/py39.yml
+++ b/.github/workflows/py39.yml
@@ -15,8 +15,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      with:
-        submodules: recursive
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2.2.2

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "src/fcc"]
-	path = src/fcc
-	url = https://github.com/haddocking/fcc.git

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -11,7 +11,9 @@ steps.
 git clone https://github.com/haddocking/haddock3
 cd haddock3/src
 git clone https://github.com/haddocking/fcc
-cd fcc/src
+cd fcc
+git checkout 3a1626de3366f6db8b45caed3bd9fbc6b2881286
+cd src
 chmod u+x Makefile
 make
 cd ../../..
@@ -78,6 +80,8 @@ Afterwards:
 
 ```bash
 git pull
+pip install -r requirements.txt  --upgrade  # for venv
+conda env update -f requirements.yml  # for conda
 python setup.py develop --no-deps
 ```
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,23 +1,36 @@
 # 1. Installation
 
+Navigate to the folder where you want to install the HADDOCK3 subfolder.
+
+You can safely follow the commands indicated below for the different
+steps.
+
 ## 1.1 Clone this repository:
 
 ```bash
-git clone --recursive https://github.com/haddocking/haddock3.git
-cd haddock3
-cd src/fcc/src
+git clone https://github.com/haddocking/haddock3
+cd haddock3/src
+git clone https://github.com/haddocking/fcc
+cd fcc/src
 chmod u+x Makefile
 make
-cd -
+cd ../../..
 ```
 
-## 1.2 Create a virtual environment with Python 3.8+ and install dependencies:
+## 1.2 Create a virtual environment with Python 3.9 and install dependencies:
+
+You can use Python's `venv` or Anaconda depending on your choice.
+Commands are provided below:
+
 ### with `venv`
 
 ```bash
-virtualenv-3.8 venv
+virtualenv venv --python=3.9
 source venv/bin/activate
 pip install -r requirements.txt
+
+# install the HADDOCK3's Python shell and command-line clients (CLIs) on
+# the newly created environment.
 python setup.py develop --no-deps
 ```
 
@@ -43,15 +56,28 @@ ln -s /PATH/TO/cns_solve-1.31-UU-MacIntel.exe bin/cns
 ln -s /PATH/TO/CNS_FOLDER/intel-x86_64bit-linux/source/cns_solve-2002171359.exe bin/cns
 ```
 
+As long as you have the HADDOCK3 python environment activated you can
+navigate away from the HADDOCK3 installation folder. You can run
+HADDOCK3 from anywhere. To run HADDOCK3, follow the [usage
+guidelines](USAGE.md).
+
 ## 1.4 Keep up to date
 
-In the `github` folder of `haddock3` run:
+Navigate to the `github` folder of `haddock3`. Ensure you have the
+haddock3 python environment activated:
 
 ```bash
-git pull --recurse-submodules
+# if you used `venv`
+source venv/bin/activate
 
-# this is only needed when new CLIs are introduced, but it doesn't hurt
-# at all doing it. So, it always better to do it.
+# if you used `conda`
+conda activate haddock3
+```
+
+Afterwards:
+
+```bash
+git pull
 python setup.py develop --no-deps
 ```
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -14,9 +14,8 @@ exclude tox.ini
 
 prune devtools
 prune examples
-prune src/fcc
 prune tests
 
-global-exclude *.py[cod] __pycache__/* *.so *.dylib 
+global-exclude *.py[cod] __pycache__/* *.so *.dylib
 global-exclude tags
 global-exclude *.swp

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,7 +7,6 @@ include LICENSE
 include requirements.txt
 include requirements.yml
 
-exclude .gitmodules
 exclude .bumpversion.cfg
 exclude .coveragerc
 exclude .readthedocs.yml

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,0 +1,7 @@
+Before using HADDOCK3, install HADDOCK3 following the [installation instructions](INSTALL.md).
+
+## Run HADDOCK3
+
+```bash
+haddock3 -h
+```


### PR DESCRIPTION
Update install instructions. `fcc` is removed as `gitmodule` and managed manually during the installation process. It adds a simple command and avoids the `--recursive` problem.

Added also a first minimal draft of a USAGE file. Later this file will grow accordingly.