### PR TITLE
Updated install instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,6 +2,8 @@
 
 ## 1.1 Clone this repository:
 
+Mind the `--recursive` flag!
+
 ```bash
 git clone --recursive https://github.com/haddocking/haddock3.git
 cd haddock3
@@ -11,27 +13,36 @@ make
 cd -
 ```
 
-## 1.2 Create a virtual environment with Python 3.8+ and install dependencies:
+By the end of the above commands, you should be back to the `haddock3`
+main folder.
+
+## 1.2 Create a virtual environment with Python 3.9+ and install dependencies:
+
+You can use Python's `venv` or Anaconda depending on your choice.
+Commands are provided below:
+
 ### with `venv`
 
 ```bash
-virtualenv-3.8 venv
+virtualenv venv --python=3.9
 source venv/bin/activate
 pip install -r requirements.txt
-python setup.py develop --no-deps
 ```
 
 ### with `conda`
+
 ```bash
 conda env create -f requirements.yml
 conda activate haddock3
+```
 
-# install the HADDOCK3's Python shell and command-line clients (CLIs) on
-# the newly created environment.
+## 1.3 Install the HADDOCK3 package and command line clients
+
+```bash
 python setup.py develop --no-deps
 ```
 
-## 1.3 Make a CNS binary shortcut to the expected path:
+## 1.4 Make a CNS binary shortcut to the expected path:
 
 ```bash
 mkdir -p bin/
@@ -43,21 +54,43 @@ ln -s /PATH/TO/cns_solve-1.31-UU-MacIntel.exe bin/cns
 ln -s /PATH/TO/CNS_FOLDER/intel-x86_64bit-linux/source/cns_solve-2002171359.exe bin/cns
 ```
 
-## 1.4 Keep up to date
+As long as you have the HADDOCK3 python environment activated, you can
+navigate away from the HADDOCK3 installation folder. You can run
+HADDOCK3 from anywhere. To run HADDOCK3, follow the [usage
+guidelines](USAGE.md).
 
-In the `github` folder of `haddock3` run:
+
+## 1.5 Keep your installation up to date
+
+Navigate to the `github` folder of `haddock3`. Ensure you have the
+`haddock3` python environment activated. Please consider HADDOCK3 is
+under active development, as well as its dependencies. In case the
+updating processing fails, it is safe to reinstall from scratch. Always
+refer to the latest installation guidelines.
 
 ```bash
-git pull --recurse-submodules
+# if you used `venv`
+source venv/bin/activate
 
-# this is only needed when new CLIs are introduced, but it doesn't hurt
-# at all doing it. So, it always better to do it.
-python setup.py develop --no-deps
+# if you used `conda`
+conda activate haddock3
 ```
 
-This will pull the latest changes to your local folder and because you
-installed `haddock3` with the option `develop` those changes become
-available immediately.
+Afterwards:
+
+```bash
+# pull the latest source code from our repository to your computer
+git pull
+
+# if you used venv to create the python environment, run:
+pip install -r requirements.txt  --upgrade
+
+# if you used anaconda to create the python environment, run:
+conda env update -f requirements.yml
+
+# ensure all command-lines clients are installed
+python setup.py develop --no-deps
+```
 
 * * *
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,0 +1,38 @@
+Before using HADDOCK3, install HADDOCK3 following the [installation
+instructions](INSTALL.md).
+
+## Run HADDOCK3
+
+This is a minimal description of how to run HADDOCK3. We are currently
+creating detailed documentation and tutorials. The minimal HADDOCK3
+execution command is:
+
+```bash
+haddock3 <CONFIG WORKFLOW>
+```
+
+Where the `<CONFIG WORKFLOW>` is a haddock3 configuration file
+describing the simulation workflow.
+
+You can inspect all `haddock3` options with:
+
+```bash
+haddock3 -h
+```
+
+Inside the HADDOCK3 main folder, there is an `examples/` folder. There
+you will find several subfolder with examples for specific docking
+scenarios. Please experiment running those configuration files ending in
+`-test.cfg`. For example:
+
+```bash
+cd examples/docking-protein-protein
+haddock3 docking-protein-protein-test.cfg
+```
+
+Feel free to open the `cfg` files with your preferred test editor, these
+are plain text files.
+
+We are actively working towards expanding our documentation pages.
+Thanks for using HADDOCK3! For any question please [open an issue
+here](https://github.com/haddocking/haddock3/issues).


### PR DESCRIPTION
Closes #118

* updates the install instructions
* adds minimal usage instructions
* Keeps the need for `--recursive`
* do not consider updating `fcc` because that package is stable and not expected to change. Once we fully move to `fcc2` we will re-update the install instructions.