### PR TITLE
Corrects explevels in `haddock3-cfg` choices

### DIFF
--- a/src/haddock/clis/cli_cfg.py
+++ b/src/haddock/clis/cli_cfg.py
@@ -74,7 +74,7 @@ def main(module, explevel):
 
     ycfg = read_from_yaml(cfg)
 
-    new_config = yaml2cfg_text(ycfg, module)
+    new_config = yaml2cfg_text(ycfg, module, explevel)
     print(new_config, file=sys.stdout, flush=True)  # noqa: T001
 
     return 0

--- a/src/haddock/clis/cli_cfg.py
+++ b/src/haddock/clis/cli_cfg.py
@@ -12,6 +12,7 @@ import argparse
 import importlib
 import sys
 
+from haddock import config_expert_levels
 from haddock.gear.yaml2cfg import yaml2cfg_text
 from haddock.libs.libio import read_from_yaml
 from haddock.modules import modules_category
@@ -37,7 +38,7 @@ ap.add_argument(
     required=False,
     help="The expertise level of the parameters. Defaults to \"all\".",
     default="all",
-    choices=("basic", "intermediate", "guru", "all"),
+    choices=config_expert_levels + ("all",),
     )
 
 

--- a/src/haddock/modules/topology/topoaa/defaults.yaml
+++ b/src/haddock/modules/topology/topoaa/defaults.yaml
@@ -50,7 +50,7 @@ ligand_param_fname:
   long: Ligand parameter file in CNS format containing all force field parameters 
     (bond, angles, dihedrals, impropers, van der waals) for any ligand not supported by default by HADDOCK
   group: 'force field'
-  explevel: intermediate
+  explevel: expert
 ligand_top_fname:
   default: ''
   type: file

--- a/tests/configs/yml_example.yml
+++ b/tests/configs/yml_example.yml
@@ -10,7 +10,7 @@ autohis:
     state of histidines ((+1: HIS or 0: HISD/HISE) by selecting the
     state leading to the lowest electrostatic energy"
   group: 'molecule'
-  explevel: basic
+  explevel: easy
 delenph:
   default: true
   type: boolean
@@ -25,7 +25,7 @@ delenph:
     restraints to specific hydrogen atoms (e.g. when using NMR distance
     restraints).
   group: 'molecule'
-  explevel: basic
+  explevel: easy
 log_level:
   default: verbose
   type: string
@@ -57,7 +57,7 @@ ligand_param_fname:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 ligand_top_fname:
   default: ''
   type: file
@@ -65,7 +65,7 @@ ligand_top_fname:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 limit:
   default: true
   type: boolean
@@ -73,7 +73,7 @@ limit:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 tolerance:
   default: 0
   type: integer
@@ -84,7 +84,7 @@ tolerance:
   short: No short description yet
   long: No long description yet
   group: ''
-  explevel: basic
+  explevel: easy
 mol1:
   prot_segid:
     default: A
@@ -95,7 +95,7 @@ mol1:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   fix_origin:
     default: false
     type: boolean
@@ -103,7 +103,7 @@ mol1:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   dna:
     default: false
     type: boolean
@@ -111,7 +111,7 @@ mol1:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   shape:
     default: false
     type: boolean
@@ -119,7 +119,7 @@ mol1:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   cg:
     default: false
     type: boolean
@@ -127,7 +127,7 @@ mol1:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   cyclicpept:
     default: false
     type: boolean
@@ -135,7 +135,7 @@ mol1:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   nhisd:
     default: 0
     type: integer
@@ -146,7 +146,7 @@ mol1:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   hisd_1:
     default: .nan
     type: float
@@ -157,7 +157,7 @@ mol1:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   nhise:
     default: 0
     type: integer
@@ -168,7 +168,7 @@ mol1:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   hise_1:
     default: .nan
     type: float
@@ -179,8 +179,8 @@ mol1:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
-  explevel: basic
+    explevel: easy
+  explevel: easy
 mol2:
   prot_segid:
     default: B
@@ -191,7 +191,7 @@ mol2:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   fix_origin:
     default: false
     type: boolean
@@ -199,7 +199,7 @@ mol2:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   dna:
     default: false
     type: boolean
@@ -207,7 +207,7 @@ mol2:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   shape:
     default: false
     type: boolean
@@ -215,7 +215,7 @@ mol2:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   cg:
     default: false
     type: boolean
@@ -223,7 +223,7 @@ mol2:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   cyclicpept:
     default: false
     type: boolean
@@ -231,7 +231,7 @@ mol2:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   nhisd:
     default: 0
     type: integer
@@ -242,7 +242,7 @@ mol2:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   hisd_1:
     default: .nan
     type: float
@@ -253,7 +253,7 @@ mol2:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   nhise:
     default: 0
     type: integer
@@ -264,7 +264,7 @@ mol2:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
+    explevel: easy
   hise_1:
     default: .nan
     type: float
@@ -275,5 +275,5 @@ mol2:
     short: No short description yet
     long: No long description yet
     group: ''
-    explevel: basic
-  explevel: basic
+    explevel: easy
+  explevel: easy

--- a/tests/test_cli_cfg.py
+++ b/tests/test_cli_cfg.py
@@ -1,0 +1,21 @@
+"""Test haddock3-cfg client."""
+import pytest
+
+from haddock import config_expert_levels
+from haddock.clis import cli_cfg
+from haddock.modules import modules_category
+
+
+@pytest.fixture(params=config_expert_levels + ("all",))
+def config_level(request):
+    """Haddock3 config levels."""
+    return request.param
+
+
+@pytest.mark.parametrize(
+    "module",
+    list(modules_category.keys()),
+    )
+def test_export_cfgs(module, config_level):
+    """Test export all configs work."""
+    cli_cfg.main(module, config_level)

--- a/tests/test_yaml2cfg.py
+++ b/tests/test_yaml2cfg.py
@@ -55,7 +55,7 @@ def test_flat_complex_config_1():
 def test_yaml2cfg_test():
     """Test yaml dict to cfg."""
     ycfg = read_from_yaml(haddock3_yaml_cfg_examples)
-    result = yaml2cfg_text(ycfg, "topoaa")
+    result = yaml2cfg_text(ycfg, "topoaa", "all")
     assert isinstance(result, str)
 
     p = Path('dummy_test.cfg')


### PR DESCRIPTION
* Corrects the `haddock-cfg` client
* Adds tests
* corrects a missing `intermediate` that ware remaining in the  `topoaa`
