### PR TITLE
Add hierarchy to the categories

### DIFF
--- a/src/haddock/modules/__init__.py
+++ b/src/haddock/modules/__init__.py
@@ -27,6 +27,13 @@ modules_category = {
 """Indexes each module in its specific category. Keys are Paths to the module,
 values are their categories. Categories are the modules parent folders."""
 
+category_hierarchy = [
+    "topology",
+    "sampling",
+    "refinement",
+    "scoring",
+    "analysis",
+    ]
 
 # this dictionary defines non-mandatory general parameters that can be defined
 # as global parameters thus affect all modules, or, instead, can be defined per

--- a/tests/test_modules_general.py
+++ b/tests/test_modules_general.py
@@ -10,7 +10,12 @@ import pytest
 from haddock import modules_defaults_path
 from haddock.core.exceptions import ConfigurationError
 from haddock.gear.yaml2cfg import read_from_yaml_config
-from haddock.modules import _not_valid_config, config_readers, modules_category
+from haddock.modules import (
+    _not_valid_config,
+    category_hierarchy,
+    config_readers,
+    modules_category,
+    )
 
 
 @pytest.fixture(params=modules_category.items())
@@ -50,3 +55,12 @@ def test_not_valid_config():
     with pytest.raises(ConfigurationError):
         with _not_valid_config():
             config_readers[".zzz"]
+
+
+def test_category_hierarchy():
+    """Test all categories are listed in hierarchies."""
+    categories_1 = set(category_hierarchy)
+    assert len(categories_1) == len(category_hierarchy)
+
+    categories_2 = set(modules_category.values())
+    assert categories_1 == categories_2


### PR DESCRIPTION
Module's categories have now a hierarchy defined in `modules/__init__.py.category_hierarchy`. With tests.

@sverhoeven