### PR TITLE
Corrects #322

### DIFF
--- a/src/haddock/gear/yaml2cfg.py
+++ b/src/haddock/gear/yaml2cfg.py
@@ -132,7 +132,8 @@ def flat_yaml_cfg(cfg):
             # users should not edit yaml files. So this error triggers
             # only during development
             if "explevel" not in values:
-                raise ConfigurationError(f"`explvl` not defined for: {param!r}")
+                emsg = f"`explevel` not defined for: {param!r}"
+                raise ConfigurationError(emsg)
 
         new[param] = new_value
 

--- a/src/haddock/gear/yaml2cfg.py
+++ b/src/haddock/gear/yaml2cfg.py
@@ -9,6 +9,7 @@ import os
 from collections.abc import Mapping
 
 from haddock import _hidden_level, config_expert_levels
+from haddock.core.exceptions import ConfigurationError
 from haddock.libs.libio import read_from_yaml
 
 
@@ -56,7 +57,7 @@ def _yaml2cfg_text(ycfg, module, explevel):
     params = []
     exp_levels = {
         _el: i
-        for i, _el in enumerate(config_expert_levels + ("all",))
+        for i, _el in enumerate(config_expert_levels + ("all", _hidden_level))
         }
     exp_level_idx = exp_levels[explevel]
 
@@ -127,8 +128,11 @@ def flat_yaml_cfg(cfg):
             # addresses `explevel` in `mol*` topoaa.
             continue
         else:
-            if values["explevel"] == _hidden_level:
-                continue
+            # coordinates with tests.
+            # users should not edit yaml files. So this error triggers
+            # only during development
+            if "explevel" not in values:
+                raise ConfigurationError(f"`explvl` not defined for: {param!r}")
 
         new[param] = new_value
 

--- a/tests/test_yaml2cfg.py
+++ b/tests/test_yaml2cfg.py
@@ -41,10 +41,6 @@ complex_cfg = {
                 },
             },
         },
-    "param8": {
-        "default": 5,
-        "explevel": "hidden",
-        },
     }
 
 
@@ -69,12 +65,6 @@ def test_flat_complex_config_1():
     """Test if complex config is flatten properly."""
     result = flat_yaml_cfg(complex_cfg)
     assert result == complex_cfg_simplified
-
-
-def test_flat_complex_keyerror():
-    """Test missing `explvl` raises Keyerror."""
-    with pytest.raises(KeyError):
-        flat_yaml_cfg(no_explvl_key)
 
 
 def test_yaml2cfg_test():

--- a/tests/test_yaml2cfg.py
+++ b/tests/test_yaml2cfg.py
@@ -2,8 +2,6 @@
 import filecmp
 from pathlib import Path
 
-import pytest
-
 from haddock.gear.yaml2cfg import flat_yaml_cfg, yaml2cfg_text
 from haddock.libs.libio import read_from_yaml
 


### PR DESCRIPTION
In #322 I removed `hidden` from `CNS` input and still considered for `haddock-cfg`. What a lapse. This corrects it properly. Related to #321 