### PR TITLE
`deafult.yaml` additional tests

### DIFF
--- a/tests/test_modules_general.py
+++ b/tests/test_modules_general.py
@@ -92,7 +92,7 @@ yaml_params_types = {
     "boolean": (bool,),
     "string": (str,),
     "list": (list,),
-    "file": (type(Path()), type(EmptyPath())),
+    "file": (str,),
     }
 
 
@@ -159,13 +159,13 @@ def inspect_types(d, module):
         if isinstance(value, dict) and "default" in value:
             inspect_commons(value, param, module)
             _type = value["type"]
-            yaml_types_to_keys[_type](value, param, module)
             inspect_default_type(
-                (str,) if param.endswith('_fname') else yaml_params_types[_type],
+                yaml_params_types[_type],
                 value["default"],
                 param,
                 module,
                 )
+            yaml_types_to_keys[_type](value, param, module)
 
         elif isinstance(value, dict):
             inspect_types(value, f'{module}_{param}')

--- a/tests/test_modules_general.py
+++ b/tests/test_modules_general.py
@@ -4,11 +4,10 @@ Test general implementation in haddock3 modules.
 Ensures all modules follow the same compatible architecture.
 """
 import importlib
-from pathlib import Path
 
 import pytest
 
-from haddock import EmptyPath, modules_defaults_path
+from haddock import modules_defaults_path
 from haddock.core.exceptions import ConfigurationError
 from haddock.gear.yaml2cfg import read_from_yaml_config
 from haddock.libs.libio import read_from_yaml


### PR DESCRIPTION
An additional battery of tests for the `default.yaml` files. All parameters get tested for their keys and types.