### PR TITLE
Impelement cluster-based output in `caprieval`

### DIFF
--- a/examples/docking-protein-protein/docking-protein-protein-cltsel-test.cfg
+++ b/examples/docking-protein-protein/docking-protein-protein-cltsel-test.cfg
@@ -31,18 +31,22 @@ hise_1 = 15
 [rigidbody]
 tolerance = 20
 ambig_fname = "data/e2a-hpr_air.tbl"
-sampling = 20
+sampling = 25
+
+[caprieval]
+#tolerance = 20
+reference_fname = "data/e2a-hpr_1GGR.pdb"
 
 [clustfcc]
 #tolerance = 20
-threshold=1
+threshold = 4
 
 [seletopclusts]
 #tolerance = 20
 ## select the best 4 clusters
 # top_cluster = [1, 2, 3, 4]
 ## select all the clusters
-top_cluster = [1,2,3,4,5,6,7,8,8,10]
+top_cluster = [1, 2, 3, 4]
 ## select the best 4 models of each cluster
 top_models = 4
 ##select all the models
@@ -50,6 +54,7 @@ top_models = 4
 
 [caprieval]
 #tolerance = 20
+clt_threshold=4
 reference_fname = "data/e2a-hpr_1GGR.pdb"
 
 [flexref]

--- a/examples/docking-protein-protein/docking-protein-protein-cltsel-test.cfg
+++ b/examples/docking-protein-protein/docking-protein-protein-cltsel-test.cfg
@@ -31,7 +31,7 @@ hise_1 = 15
 [rigidbody]
 tolerance = 20
 ambig_fname = "data/e2a-hpr_air.tbl"
-sampling = 25
+sampling = 100
 
 [caprieval]
 #tolerance = 20
@@ -46,7 +46,7 @@ threshold = 4
 ## select the best 4 clusters
 # top_cluster = [1, 2, 3, 4]
 ## select all the clusters
-top_cluster = [1, 2, 3, 4]
+top_cluster = []
 ## select the best 4 models of each cluster
 top_models = 4
 ##select all the models
@@ -54,6 +54,7 @@ top_models = 4
 
 [caprieval]
 #tolerance = 20
+sortby="irmsd"
 clt_threshold=4
 reference_fname = "data/e2a-hpr_1GGR.pdb"
 

--- a/src/haddock/modules/analysis/caprieval/__init__.py
+++ b/src/haddock/modules/analysis/caprieval/__init__.py
@@ -89,8 +89,6 @@ class HaddockModule(BaseHaddockModule):
             self.params["clt_threshold"],
             sortby_key=self.params["sortby"],
             sort_ascending=self.params["sort_ascending"],
-            rankby_key=self.params["rankby"],
-            rank_ascending=self.params["sort_ascending"],
             )
 
         selected_models = models_to_calc

--- a/src/haddock/modules/analysis/caprieval/__init__.py
+++ b/src/haddock/modules/analysis/caprieval/__init__.py
@@ -84,8 +84,7 @@ class HaddockModule(BaseHaddockModule):
             self.log("Calculating DockQ metric")
             capri.dockq()
 
-        output_fname = "capri.tsv"
-        self.log(f" Saving output to {output_fname}")
+        self.log(" Saving output")
         capri.output(
             self.params["clt_threshold"],
             sortby_key=self.params["sortby"],

--- a/src/haddock/modules/analysis/caprieval/__init__.py
+++ b/src/haddock/modules/analysis/caprieval/__init__.py
@@ -87,7 +87,7 @@ class HaddockModule(BaseHaddockModule):
         output_fname = "capri.tsv"
         self.log(f" Saving output to {output_fname}")
         capri.output(
-            output_fname,
+            self.params["clt_threshold"],
             sortby_key=self.params["sortby"],
             sort_ascending=self.params["sort_ascending"],
             rankby_key=self.params["rankby"],

--- a/src/haddock/modules/analysis/caprieval/capri.py
+++ b/src/haddock/modules/analysis/caprieval/capri.py
@@ -380,22 +380,12 @@ class CAPRI:
             clt_threshold,
             sortby_key,
             sort_ascending,
-            rankby_key,
-            rank_ascending,
             ):
         """Output the CAPRI results to a .tsv file."""
-        self._output_ss(sortby_key, sort_ascending, rankby_key, rank_ascending)
-        self._output_clt(
-            clt_threshold,
-            sortby_key,
-            sort_ascending,
-            rankby_key,
-            rank_ascending,
-            )
+        self._output_ss(sortby_key, sort_ascending)
+        self._output_clt(clt_threshold, sortby_key, sort_ascending,)
 
-    def _output_ss(
-            self, sortby_key, sort_ascending, rankby_key, rank_ascending
-            ):
+    def _output_ss(self, sortby_key, sort_ascending):
         output_l = []
         for model in self.model_list:
             data = {}
@@ -426,8 +416,6 @@ class CAPRI:
         self._dump_file(
             output_l,
             output_fname,
-            rankby_key,
-            rank_ascending,
             sortby_key,
             sort_ascending,
             )
@@ -437,8 +425,6 @@ class CAPRI:
             clt_threshold,
             sortby_key,
             sort_ascending,
-            rankby_key,
-            rank_ascending,
             ):
         """Output cluster-based results."""
         has_cluster_info = any(m.clt_id for m in self.model_list)
@@ -505,7 +491,6 @@ class CAPRI:
                 dockq_mean = float("nan")
                 dockq_stdev = float("nan")
 
-            data["caprieval_rank"] = None
             data["cluster_rank"] = element[0]
             data["cluster_id"] = element[1]
             data["n"] = number_of_models_in_cluster
@@ -533,8 +518,6 @@ class CAPRI:
         info_header = "#" * 40 + os.linesep
         info_header += "# `caprieval` cluster-based analysis" + os.linesep
         info_header += "#" + os.linesep
-        info_header += f"# > rankby_key={rankby_key}" + os.linesep
-        info_header += f"# > rank_ascending={rank_ascending}" + os.linesep
         info_header += f"# > sortby_key={sortby_key}" + os.linesep
         info_header += f"# > sort_ascending={sort_ascending}" + os.linesep
         info_header += f"# > clt_threshold={clt_threshold}" + os.linesep
@@ -560,8 +543,6 @@ class CAPRI:
         self._dump_file(
             output_l,
             output_fname,
-            rankby_key,
-            rank_ascending,
             sortby_key,
             sort_ascending,
             info_header=info_header,
@@ -571,8 +552,6 @@ class CAPRI:
             self,
             container,
             output_fname,
-            rankby_key,
-            rank_ascending,
             sortby_key,
             sort_ascending,
             info_header="",
@@ -580,7 +559,7 @@ class CAPRI:
 
         # rank
         ranked_output_l = self._rank(
-            container, key=rankby_key, ascending=rank_ascending
+            container, key='score', ascending=True
             )
 
         # sort

--- a/src/haddock/modules/analysis/caprieval/capri.py
+++ b/src/haddock/modules/analysis/caprieval/capri.py
@@ -536,7 +536,7 @@ class CAPRI:
             + os.linesep
             )
         info_header += (
-            "#   You might need to tweak the value of clt_threshold change"
+            "#   You might need to tweak the value of clt_threshold or change"
             " some parameters" + os.linesep
             )
         info_header += (

--- a/src/haddock/modules/analysis/caprieval/capri.py
+++ b/src/haddock/modules/analysis/caprieval/capri.py
@@ -4,8 +4,8 @@ import shlex
 import shutil
 import subprocess
 import tempfile
-from math import sqrt
 from functools import partial
+from math import sqrt
 from pathlib import Path
 
 import numpy as np

--- a/src/haddock/modules/analysis/caprieval/capri.py
+++ b/src/haddock/modules/analysis/caprieval/capri.py
@@ -4,6 +4,7 @@ import shlex
 import shutil
 import subprocess
 import tempfile
+from math import sqrt
 from functools import partial
 from pathlib import Path
 
@@ -136,16 +137,16 @@ class CAPRI:
 
             Q = np.asarray(Q)
             P = np.asarray(P)
-            # write_coords('model.pdb', P)
-            # write_coords('ref.pdb', Q)
+            # write_coords("model.pdb", P)
+            # write_coords("ref.pdb", Q)
 
             Q = Q - self.centroid(Q)
             P = P - self.centroid(P)
             U = self.kabsch(P, Q)
             P = np.dot(P, U)
             i_rmsd = self.calc_rmsd(P, Q)
-            # write_coords('model_aln.pdb', P)
-            # write_coords('ref_aln.pdb', Q)
+            # write_coords("model_aln.pdb", P)
+            # write_coords("ref_aln.pdb", Q)
 
             self.irmsd_dic[model] = i_rmsd
 
@@ -186,11 +187,11 @@ class CAPRI:
             Q = np.asarray(Q)
             P = np.asarray(P)
 
-            # write_coord_dic('ref.pdb', ref_coord_dic)
-            # write_coord_dic('model.pdb', mod_coord_dic)
+            # write_coord_dic("ref.pdb", ref_coord_dic)
+            # write_coord_dic("model.pdb", mod_coord_dic)
 
-            # write_coords('ref.pdb', Q)
-            # write_coords('model.pdb', P)
+            # write_coords("ref.pdb", Q)
+            # write_coords("model.pdb", P)
 
             # # move to the origin
             Q = Q - self.centroid(Q)
@@ -214,21 +215,21 @@ class CAPRI:
             #  - complex are now aligned by the receptor
             P = np.dot(P, U_r)
 
-            # write_coords('ref.pdb', Q)
-            # write_coords('model.pdb', P)
+            # write_coords("ref.pdb", Q)
+            # write_coords("model.pdb", P)
 
             # Identify the ligand coordinates
             Q_l = Q[l_start: l_end - 1]
             P_l = P[l_start: l_end - 1]
 
-            # write_coords('ref_l.pdb', Q_l)
-            # write_coords('model_l.pdb', P_l)
+            # write_coords("ref_l.pdb", Q_l)
+            # write_coords("model_l.pdb", P_l)
 
             # Calculate the RMSD of the ligands
             l_rmsd = self.calc_rmsd(P_l, Q_l)
 
-            # write_coords('ref.pdb', Q)
-            # write_coords('model.pdb', P)
+            # write_coords("ref.pdb", Q)
+            # write_coords("model.pdb", P)
 
             self.lrmsd_dic[model] = l_rmsd
 
@@ -254,8 +255,8 @@ class CAPRI:
                 model, ref_interface_resdic, match=True
                 )
 
-            # write_coord_dic('ref.pdb', ref_int_coord_dic)
-            # write_coord_dic('model.pdb', mod_int_coord_dic)
+            # write_coord_dic("ref.pdb", ref_int_coord_dic)
+            # write_coord_dic("model.pdb", mod_int_coord_dic)
 
             # find atoms present in both interfaces
             Q_int = []
@@ -271,8 +272,8 @@ class CAPRI:
             Q_int = np.asarray(Q_int)
             P_int = np.asarray(P_int)
 
-            # write_coords('ref.pdb', Q_int)
-            # write_coords('model.pdb', P_int)
+            # write_coords("ref.pdb", Q_int)
+            # write_coords("model.pdb", P_int)
 
             # find atoms present in both molecules
             Q = []
@@ -298,8 +299,8 @@ class CAPRI:
             Q = np.asarray(Q)
             P = np.asarray(P)
 
-            # write_coords('ref.pdb', Q)
-            # write_coords('model.pdb', P)
+            # write_coords("ref.pdb", Q)
+            # write_coords("model.pdb", P)
 
             # put system at origin
             Q_int = Q_int - self.centroid(Q_int)
@@ -313,35 +314,35 @@ class CAPRI:
             U_int = self.kabsch(P_int, Q_int)
             P_int = np.dot(P_int, U_int)
 
-            # write_coords('ref.pdb', Q_int)
-            # write_coords('model.pdb', P_int)
+            # write_coords("ref.pdb", Q_int)
+            # write_coords("model.pdb", P_int)
 
             # # move the system to the centroid of the interfaces
             Q = Q - self.centroid(Q)
             P = P - self.centroid(P)
 
-            # write_coords('ref_1.pdb', Q)
-            # write_coords('model_1.pdb', P)
+            # write_coords("ref_1.pdb", Q)
+            # write_coords("model_1.pdb", P)
 
             Q = Q - self.centroid(Q_int)
             P = P - self.centroid(P_int)
 
-            # write_coords('ref_2.pdb', Q)
-            # write_coords('model_2.pdb', P)
+            # write_coords("ref_2.pdb", Q)
+            # write_coords("model_2.pdb", P)
 
             # apply this rotation to the model
             #  - complexes are now aligned by the interfaces
             P = np.dot(P, U_int)
 
-            # write_coords('ref_i.pdb', Q)
-            # write_coords('model_i.pdb', P)
+            # write_coords("ref_i.pdb", Q)
+            # write_coords("model_i.pdb", P)
 
             # Calculate the rmsd of the ligand
             Q_l = Q[l_start: l_end - 1]
             P_l = P[l_start: l_end - 1]
 
-            # write_coords('ref_l.pdb', Q_l)
-            # write_coords('model_l.pdb', P_l)
+            # write_coords("ref_l.pdb", Q_l)
+            # write_coords("model_l.pdb", P_l)
 
             # this will be the interface-ligand-rmsd
             i_l_rmsd = self.calc_rmsd(P_l, Q_l)
@@ -398,7 +399,7 @@ class CAPRI:
         output_l = []
         for model in self.model_list:
             data = {}
-            # keep always 'model' the first key
+            # keep always "model" the first key
             data["model"] = model
             # create the empty rank here so that it will appear
             #  as the second column
@@ -457,47 +458,52 @@ class CAPRI:
             number_of_models_in_cluster = len(clt_data[element])
             # TODO: Refactor these ugly try/excepts
             try:
-                mean_score = (
-                    sum(v.score for v in clt_data[element][:clt_threshold])
-                    / clt_threshold
-                    )
+                score_array = [v.score
+                               for v in clt_data[element][: clt_threshold]]
+                score_mean, score_stdev = self._calc_stats(
+                    score_array, clt_threshold)
             except KeyError:
-                mean_score = float('nan')
+                score_mean = float("nan")
+                score_stdev = float("nan")
 
             try:
-                mean_irmsd = (
-                    sum(
-                        self.irmsd_dic[v]
-                        for v in clt_data[element]
-                        [: clt_threshold]) / clt_threshold)
+                irmsd_array = [
+                    self.irmsd_dic[v]
+                    for v in clt_data[element]
+                    [: clt_threshold]]
+                irmsd_mean, irmsd_stdev = self._calc_stats(
+                    irmsd_array, clt_threshold)
             except KeyError:
-                mean_irmsd = float('nan')
+                irmsd_mean = float("nan")
+                irmsd_stdev = float("nan")
 
             try:
-                mean_fnat = (
-                    sum(self.fnat_dic[v] for v in
-                        clt_data[element][:clt_threshold])
-                    / clt_threshold
-                    )
+                fnat_array = [self.fnat_dic[v]
+                              for v in clt_data[element][:clt_threshold]]
+                fnat_mean, fnat_stdev = self._calc_stats(
+                    fnat_array, clt_threshold)
             except KeyError:
-                mean_fnat = float('nan')
+                fnat_mean = float("nan")
+                fnat_stdev = float("nan")
 
             try:
-                mean_lrmsd = (
-                    sum(
-                        self.lrmsd_dic[v]
-                        for v in clt_data[element]
-                        [: clt_threshold]) / clt_threshold)
+                lrmsd_array = [self.lrmsd_dic[v]
+                               for v in clt_data[element]
+                               [: clt_threshold]]
+                lrmsd_mean, lrmsd_stdev = self._calc_stats(
+                    lrmsd_array, clt_threshold)
             except KeyError:
-                mean_lrmsd = float('nan')
+                lrmsd_mean = float("nan")
+                lrmsd_stdev = float("nan")
             try:
-                mean_dockq = (
-                    sum(
-                        self.dockq_dic[v]
-                        for v in clt_data[element]
-                        [: clt_threshold]) / clt_threshold)
+                dockq_array = [self.dockq_dic[v]
+                               for v in clt_data[element]
+                               [: clt_threshold]]
+                dockq_mean, dockq_stdev = self._calc_stats(
+                    dockq_array, clt_threshold)
             except KeyError:
-                mean_dockq = float('nan')
+                dockq_mean = float("nan")
+                dockq_stdev = float("nan")
 
             data["caprieval_rank"] = None
             data["cluster_rank"] = element[0]
@@ -509,11 +515,17 @@ class CAPRI:
                 data["under_eval"] = "yes"
             else:
                 data["under_eval"] = "-"
-            data["score"] = mean_score
-            data["irmsd"] = mean_irmsd
-            data["fnat"] = mean_fnat
-            data["lrmsd"] = mean_lrmsd
-            data["dockq"] = mean_dockq
+
+            data["score"] = score_mean
+            data["score_std"] = score_stdev
+            data["irmsd"] = irmsd_mean
+            data["irmsd_std"] = irmsd_stdev
+            data["fnat"] = fnat_mean
+            data["fnat_std"] = fnat_stdev
+            data["lrmsd"] = lrmsd_mean
+            data["lrmsd_std"] = lrmsd_stdev
+            data["dockqn"] = dockq_mean
+            data["dockq_std"] = dockq_stdev
 
             output_l.append(data)
 
@@ -615,6 +627,14 @@ class CAPRI:
             idx, _ = k
             container[idx]["caprieval_rank"] = i
         return container
+
+    @staticmethod
+    def _calc_stats(data, n):
+        """Calculate the mean and stdev."""
+        mean = sum(data) / n
+        var = sum((x - mean) ** 2 for x in data) / n
+        stdev = sqrt(var)
+        return mean, stdev
 
     @staticmethod
     def identify_interface(pdb_f, cutoff=5.0):
@@ -720,12 +740,12 @@ class CAPRI:
                             # this residue is not matched, and so it should
                             #  not be considered
                             # self.log(
-                            #     f'WARNING: {chain}.{resnum}.{atom_name}'
-                            #     ' was not matched!'
+                            #     f"WARNING: {chain}.{resnum}.{atom_name}"
+                            #     " was not matched!"
                             #     )
                             continue
 
-                    # identifier = f'{chain}.{resnum}.{atom_name}'
+                    # identifier = f"{chain}.{resnum}.{atom_name}"
                     identifier = (chain, resnum, atom_name)
 
                     if atom_name not in self.atoms[resname]:
@@ -897,7 +917,7 @@ def align_strct(reference, model, output_path, lovoalign_exec=None):
     for chain in protein_a_dic.keys():
         pa_seqdic = pdb2fastadic(protein_a_dic[chain])
         pb_seqdic = pdb2fastadic(protein_b_dic[chain])
-        # logging.debug(f'Structurally aligning chain {chain}')
+        # logging.debug(f"Structurally aligning chain {chain}")
         numbering_dic[chain] = {}
         cmd = (
             f"{lovoalign_exec} -p1 {protein_a_dic[chain]} "
@@ -905,11 +925,11 @@ def align_strct(reference, model, output_path, lovoalign_exec=None):
             f"-c1 {chain} -c2 {chain}"
             )
 
-        # logging.debug(f'Command is: {cmd}')
+        # logging.debug(f"Command is: {cmd}")
         p = subprocess.run(shlex.split(cmd), capture_output=True, text=True)
         lovoalign_out = p.stdout.split(os.linesep)
 
-        # we don't need the splitted proteins anymore
+        # we don"t need the splitted proteins anymore
         protein_a_dic[chain].unlink()
         protein_b_dic[chain].unlink()
 
@@ -962,15 +982,15 @@ def align_strct(reference, model, output_path, lovoalign_exec=None):
 
         if identity <= 40.0:
             log.warning(
-                f'"Structural" identity of chain {chain} is {identity:.2f}%,'
+                f"\"Structural\" identity of chain {chain} is {identity:.2f}%,"
                 " please check the results carefully"
                 )
         else:
             log.info(
-                f'"Structural" identity of chain {chain} is {identity:.2f}%'
+                f"\"Structural\" identity of chain {chain} is {identity:.2f}%"
                 )
 
-        # logging.debug('Reading alignment and matching numbering')
+        # logging.debug("Reading alignment and matching numbering")
         for element in alignment:
             line_a, line_b = element
 
@@ -1052,7 +1072,8 @@ def align_seq(reference, model, output_path):
                     f"Sequence identity of chain {a} is {identity:.2f}%,"
                     " please check the results carefully"
                     )
-                log.warning('Please use alignment_method = "structure" instead')
+                log.warning(
+                    "Please use alignment_method = \"structure\" instead")
             else:
                 log.info(f"Sequence identity of chain {a} is {identity:.2f}%")
             for seg_a, seg_b in zip(aligned_seg_a, aligned_seg_b):

--- a/src/haddock/modules/analysis/caprieval/defaults.yaml
+++ b/src/haddock/modules/analysis/caprieval/defaults.yaml
@@ -155,3 +155,13 @@ lovoalign_exec:
   long: No long description yet
   group: ''
   explevel: easy
+clt_threshold:
+  default: 4
+  type: integer
+  min: 0
+  max: 1000
+  title: No title yet
+  short: No short description yet
+  long: No long description yet
+  group: ''
+  explevel: easy

--- a/src/haddock/modules/analysis/caprieval/defaults.yaml
+++ b/src/haddock/modules/analysis/caprieval/defaults.yaml
@@ -1,167 +1,180 @@
 reference_fname:
   default: ''
   type: file
-  title: No title yet
-  short: No short description yet
-  long: No long description yet
-  group: ''
+  title: Reference structure
+  short: Structure to be used when calculating the CAPRI metrics.
+  long: Structure to be used when calculating the CAPRI metrics.
+    If none is defined then the lowest scoring structure is selected by default.
+  group: 'analysis'
   explevel: easy
 irmsd:
   default: true
   type: boolean
-  title: No title yet
-  short: No short description yet
-  long: No long description yet
-  group: ''
+  title: Calculate the I-RMSD
+  short: Perform I-RMSD calculations.
+  long: Perform I-RMSD calculations.
+  group: 'analysis'
   explevel: easy
 fnat:
   default: true
   type: boolean
   title: No title yet
-  short: No short description yet
-  long: No long description yet
-  group: ''
+  short: Perform FNAT calculations.
+  long: Perform FNAT calculations.
+  group: 'analysis'
   explevel: easy
 lrmsd:
   default: true
   type: boolean
   title: No title yet
-  short: No short description yet
-  long: No long description yet
-  group: ''
+  short: Perform L-RMSD calculations.
+  long: Perform L-RMSD calculations.
+  group: 'analysis'
   explevel: easy
 ilrmsd:
   default: true
   type: boolean
   title: No title yet
-  short: No short description yet
-  long: No long description yet
-  group: ''
+  short: Perform I-L-RMSD calculations.
+  long: Perform I-L-RMSD calculations.
+  group: 'analysis'
   explevel: easy
 dockq:
   default: true
   type: boolean
   title: No title yet
-  short: No short description yet
-  long: No long description yet
-  group: ''
+  short: Evaluate DockQ.
+  long: Evaluate DockQ.
+  group: 'analysis'
   explevel: easy
 irmsd_cutoff:
   default: 10.0
   type: float
-  min: -9999
+  min: 0.0
   max: 9999
   precision: 3
-  title: No title yet
-  short: No short description yet
-  long: No long description yet
-  group: ''
+  title: Distance cutoff (Å) to consider the interface
+  short: Distance cutoff (Å) to consider the interface.
+  long: Distance cutoff (Å) to consider the interface.
+  group: 'analysis'
   explevel: easy
 fnat_cutoff:
   default: 5.0
   type: float
-  min: -9999
+  min: 0.0
   max: 9999
   precision: 3
-  title: No title yet
-  short: No short description yet
-  long: No long description yet
-  group: ''
+  title: Distance cutoff (Å) to consider the interface
+  short: Distance cutoff (Å) to consider the interface.
+  long: Distance cutoff (Å) to consider the interface.
+  group: 'analysis'
   explevel: easy
 lrmsd_cutoff:
   default: 10.0
   type: float
-  min: -9999
+  min: 0.0
   max: 9999
   precision: 3
-  title: No title yet
-  short: No short description yet
-  long: No long description yet
-  group: ''
+  title: Distance cutoff (Å) to consider the interface
+  short: Distance cutoff (Å) to consider the interface.
+  long: Distance cutoff (Å) to consider the interface.
+  group: 'analysis'
   explevel: easy
 receptor_chain:
   default: A
   type: string
-  minchars: 0
-  maxchars: 100
-  title: No title yet
-  short: No short description yet
-  long: No long description yet
-  group: ''
+  minchars: 1
+  maxchars: 1
+  title: Receptor ChainID
+  short: Receptor ChainID.
+  long: Receptor ChainID.
+  group: 'analysis'
   explevel: easy
 ligand_chain:
   default: B
   type: string
-  minchars: 0
-  maxchars: 100
-  title: No title yet
-  short: No short description yet
-  long: No long description yet
-  group: ''
+  minchars: 1
+  maxchars: 1
+  title: Ligand ChainID
+  short: Ligand ChainID.
+  long: Ligand ChainID.
+  group: 'analysis'
   explevel: easy
 rankby:
   default: score
   type: string
-  minchars: 0
-  maxchars: 100
-  title: No title yet
-  short: No short description yet
-  long: No long description yet
-  group: ''
+  choices:
+    - score
+    - irmsd
+    - lrmsd
+    - ilrmsd
+    - fnat
+    - dockq
+  title: Rank the structures in the output file by this value
+  short: Which value should be used to rank the structures in the output file.
+  long: Which value should be used to rank the structures in the output file, this will determine the `caprieval_rank`
+  group: 'analysis'
   explevel: easy
 rank_ascending:
   default: true
   type: boolean
-  title: No title yet
-  short: No short description yet
-  long: No long description yet
-  group: ''
+  title: Rank in ascending order
+  short: Rank in ascending order.
+  long: Rank in ascending order.
+  group: 'analysis'
   explevel: easy
 sortby:
   default: score
   type: string
-  minchars: 0
-  maxchars: 100
-  title: No title yet
-  short: No short description yet
-  long: No long description yet
-  group: ''
+  choices:
+    - score
+    - irmsd
+    - lrmsd
+    - ilrmsd
+    - fnat
+    - dockq
+  title: Sort the structures in the output file by this value
+  short: Which value should be used to sort the output.
+  long: Which value should be used to sort the output, the output table will be sorted accordingly.
+  group: 'analysis'
   explevel: easy
 sort_ascending:
   default: true
   type: boolean
-  title: No title yet
-  short: No short description yet
-  long: No long description yet
-  group: ''
+  title: Sort in ascending order
+  short: Sort in ascending order.
+  long: Sort in ascending order.
+  group: 'analysis'
   explevel: easy
 alignment_method:
   default: sequence
   type: string
-  minchars: 0
-  maxchars: 100
-  title: No title yet
-  short: No short description yet
-  long: No long description yet
-  group: ''
+  choices:
+    - structure
+    - sequence
+  title: Alignment method used to match the numbering.
+  short: Which alignment method should be used to match the numbering.
+  long: Alignment method used to match the numbering. Sequence alignment is haddock3-friendly but might not produce best results
+    for structures that are too different, for that use
+  group: 'analysis'
   explevel: easy
 lovoalign_exec:
   default: ''
   type: string
   minchars: 0
-  maxchars: 100
-  title: No title yet
-  short: No short description yet
-  long: No long description yet
-  group: ''
+  maxchars: 999
+  title: Location (path) of the LovoAlign executable
+  short: Location (path) of the LovoAlign executable.
+  long: Location (path) of the LovoAlign executable.
+  group: 'analysis'
   explevel: easy
 clt_threshold:
   default: 4
   type: integer
-  min: 0
+  min: 1
   max: 1000
-  title: No title yet
-  short: No short description yet
-  long: No long description yet
-  group: ''
+  title: Threshold (n) used for the average evaluation in the cluster-based output
+  short: Threshold (n) used for the average evaluation in the cluster-based output.
+  long: Threshold (n) used for the average evaluation in the cluster-based output.
+  group: 'analysis'
   explevel: easy

--- a/src/haddock/modules/analysis/caprieval/defaults.yaml
+++ b/src/haddock/modules/analysis/caprieval/defaults.yaml
@@ -7,38 +7,47 @@ reference_fname:
     If none is defined then the lowest scoring structure is selected by default.
   group: 'analysis'
   explevel: easy
+
 irmsd:
   default: true
   type: boolean
   title: Calculate the I-RMSD
-  short: Perform I-RMSD calculations.
-  long: Perform I-RMSD calculations.
+  short: Perform Interface RMSD calculations.
+  long: Calculate the Interface Root Mean Square Deviation.
+    This calculation evaluates the RMSD between two interfaces, not considering the rest of the complex.
   group: 'analysis'
   explevel: easy
+
 fnat:
   default: true
   type: boolean
-  title: No title yet
+  title: Calculate the FNAT.
   short: Perform FNAT calculations.
-  long: Perform FNAT calculations.
+  long: Calculate the Frequency of Native Contacts, this calculation evaluates how many contacts observed
+    in the reference are present in the model.
   group: 'analysis'
   explevel: easy
+
 lrmsd:
   default: true
   type: boolean
-  title: No title yet
-  short: Perform L-RMSD calculations.
-  long: Perform L-RMSD calculations.
+  title: Calculate the L-RMSD
+  short: Perform Ligand RMSD calculations.
+  long: Calculate the Ligand Root Mean Square Deviation. This calculation is done by superimposing
+    the receptors and then evaluating the RMSD of the ligands.
   group: 'analysis'
   explevel: easy
+
 ilrmsd:
   default: true
   type: boolean
-  title: No title yet
-  short: Perform I-L-RMSD calculations.
-  long: Perform I-L-RMSD calculations.
+  title: Calculate I-L-RMSD
+  short: Perform Interface Ligand RMSD calculations.
+  long: Perform I-L-RMSD calculations. This calculation is done by superimposing the receptors and evaluating
+    the RMSD of the interface of the ligands.
   group: 'analysis'
   explevel: easy
+
 dockq:
   default: true
   type: boolean
@@ -47,84 +56,55 @@ dockq:
   long: Evaluate DockQ.
   group: 'analysis'
   explevel: easy
+
 irmsd_cutoff:
   default: 10.0
   type: float
   min: 0.0
   max: 9999
   precision: 3
-  title: Distance cutoff (Å) to consider the interface
-  short: Distance cutoff (Å) to consider the interface.
-  long: Distance cutoff (Å) to consider the interface.
+  title: Distance cutoff (Å) used to define interface contacts.
+  short: Distance cutoff (Å) used to define interface contacts between two interacting molecules.
+  long: Distance cutoff (Å) used to define interface contacts between two interacting molecules.
   group: 'analysis'
   explevel: easy
+
 fnat_cutoff:
   default: 5.0
   type: float
   min: 0.0
   max: 9999
   precision: 3
-  title: Distance cutoff (Å) to consider the interface
-  short: Distance cutoff (Å) to consider the interface.
-  long: Distance cutoff (Å) to consider the interface.
+  title: Distance cutoff (Å) used to define interface contacts.
+  short: Distance cutoff (Å) used to define interface contacts between two interacting molecules.
+  long: Distance cutoff (Å) used to define interface contacts between two interacting molecules.
   group: 'analysis'
   explevel: easy
-lrmsd_cutoff:
-  default: 10.0
-  type: float
-  min: 0.0
-  max: 9999
-  precision: 3
-  title: Distance cutoff (Å) to consider the interface
-  short: Distance cutoff (Å) to consider the interface.
-  long: Distance cutoff (Å) to consider the interface.
-  group: 'analysis'
-  explevel: easy
+
 receptor_chain:
   default: A
   type: string
   minchars: 1
   maxchars: 1
   title: Receptor ChainID
-  short: Receptor ChainID.
-  long: Receptor ChainID.
+  short: Receptor ChainID to be considered for the RMSD calculations.
+  long: Receptor ChainID to be considered for the RMSD calculations. This determines which chain will be
+    treated as the receptor for the L-RMSD and for I-L-RMSD.
   group: 'analysis'
   explevel: easy
+
 ligand_chain:
   default: B
   type: string
   minchars: 1
   maxchars: 1
   title: Ligand ChainID
-  short: Ligand ChainID.
-  long: Ligand ChainID.
+  short: Ligand ChainID to be considered for the RMSD calculations.
+  long: Ligand ChainID to be considered for the RMSD calculations. This determines which chain will be
+    treated as the ligand for the L-RMSD and for I-L-RMSD.
   group: 'analysis'
   explevel: easy
-rankby:
-  default: score
-  type: string
-  minchars: -999999999999
-  maxchars: 999999999999
-  choices:
-    - score
-    - irmsd
-    - lrmsd
-    - ilrmsd
-    - fnat
-    - dockq
-  title: Rank the structures in the output file by this value
-  short: Which value should be used to rank the structures in the output file.
-  long: Which value should be used to rank the structures in the output file, this will determine the `caprieval_rank`
-  group: 'analysis'
-  explevel: easy
-rank_ascending:
-  default: true
-  type: boolean
-  title: Rank in ascending order
-  short: Rank in ascending order.
-  long: Rank in ascending order.
-  group: 'analysis'
-  explevel: easy
+
 sortby:
   default: score
   type: string
@@ -142,6 +122,7 @@ sortby:
   long: Which value should be used to sort the output, the output table will be sorted accordingly.
   group: 'analysis'
   explevel: easy
+
 sort_ascending:
   default: true
   type: boolean
@@ -150,6 +131,7 @@ sort_ascending:
   long: Sort in ascending order.
   group: 'analysis'
   explevel: easy
+
 alignment_method:
   default: sequence
   type: string
@@ -164,6 +146,7 @@ alignment_method:
     for structures that are too different, for that use
   group: 'analysis'
   explevel: easy
+
 lovoalign_exec:
   default: ''
   type: string
@@ -174,6 +157,7 @@ lovoalign_exec:
   long: Location (path) of the LovoAlign executable.
   group: 'analysis'
   explevel: easy
+
 clt_threshold:
   default: 4
   type: integer

--- a/src/haddock/modules/analysis/caprieval/defaults.yaml
+++ b/src/haddock/modules/analysis/caprieval/defaults.yaml
@@ -5,7 +5,7 @@ reference_fname:
   short: Structure to be used when calculating the CAPRI metrics.
   long: Reference tructure to be used when calculating the CAPRI metrics.
     If none is defined then the lowest scoring model is selected by default.
-  group: 'analysis'
+  group: analysis
   explevel: easy
 
 irmsd:
@@ -16,7 +16,7 @@ irmsd:
   long: Calculates the Interface Root Mean Square Deviation.
     This calculate the RMSD of interface backbone atoms after fitting on the interface backbone atoms.
     The interface is idenfied based on intermolecular contacts shorter than the defined irmsd_cutoff.
-  group: 'analysis'
+  group: analysis
   explevel: easy
 
 fnat:
@@ -27,7 +27,7 @@ fnat:
   long: Calculates the Fraction of Native Contacts. This evaluates how many contacts observed
     in the reference are present in the model. The distance cutoff used to define intermolecular contacts is
     defined by the fnat_cutoff parameter.
-  group: 'analysis'
+  group: analysis
   explevel: easy
 
 lrmsd:
@@ -38,7 +38,7 @@ lrmsd:
   long: Calculates the Ligand Root Mean Square Deviation. This calculation is done by superimposing
     the receptors (defined by the receptor_chain parameter) and then evaluating the RMSD on the ligands (defined by the ligand_chain parameter). 
     Superposition and RMSD calculations are done on backbone heavy atoms.
-  group: 'analysis'
+  group: analysis
   explevel: easy
 
 ilrmsd:
@@ -47,9 +47,9 @@ ilrmsd:
   title: Calculate I-L-RMSD
   short: Performs Interface Ligand RMSD calculations.
   long: Calculates the Interface Ligand Root Mean Square Deviation. This calculation is done by superimposing the model and the target
-  on the interface backbone atoms of the receptor (defined by the receptor_chain parameter) and calculating the RMSD on all heavy atoms 
-  of the ligand (defined by the ligand_chain parameter).
-  group: 'analysis'
+        on the interface backbone atoms of the receptor (defined by the receptor_chain parameter) and calculating the RMSD on all heavy atoms 
+        of the ligand (defined by the ligand_chain parameter).
+  group: analysis
   explevel: easy
 
 dockq:
@@ -58,8 +58,8 @@ dockq:
   title: Calculate DockQ
   short: Evaluate DockQ.
   long: Evaluate DockQ. A single continuous quality measure for protein docked models based on the CAPRI criteria, 
-    a combination of i-RMSD, l-RMSD and FNAT value. For details check the DockQ publication `DOI:10.1371/journal.pone.0161879`
-  group: 'analysis'
+        a combination of i-RMSD, l-RMSD and FNAT value. For details check the DockQ publication `DOI:10.1371/journal.pone.0161879`
+  group: analysis
   explevel: easy
 
 irmsd_cutoff:
@@ -71,7 +71,7 @@ irmsd_cutoff:
   title: Distance cutoff (Å) used to define interface residues.
   short: Distance cutoff (Å) used to define interface residues based on intermolecular contacts.
   long: Distance cutoff (Å) used to define interface residues based on intermolecular contacts.
-  group: 'analysis'
+  group: analysis
   explevel: easy
 
 fnat_cutoff:
@@ -83,7 +83,7 @@ fnat_cutoff:
   title: Distance cutoff (Å) used to define interface contacts.
   short: Distance cutoff (Å) used to define interface contacts between two interacting molecules.
   long: Distance cutoff (Å) used to define interface contacts between two interacting molecules.
-  group: 'analysis'
+  group: analysis
   explevel: easy
 
 receptor_chain:
@@ -95,7 +95,7 @@ receptor_chain:
   short: Receptor ChainID to be considered for the RMSD calculations.
   long: Receptor ChainID to be considered for the RMSD calculations. This determines which chain will be
     treated as the receptor for the L-RMSD and for I-L-RMSD.
-  group: 'analysis'
+  group: analysis
   explevel: easy
 
 ligand_chain:
@@ -107,14 +107,14 @@ ligand_chain:
   short: Ligand ChainID to be considered for the RMSD calculations.
   long: Ligand ChainID to be considered for the RMSD calculations. This determines which chain will be
     treated as the ligand for the L-RMSD and for I-L-RMSD.
-  group: 'analysis'
+  group: analysis
   explevel: easy
 
 sortby:
   default: score
   type: string
-  minchars: -999999999999
-  maxchars: 999999999999
+  minchars: -20
+  maxchars: 20
   choices:
     - score
     - irmsd
@@ -125,7 +125,7 @@ sortby:
   title: Sort the structures/clusters in the output file by this value
   short: Which value should be used to sort the output.
   long: Which value should be used to sort the output, the output table will be sorted accordingly.
-  group: 'analysis'
+  group: analysis
   explevel: easy
 
 sort_ascending:
@@ -134,7 +134,7 @@ sort_ascending:
   title: Sort in ascending order
   short: Sort in ascending order.
   long: Sort in ascending order.
-  group: 'analysis'
+  group: analysis
   explevel: easy
 
 alignment_method:
@@ -149,7 +149,7 @@ alignment_method:
   short: Which alignment method should be used to match the numbering.
   long: Alignment method used to match the numbering. Sequence alignment is haddock3-friendly but might not produce best results
     for structures that are too different, for that use
-  group: 'analysis'
+  group: analysis
   explevel: easy
 
 lovoalign_exec:
@@ -160,7 +160,7 @@ lovoalign_exec:
   title: Location (path) of the LovoAlign executable
   short: Location (path) of the LovoAlign executable.
   long: Location (path) of the LovoAlign executable.
-  group: 'analysis'
+  group: analysis
   explevel: easy
 
 clt_threshold:
@@ -171,5 +171,5 @@ clt_threshold:
   title: Threshold (n) used for the average evaluation in the cluster-based output
   short: Threshold (n) used for the average evaluation in the cluster-based output.
   long: Threshold (n) used for the average evaluation in the cluster-based output.
-  group: 'analysis'
+  group: analysis
   explevel: easy

--- a/src/haddock/modules/analysis/caprieval/defaults.yaml
+++ b/src/haddock/modules/analysis/caprieval/defaults.yaml
@@ -103,6 +103,8 @@ ligand_chain:
 rankby:
   default: score
   type: string
+  minchars: -999999999999
+  maxchars: 999999999999
   choices:
     - score
     - irmsd
@@ -126,6 +128,8 @@ rank_ascending:
 sortby:
   default: score
   type: string
+  minchars: -999999999999
+  maxchars: 999999999999
   choices:
     - score
     - irmsd
@@ -149,6 +153,8 @@ sort_ascending:
 alignment_method:
   default: sequence
   type: string
+  minchars: -999999999999
+  maxchars: 999999999999
   choices:
     - structure
     - sequence
@@ -161,8 +167,8 @@ alignment_method:
 lovoalign_exec:
   default: ''
   type: string
-  minchars: 0
-  maxchars: 999
+  minchars: -999999999999
+  maxchars: 999999999999
   title: Location (path) of the LovoAlign executable
   short: Location (path) of the LovoAlign executable.
   long: Location (path) of the LovoAlign executable.

--- a/src/haddock/modules/analysis/caprieval/defaults.yaml
+++ b/src/haddock/modules/analysis/caprieval/defaults.yaml
@@ -3,38 +3,41 @@ reference_fname:
   type: file
   title: Reference structure
   short: Structure to be used when calculating the CAPRI metrics.
-  long: Structure to be used when calculating the CAPRI metrics.
-    If none is defined then the lowest scoring structure is selected by default.
+  long: Reference tructure to be used when calculating the CAPRI metrics.
+    If none is defined then the lowest scoring model is selected by default.
   group: 'analysis'
   explevel: easy
 
 irmsd:
   default: true
   type: boolean
-  title: Calculate the I-RMSD
-  short: Perform Interface RMSD calculations.
-  long: Calculate the Interface Root Mean Square Deviation.
-    This calculation evaluates the RMSD between two interfaces, not considering the rest of the complex.
+  title: Calculate I-RMSD
+  short: Performs Interface RMSD calculations.
+  long: Calculates the Interface Root Mean Square Deviation.
+    This calculate the RMSD of interface backbone atoms after fitting on the interface backbone atoms.
+    The interface is idenfied based on intermolecular contacts shorter than the defined irmsd_cutoff.
   group: 'analysis'
   explevel: easy
 
 fnat:
   default: true
   type: boolean
-  title: Calculate the FNAT.
-  short: Perform FNAT calculations.
-  long: Calculate the Frequency of Native Contacts, this calculation evaluates how many contacts observed
-    in the reference are present in the model.
+  title: Calculate FNAT
+  short: Performs FNAT calculations.
+  long: Calculates the Fraction of Native Contacts. This evaluates how many contacts observed
+    in the reference are present in the model. The distance cutoff used to define intermolecular contacts is
+    defined by the fnat_cutoff parameter.
   group: 'analysis'
   explevel: easy
 
 lrmsd:
   default: true
   type: boolean
-  title: Calculate the L-RMSD
-  short: Perform Ligand RMSD calculations.
-  long: Calculate the Ligand Root Mean Square Deviation. This calculation is done by superimposing
-    the receptors and then evaluating the RMSD of the ligands.
+  title: Calculate L-RMSD
+  short: Performs Ligand RMSD calculations.
+  long: Calculates the Ligand Root Mean Square Deviation. This calculation is done by superimposing
+    the receptors (defined by the receptor_chain parameter) and then evaluating the RMSD on the ligands (defined by the ligand_chain parameter). 
+    Superposition and RMSD calculations are done on backbone heavy atoms.
   group: 'analysis'
   explevel: easy
 
@@ -42,9 +45,10 @@ ilrmsd:
   default: true
   type: boolean
   title: Calculate I-L-RMSD
-  short: Perform Interface Ligand RMSD calculations.
-  long: Perform I-L-RMSD calculations. This calculation is done by superimposing the receptors and evaluating
-    the RMSD of the interface of the ligands.
+  short: Performs Interface Ligand RMSD calculations.
+  long: Calculates the Interface Ligand Root Mean Square Deviation. This calculation is done by superimposing the model and the target
+  on the interface backbone atoms of the receptor (defined by the receptor_chain parameter) and calculating the RMSD on all heavy atoms 
+  of the ligand (defined by the ligand_chain parameter).
   group: 'analysis'
   explevel: easy
 
@@ -53,8 +57,8 @@ dockq:
   type: boolean
   title: Calculate DockQ
   short: Evaluate DockQ.
-  long: Evaluate DockQ. A single continuous quality measure for protein docked models based on the CAPRI evaluation protocol,
-    check their publication for more info `10.1371/journal.pone.0161879`
+  long: Evaluate DockQ. A single continuous quality measure for protein docked models based on the CAPRI criteria, 
+    a combination of i-RMSD, l-RMSD and FNAT value. For details check the DockQ publication `DOI:10.1371/journal.pone.0161879`
   group: 'analysis'
   explevel: easy
 
@@ -64,9 +68,9 @@ irmsd_cutoff:
   min: 3.0
   max: 20.0
   precision: 3
-  title: Distance cutoff (Å) used to define interface contacts.
-  short: Distance cutoff (Å) used to define interface contacts between two interacting molecules.
-  long: Distance cutoff (Å) used to define interface contacts between two interacting molecules.
+  title: Distance cutoff (Å) used to define interface residues.
+  short: Distance cutoff (Å) used to define interface residues based on intermolecular contacts.
+  long: Distance cutoff (Å) used to define interface residues based on intermolecular contacts.
   group: 'analysis'
   explevel: easy
 
@@ -118,7 +122,7 @@ sortby:
     - ilrmsd
     - fnat
     - dockq
-  title: Sort the structures in the output file by this value
+  title: Sort the structures/clusters in the output file by this value
   short: Which value should be used to sort the output.
   long: Which value should be used to sort the output, the output table will be sorted accordingly.
   group: 'analysis'
@@ -136,8 +140,8 @@ sort_ascending:
 alignment_method:
   default: sequence
   type: string
-  minchars: -999999999999
-  maxchars: 999999999999
+  minchars: 0
+  maxchars: 100
   choices:
     - structure
     - sequence
@@ -151,8 +155,8 @@ alignment_method:
 lovoalign_exec:
   default: ''
   type: string
-  minchars: -999999999999
-  maxchars: 999999999999
+  minchars: 0
+  maxchars: 200
   title: Location (path) of the LovoAlign executable
   short: Location (path) of the LovoAlign executable.
   long: Location (path) of the LovoAlign executable.

--- a/src/haddock/modules/analysis/caprieval/defaults.yaml
+++ b/src/haddock/modules/analysis/caprieval/defaults.yaml
@@ -51,17 +51,18 @@ ilrmsd:
 dockq:
   default: true
   type: boolean
-  title: No title yet
+  title: Calculate DockQ
   short: Evaluate DockQ.
-  long: Evaluate DockQ.
+  long: Evaluate DockQ. A single continuous quality measure for protein docked models based on the CAPRI evaluation protocol,
+    check their publication for more info `10.1371/journal.pone.0161879`
   group: 'analysis'
   explevel: easy
 
 irmsd_cutoff:
   default: 10.0
   type: float
-  min: 0.0
-  max: 9999
+  min: 3.0
+  max: 20.0
   precision: 3
   title: Distance cutoff (Å) used to define interface contacts.
   short: Distance cutoff (Å) used to define interface contacts between two interacting molecules.
@@ -72,8 +73,8 @@ irmsd_cutoff:
 fnat_cutoff:
   default: 5.0
   type: float
-  min: 0.0
-  max: 9999
+  min: 3.0
+  max: 20.
   precision: 3
   title: Distance cutoff (Å) used to define interface contacts.
   short: Distance cutoff (Å) used to define interface contacts between two interacting molecules.

--- a/src/haddock/modules/analysis/caprieval/defaults.yaml
+++ b/src/haddock/modules/analysis/caprieval/defaults.yaml
@@ -113,7 +113,7 @@ ligand_chain:
 sortby:
   default: score
   type: string
-  minchars: -20
+  minchars: 0
   maxchars: 20
   choices:
     - score

--- a/tests/test_module_caprieval.py
+++ b/tests/test_module_caprieval.py
@@ -332,9 +332,12 @@ def test_output(protprot_caprimodule):
         clt_fname).readlines() if not e.startswith('#')]
     expected_outf_l = [
         ['caprieval_rank', 'cluster_rank', 'cluster_id', 'n', 'under_eval',
-         'score', 'irmsd', 'fnat', 'lrmsd', 'dockq'],
-        ['1', '-', '1', '1', '-', 'nan', '0.111', '0.333', '0.444', 'nan'],
-        ['2', '-', '2', '1', '-', 'nan', '0.278', '0.833', '1.110', 'nan']]
+         'score', 'score_std', 'irmsd', 'irmsd_std', 'fnat', 'fnat_std',
+         'lrmsd', 'lrmsd_std', 'dockqn', 'dockq_std'],
+        ['1', '-', '1', '1', '-', 'nan', 'nan', '0.111', '0.000', '0.333',
+         '0.000', '0.444', '0.000', 'nan', 'nan'],
+        ['2', '-', '2', '1', '-', 'nan', 'nan', '0.278', '0.000', '0.833',
+         '0.000', '1.110', '0.000', 'nan', 'nan']]
 
     assert observed_outf_l == expected_outf_l
 

--- a/tests/test_module_caprieval.py
+++ b/tests/test_module_caprieval.py
@@ -299,15 +299,11 @@ def test_output(protprot_caprimodule):
 
     sortby_key = "fnat"
     sort_ascending = True
-    rankby_key = "irmsd"
-    rank_ascending = True
     clt_threshold = 1
     protprot_caprimodule.output(
         clt_threshold,
         sortby_key=sortby_key,
         sort_ascending=sort_ascending,
-        rankby_key=rankby_key,
-        rank_ascending=rank_ascending,
         )
 
     ss_fname = Path(protprot_caprimodule.path, "capri_ss.tsv")
@@ -331,13 +327,13 @@ def test_output(protprot_caprimodule):
     observed_outf_l = [e.split() for e in open(
         clt_fname).readlines() if not e.startswith('#')]
     expected_outf_l = [
-        ['caprieval_rank', 'cluster_rank', 'cluster_id', 'n', 'under_eval',
-         'score', 'score_std', 'irmsd', 'irmsd_std', 'fnat', 'fnat_std',
-         'lrmsd', 'lrmsd_std', 'dockqn', 'dockq_std'],
-        ['1', '-', '1', '1', '-', 'nan', 'nan', '0.111', '0.000', '0.333',
-         '0.000', '0.444', '0.000', 'nan', 'nan'],
-        ['2', '-', '2', '1', '-', 'nan', 'nan', '0.278', '0.000', '0.833',
-         '0.000', '1.110', '0.000', 'nan', 'nan']]
+        ['cluster_rank', 'cluster_id', 'n', 'under_eval', 'score', 'score_std',
+         'irmsd', 'irmsd_std', 'fnat', 'fnat_std', 'lrmsd', 'lrmsd_std',
+         'dockqn', 'dockq_std', 'caprieval_rank'],
+        ['-', '1', '1', '-', 'nan', 'nan', '0.111', '0.000', '0.333', '0.000',
+         '0.444', '0.000', 'nan', 'nan', '1'],
+        ['-', '2', '1', '-', 'nan', 'nan', '0.278', '0.000', '0.833', '0.000',
+         '1.110', '0.000', 'nan', 'nan', '2']]
 
     assert observed_outf_l == expected_outf_l
 


### PR DESCRIPTION
# Pull Request template

You are about to submit a new Pull Request. Before continuing make sure
you read the [contributing guidelines](CONTRIBUTING.md) and you comply
with the following criteria:

- [X] Your code is well documented. Functions and classes have proper docstrings
  as explained in contributing guidelines. You wrote explanatory comments for
  those tricky parts.
- [X] You wrote tests for the new code.
- [X] `tox` tests pass. Run `tox` command inside the repository folder.
- [X] `-test.cfg` examples execute without errors. Inside `examples/` run
  `python run_tests.py -b`
- [X] You have stick to Python. Talk with us before if you really need to add
  other programming languages to HADDOCK3
- [X] code follows our coding style
- [x] You avoided structuring the code into classes as much as possible, using
  small functions instead. But, you can use classes if there's a purpose.
- [X] PR does not add any *install dependencies* unless permission was granted
  by the HADDOCK team
- [X] PR does not break licensing
- [X] You get extra bonus if you write tests for already existing code :godmode:

* * *

Closes #352 by implementing a cluster-based output to `caprieval`;

it now has two output files: `capri_ss.tsv` for single-structure and `capri_clt.tsv` for cluster-based, if there is no cluster information in the models, then only `capri_ss.tsv` is generated. 

The models inside each cluster are ranked by score; so by setting `clt_threshold=4` (new parameter) the average metrics will be calculated over the top4 of each cluster.

There is a scenario in which `clt_threshold > total_number_of_clusters` that results in the metrics being under-evaluated; ex: each cluster has 2 models but if `clt_threshold=4`, the values of these 2 models will be divided by 4. When this happens, the module will set `under_eval=yes` in `capri_clt.tsv`.

## Example 1: `capri_clt.tsv`

```tsv
########################################
# `caprieval` cluster-based analysis
#
# > rankby_key=score
# > rank_ascending=True
# > sortby_key=score
# > sort_ascending=True
# > clt_threshold=4
#
# NOTE: if under_eval=yes, it means that there were less models in a cluster than
#    clt_threshold, thus these values were under evaluated.
#   You might need to tweak the value of clt_thresholdor change some parameters
#    in `clustfcc` depending on your analysis.
#
########################################
caprieval_rank	cluster_rank	cluster_id	n	under_eval	score	irmsd	fnat	lrmsd	dockq
1	1	2	2	yes	-11.379	1.608	0.146	2.915	0.192
2	2	1	2	yes	-8.921	2.616	0.056	4.638	0.108
```
## Example 2: `capri_clt.tsv`

```tsv
########################################
# `caprieval` cluster-based analysis
#
# > rankby_key=score
# > rank_ascending=True
# > sortby_key=score
# > sort_ascending=True
# > clt_threshold=4
#
# NOTE: if under_eval=yes, it means that there were less models in a cluster than
#    clt_threshold, thus these values were under evaluated.
#   You might need to tweak the value of clt_threshold or change some parameters
#    in `clustfcc` depending on your analysis.
#
########################################
caprieval_rank	cluster_rank	cluster_id	n	under_eval	score	irmsd	fnat	lrmsd	dockq
1	1	1	4	-	-33.461	2.358	0.354	4.406	0.479
2	2	3	4	-	-26.601	10.927	0.111	17.980	0.104
3	3	5	4	-	-20.855	5.686	0.111	10.384	0.193
4	4	6	4	-	-20.489	6.591	0.076	11.419	0.161
5	5	2	4	-	-18.540	9.972	0.069	16.070	0.104
6	6	8	4	-	-16.757	3.774	0.278	7.214	0.333
7	7	4	4	-	-14.531	2.544	0.361	4.915	0.457
8	8	7	4	-	-14.480	10.449	0.104	17.195	0.107
```

## Example 3 `capri_clt.tsv` `rankby/sortby=irmsd`

```
########################################
# `caprieval` cluster-based analysis
#
# > rankby_key=irmsd
# > rank_ascending=True
# > sortby_key=irmsd
# > sort_ascending=True
# > clt_threshold=4
#
# NOTE: if under_eval=yes, it means that there were less models in a cluster than
#    clt_threshold, thus these values were under evaluated.
#   You might need to tweak the value of clt_threshold or change some parameters
#    in `clustfcc` depending on your analysis.
#
########################################
caprieval_rank	cluster_rank	cluster_id	n	under_eval	score	irmsd	fnat	lrmsd	dockq
1	1	1	4	-	-33.461	2.358	0.354	4.406	0.479
2	7	4	4	-	-14.531	2.544	0.361	4.915	0.457
3	6	8	4	-	-16.757	3.774	0.278	7.214	0.333
4	3	5	4	-	-20.855	5.686	0.111	10.384	0.193
5	4	6	4	-	-20.489	6.591	0.076	11.419	0.161
6	5	2	4	-	-18.540	9.972	0.069	16.070	0.104
7	8	7	4	-	-14.480	10.449	0.104	17.195	0.107
8	2	3	4	-	-26.601	10.927	0.111	17.980	0.104
```

## `capri_ss.tsv` (unchanged)
```tsv
model	caprieval_rank	score	irmsd	fnat	lrmsd	ilrmsd	dockq	cluster-id	cluster-ranking	model-cluster-ranking
../01_rigidbody/rigidbody_16.pdb	1	-24.729	3.051	0.361	5.911	4.083	0.410	2	1	1
../01_rigidbody/rigidbody_12.pdb	2	-21.579	5.714	0.111	10.224	8.199	0.195	1	2	1
../01_rigidbody/rigidbody_20.pdb	3	-20.785	3.383	0.222	5.748	4.111	0.358	2	1	2
../01_rigidbody/rigidbody_2.pdb	4	-14.105	4.751	0.111	8.330	6.732	0.237	1	2	2
```
