### PR TITLE
Improves `defaults.yaml` tests

### DIFF
--- a/src/haddock/modules/topology/topoaa/defaults.yaml
+++ b/src/haddock/modules/topology/topoaa/defaults.yaml
@@ -147,8 +147,9 @@ mol1:
     long: Residue number of the Histidine to be defined as HISE
     group: molecule
     explevel: expert
+  group: input molecules
   explevel: easy
-  tile: Input molecule configuration
+  title: Input molecule configuration
   short: Specific molecule configuration
   long: You can expand this parameter and associated sub-parameters to the other input molecules. For example,
         if you input three molecules, you can define mol1, mol2, and mol3

--- a/tests/test_modules_general.py
+++ b/tests/test_modules_general.py
@@ -167,10 +167,13 @@ def inspect_types(d, module):
             yaml_types_to_keys[_type](value, param, module)
 
         elif isinstance(value, dict):
-            inspect_types(value, f'{module}_{param}')
+            inspect_commons(value, param, module)
 
         else:
-            return
+            assert False, (  # noqa: B011
+                "If you reach here something changed in the defaults.yaml "
+                "structure. Adapt the tests accordingly."
+                )
 
     return
 

--- a/tests/test_modules_general.py
+++ b/tests/test_modules_general.py
@@ -150,14 +150,13 @@ def test_yaml_keys(module_yaml_pure):
 
 def inspect_types(d, module):
     """Recursively inspect parameter keys according to their types."""
-    # this dictionary also asserts that all types are controlled
-    # it there's a type in the yaml that is not in this dict, a KeyError
-    # raises
-
     for param, value in d.items():
         if isinstance(value, dict) and "default" in value:
             inspect_commons(value, param, module)
-            _type = value["type"]
+            try:
+                _type = value["type"]
+            except KeyError:
+                raise KeyError(f"`type` is expected in {param} from {module}") from None  # noqa: E501
             inspect_default_type(
                 yaml_params_types[_type],
                 value["default"],
@@ -168,6 +167,7 @@ def inspect_types(d, module):
 
         elif isinstance(value, dict):
             inspect_commons(value, param, module)
+            inspect_types(value, f'{module}_{param}')
 
         else:
             assert False, (  # noqa: B011

--- a/tests/test_modules_general.py
+++ b/tests/test_modules_general.py
@@ -42,16 +42,18 @@ def ignore(*args, **kwargs):
     return
 
 
+DOC_KEYS = (
+    'title',
+    'short',
+    'long',
+    'group',
+    'explevel',
+    )
+
+
 def inspect_commons(*args):
     """Inspect keys that are common to all parameters."""
-    keys = (
-        'title',
-        'short',
-        'long',
-        'group',
-        'explevel',
-        )
-    keys_inspect(keys, *args)
+    keys_inspect(DOC_KEYS, *args)
 
 
 def inspect_int(*args):
@@ -169,10 +171,10 @@ def inspect_types(d, module):
             inspect_commons(value, param, module)
             inspect_types(value, f'{module}_{param}')
 
-        else:
-            assert False, (  # noqa: B011
-                "If you reach here something changed in the defaults.yaml "
-                "structure. Adapt the tests accordingly."
+        elif param not in DOC_KEYS + ("type",):
+            raise Exception(
+                f"parameter {param!r} is not expected for {module!r}. "
+                "If this is a new parameter, update tests."
                 )
 
     return


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and you comply with the following criteria:

- [x] You have stick to Python. Talk with us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [ ] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [ ] You structured the code into small functions as much as possible. You can use classes if there's a (state) purpose
- [x] code follows our coding style
- [ ] You wrote tests for the new code
- [x] `tox` tests pass. *Run `tox` command inside the repository folder*
- [ ] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [x] PR does not add any *install dependencies* unless permission granted by the HADDOCK team
- [x] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [x] Your PR is about writing tests for already existing code :godmode:

---

Updates `defaults.yaml` tests after #361. Thanks to @sverhoeven 
