### PR TITLE
Read yaml should return always a dictionary

### DIFF
--- a/src/haddock/libs/libio.py
+++ b/src/haddock/libs/libio.py
@@ -7,9 +7,31 @@ import yaml
 
 
 def read_from_yaml(yaml_file):
-    """Read a configuration from a yaml file."""
+    """
+    Read a YAML file to a dictionary.
+
+    Used internally to read HADDOCK3's default configuration files.
+
+    Parameters
+    ----------
+    yaml_file : str or Path
+        Path to the YAML file.
+
+    Returns
+    -------
+    dict
+        Always returns a dictionary.
+        Returns empty dictionary if yaml_file is empty.
+    """
     with open(yaml_file, 'r') as fin:
         ycfg = yaml.safe_load(fin)
+
+    # ycfg is None if yaml_file is empty
+    # returns an empty dictionary to comply with HADDOCK workflow
+    if ycfg is None:
+        return {}
+
+    assert isinstance(ycfg, dict), type(ycfg)
     return ycfg
 
 

--- a/src/haddock/libs/libsubprocess.py
+++ b/src/haddock/libs/libsubprocess.py
@@ -20,7 +20,6 @@ class BaseJob:
     def run(self):
         """Execute job in subprocess."""
         self.make_cmd()
-        print(self.cmd)
 
         with open(self.output, 'w') as outf:
             p = subprocess.Popen(

--- a/src/haddock/libs/libsubprocess.py
+++ b/src/haddock/libs/libsubprocess.py
@@ -20,6 +20,7 @@ class BaseJob:
     def run(self):
         """Execute job in subprocess."""
         self.make_cmd()
+        print(self.cmd)
 
         with open(self.output, 'w') as outf:
             p = subprocess.Popen(

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -6,5 +6,6 @@ tests_path = Path(__file__).resolve().parents[0]
 golden_data = Path(tests_path, 'golden_data')
 
 configs_data = Path(tests_path, 'configs')
+emptycfg = Path(configs_data, 'empty.cfg')
 haddock3_yaml_cfg_examples = Path(configs_data, 'yml_example.yml')
 haddock3_yaml_converted = Path(configs_data, 'yaml2cfg_converted.cfg')

--- a/tests/test_libio.py
+++ b/tests/test_libio.py
@@ -1,0 +1,19 @@
+"""Test libio."""
+import pytest
+
+from haddock.libs.libio import read_from_yaml
+
+from . import emptycfg, haddock3_yaml_cfg_examples
+
+
+@pytest.mark.parametrize(
+    "cfg",
+    [
+        emptycfg,
+        haddock3_yaml_cfg_examples,
+        ],
+    )
+def test_read_from_yaml(cfg):
+    """Test read from yaml file."""
+    result = read_from_yaml(cfg)
+    assert isinstance(result, dict)


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and you comply with the following criteria:

- [x] You have stick to Python. Talk with us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [x] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [x] You structured the code into small functions as much as possible. You can use classes if there's a (state) purpose
- [x] code follows our coding style
- [x] You wrote tests for the new code
- [x] `tox` tests pass. *Run `tox` command inside the repository folder*
- [ ] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [x] PR does not add any *install dependencies* unless permission granted by the HADDOCK team
- [x] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---

If the `YAML` was an empty file (rare, but possible) the `read_yaml` function was returning a `None`, which creates inconsistent types for implemented parameter reading/setup pipelines. Now, the function returns an empty dictionary, instead.

Found this when testing some ideas discussed with @mgiulini this morning.
