### PR TITLE
lifts ModuleIO export to baseclass

### DIFF
--- a/src/haddock/modules/__init__.py
+++ b/src/haddock/modules/__init__.py
@@ -178,6 +178,18 @@ class BaseHaddockModule(ABC):
         """
         return
 
+    def export_ouput_models(self, faulty_tolerance=0):
+        """Export output to the ModuleIO interface."""
+        io = ModuleIO()
+        io.add(self.output_models, "o")
+        faulty = io.check_faulty()
+        if faulty > faulty_tolerance:
+            _msg = (
+                f"{faulty:.2f}% of output was not generated for this module "
+                f"and tolerance was set to {faulty_tolerance:.2f}%.")
+            self.finish_with_error(_msg)
+        io.save()
+
     def finish_with_error(self, reason="Module has failed."):
         """Finish with error message."""
         if isinstance(reason, Exception):

--- a/src/haddock/modules/analysis/caprieval/__init__.py
+++ b/src/haddock/modules/analysis/caprieval/__init__.py
@@ -1,7 +1,6 @@
 """Calculate CAPRI metrics."""
 from pathlib import Path
 
-from haddock.libs.libontology import ModuleIO
 from haddock.modules import BaseHaddockModule
 from haddock.modules.analysis.caprieval.capri import CAPRI
 
@@ -31,11 +30,11 @@ class HaddockModule(BaseHaddockModule):
             _e = "This module cannot come after one that produced an iterable."
             self.finish_with_error(_e)
 
-        models_to_calc = self.previous_io.retrieve_models()
+        self.output_models = self.previous_io.retrieve_models()
 
         #  Sort by score
-        models_to_calc.sort()
-        best_model_fname = Path(models_to_calc[0].rel_path)
+        self.output_models.sort()
+        best_model_fname = Path(self.output_models[0].rel_path)
 
         if self.params["reference_fname"]:
             reference = Path(self.params["reference_fname"])
@@ -47,7 +46,7 @@ class HaddockModule(BaseHaddockModule):
 
         capri = CAPRI(
             reference,
-            models_to_calc,
+            self.output_models,
             receptor_chain=self.params["receptor_chain"],
             ligand_chain=self.params["ligand_chain"],
             aln_method=self.params["alignment_method"],
@@ -91,7 +90,4 @@ class HaddockModule(BaseHaddockModule):
             sort_ascending=self.params["sort_ascending"],
             )
 
-        selected_models = models_to_calc
-        io = ModuleIO()
-        io.add(selected_models, "o")
-        io.save()
+        self.export_ouput_models()

--- a/src/haddock/modules/analysis/clustfcc/__init__.py
+++ b/src/haddock/modules/analysis/clustfcc/__init__.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from fcc.scripts import calc_fcc_matrix, cluster_fcc
 
 from haddock import FCC_path, log
-from haddock.libs.libontology import ModuleIO
 from haddock.libs.libparallel import Scheduler
 from haddock.libs.libsubprocess import JobInputFirst
 from haddock.modules import BaseHaddockModule, read_from_yaml_config
@@ -161,7 +160,7 @@ class HaddockModule(BaseHaddockModule):
             sorted_score_dic = sorted(score_dic.items(), key=lambda k: k[1])
 
             # Add this info to the models
-            clustered_models = []
+            self.output_models = []
             for cluster_rank, _e in enumerate(sorted_score_dic, start=1):
                 cluster_id, _ = _e
                 # sort the models by score
@@ -172,7 +171,7 @@ class HaddockModule(BaseHaddockModule):
                     pdb.clt_id = cluster_id
                     pdb.clt_rank = cluster_rank
                     pdb.clt_model_rank = model_ranking
-                    clustered_models.append(pdb)
+                    self.output_models.append(pdb)
 
             # Prepare clustfcc.txt
             output_fname = Path('clustfcc.txt')
@@ -236,9 +235,6 @@ class HaddockModule(BaseHaddockModule):
                 out_fh.write(output_str)
         else:
             log.warning('No clusters were found')
-            clustered_models = models_to_cluster
+            self.output_models = models_to_cluster
 
-        # Save module information
-        io = ModuleIO()
-        io.add(clustered_models, "o")
-        io.save()
+        self.export_ouput_models()

--- a/src/haddock/modules/analysis/seletop/__init__.py
+++ b/src/haddock/modules/analysis/seletop/__init__.py
@@ -1,7 +1,7 @@
 """HADDOCK3 module to select a top cluster/model."""
 from pathlib import Path
 
-from haddock.libs.libontology import Format, ModuleIO
+from haddock.libs.libontology import Format
 from haddock.modules import BaseHaddockModule
 
 
@@ -52,8 +52,5 @@ class HaddockModule(BaseHaddockModule):
                 )
 
         # select the models based on the parameter
-        selected_models = models_to_select[:self.params['select']]
-
-        io = ModuleIO()
-        io.add(selected_models, "o")
-        io.save()
+        self.output_models = models_to_select[:self.params['select']]
+        self.export_ouput_models()

--- a/src/haddock/modules/analysis/seletopclusts/__init__.py
+++ b/src/haddock/modules/analysis/seletopclusts/__init__.py
@@ -2,7 +2,6 @@
 import math
 from pathlib import Path
 
-from haddock.libs.libontology import ModuleIO
 from haddock.modules import BaseHaddockModule
 
 
@@ -37,7 +36,7 @@ class HaddockModule(BaseHaddockModule):
         models_to_select = self.previous_io.retrieve_models()
 
         # how many models should we output?
-        models = []
+        self.output_models = []
         if not self.params["top_cluster"]:
             target_rankings = list(set([p.clt_rank for p in models_to_select]))
             target_rankins_str = ",".join(map(str, target_rankings))
@@ -51,7 +50,7 @@ class HaddockModule(BaseHaddockModule):
             if math.isnan(self.params["top_models"]):
                 for pdb in models_to_select:
                     if pdb.clt_rank == target_ranking:
-                        models.append(pdb)
+                        self.output_models.append(pdb)
             else:
                 for model_ranking in range(1, self.params["top_models"] + 1):
                     for pdb in models_to_select:
@@ -64,9 +63,6 @@ class HaddockModule(BaseHaddockModule):
                                 f"Cluster {target_ranking} "
                                 f"Model {model_ranking}"
                                 )
-                            models.append(pdb)
+                            self.output_models.append(pdb)
 
-        # Save module information
-        io = ModuleIO()
-        io.add(models, "o")
-        io.save()
+        self.export_ouput_models()

--- a/src/haddock/modules/refinement/emref/__init__.py
+++ b/src/haddock/modules/refinement/emref/__init__.py
@@ -3,7 +3,6 @@ from pathlib import Path
 
 from haddock.gear.haddockmodel import HaddockModel
 from haddock.libs.libcns import prepare_cns_input, prepare_expected_pdb
-from haddock.libs.libontology import ModuleIO
 from haddock.libs.libsubprocess import CNSJob
 from haddock.modules import get_engine
 from haddock.modules.base_cns_module import BaseCNSModule
@@ -39,7 +38,7 @@ class HaddockModule(BaseCNSModule):
         except Exception as e:
             self.finish_with_error(e)
 
-        refined_structure_list = []
+        self.output_models = []
         idx = 1
         sampling_factor = self.params["sampling_factor"]
         if sampling_factor > 1:
@@ -69,7 +68,7 @@ class HaddockModule(BaseCNSModule):
                     model, idx, ".", "emref"
                     )
 
-                refined_structure_list.append(expected_pdb)
+                self.output_models.append(expected_pdb)
 
                 job = CNSJob(inp_file, out_file, envvars=self.envvars)
 
@@ -88,7 +87,7 @@ class HaddockModule(BaseCNSModule):
         _weight_keys = ("w_vdw", "w_elec", "w_desolv", "w_air", "w_bsa")
         weights = {e: self.params[e] for e in _weight_keys}
 
-        for pdb in refined_structure_list:
+        for pdb in self.output_models:
             if pdb.is_present():
                 haddock_score = HaddockModel(pdb.file_name).calc_haddock_score(
                     **weights
@@ -96,14 +95,4 @@ class HaddockModule(BaseCNSModule):
 
                 pdb.score = haddock_score
 
-        # Save module information
-        io = ModuleIO()
-        io.add(refined_structure_list, "o")
-        faulty = io.check_faulty()
-        tolerance = self.params["tolerance"]
-        if faulty > tolerance:
-            _msg = (
-                f"{faulty:.2f}% of output was not generated for this module "
-                f"and tolerance was set to {tolerance:.2f}%.")
-            self.finish_with_error(_msg)
-        io.save()
+        self.export_ouput_models(faulty_tolerance=self.params["tolerance"])

--- a/src/haddock/modules/refinement/mdref/__init__.py
+++ b/src/haddock/modules/refinement/mdref/__init__.py
@@ -3,7 +3,6 @@ from pathlib import Path
 
 from haddock.gear.haddockmodel import HaddockModel
 from haddock.libs.libcns import prepare_cns_input, prepare_expected_pdb
-from haddock.libs.libontology import ModuleIO
 from haddock.libs.libsubprocess import CNSJob
 from haddock.modules import get_engine
 from haddock.modules.base_cns_module import BaseCNSModule
@@ -38,7 +37,7 @@ class HaddockModule(BaseCNSModule):
         except Exception as e:
             self.finish_with_error(e)
 
-        refined_structure_list = []
+        self.output_models = []
         idx = 1
         sampling_factor = self.params["sampling_factor"]
         if sampling_factor > 1:
@@ -67,7 +66,7 @@ class HaddockModule(BaseCNSModule):
                     model, idx, ".", "mdref"
                     )
 
-                refined_structure_list.append(expected_pdb)
+                self.output_models.append(expected_pdb)
 
                 job = CNSJob(inp_file, out_file, envvars=self.envvars)
 
@@ -86,7 +85,7 @@ class HaddockModule(BaseCNSModule):
         _weight_keys = ("w_vdw", "w_elec", "w_desolv", "w_air", "w_bsa")
         weights = {e: self.params[e] for e in _weight_keys}
 
-        for pdb in refined_structure_list:
+        for pdb in self.output_models:
             if pdb.is_present():
                 haddock_score = HaddockModel(pdb.file_name).calc_haddock_score(
                     **weights
@@ -95,13 +94,4 @@ class HaddockModule(BaseCNSModule):
                 pdb.score = haddock_score
 
         # Save module information
-        io = ModuleIO()
-        io.add(refined_structure_list, "o")
-        faulty = io.check_faulty()
-        tolerance = self.params["tolerance"]
-        if faulty > tolerance:
-            _msg = (
-                f"{faulty:.2f}% of output was not generated for this module "
-                f"and tolerance was set to {tolerance:.2f}%.")
-            self.finish_with_error(_msg)
-        io.save()
+        self.export_ouput_models(faulty_tolerance=self.params["tolerance"])

--- a/src/haddock/modules/sampling/gdock/__init__.py
+++ b/src/haddock/modules/sampling/gdock/__init__.py
@@ -10,7 +10,7 @@ from pdbtools import pdb_tidy
 
 from haddock import log
 from haddock.libs import libpdb
-from haddock.libs.libontology import ModuleIO, PDBFile
+from haddock.libs.libontology import PDBFile
 from haddock.modules import BaseHaddockModule
 
 
@@ -126,7 +126,7 @@ class HaddockModule(BaseHaddockModule):
         subprocess.call(cmd, shell=True)
 
         # retrieve the structures
-        output_structures = []
+        self.output_models = []
         structure_folder = Path('gdock-integration/structures')
         for model in structure_folder.glob('*pdb'):
             # Make sure the output is tidy, this should be handled
@@ -142,8 +142,6 @@ class HaddockModule(BaseHaddockModule):
             pdb = PDBFile(model)
             pdb.score = .0
             pdb.topology = topologies
-            output_structures.append(pdb)
+            self.output_models.append(pdb)
 
-        io = ModuleIO()
-        io.add(output_structures, "o")
-        io.save()
+        self.export_ouput_models()

--- a/src/haddock/modules/sampling/lightdock/__init__.py
+++ b/src/haddock/modules/sampling/lightdock/__init__.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from haddock import log
 from haddock.libs import libpdb
 from haddock.libs.libio import working_directory
-from haddock.libs.libontology import Format, ModuleIO, PDBFile
+from haddock.libs.libontology import Format, PDBFile
 from haddock.libs.libutil import check_subprocess
 from haddock.modules import BaseHaddockModule
 
@@ -38,18 +38,18 @@ class HaddockModule(BaseHaddockModule):
     def _run(self):
         """Execute module."""
         # Get the models generated in previous step
-        models_to_score = [
+        self.output_models = [
             p
             for p in self.previous_io.output
             if p.file_type == Format.PDB
             ]
 
         # Check if multiple models are provided
-        if len(models_to_score) > 1:
+        if len(self.output_models) > 1:
             _msg = "Only one model allowed in LightDock sampling module"
             self.finish_with_error(_msg)
 
-        model = models_to_score[0]
+        model = self.output_models[0]
         # Check if chain IDs are present
         _path = Path(model.path, model.file_name)
         segids, chains = libpdb.identify_chainseg(_path)
@@ -154,8 +154,4 @@ class HaddockModule(BaseHaddockModule):
                                     topology=model.topology,
                                     path=self.path))
 
-        # Save module information
-        io = ModuleIO()
-        io.add(models_to_score)
-        io.add(expected, "o")
-        io.save()
+        self.export_ouput_models()

--- a/src/haddock/modules/sampling/rigidbody/__init__.py
+++ b/src/haddock/modules/sampling/rigidbody/__init__.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from haddock.gear.haddockmodel import HaddockModel
 from haddock.libs.libcns import prepare_cns_input
-from haddock.libs.libontology import ModuleIO, PDBFile
+from haddock.libs.libontology import PDBFile
 from haddock.libs.libsubprocess import CNSJob
 from haddock.modules import get_engine
 from haddock.modules.base_cns_module import BaseCNSModule
@@ -55,7 +55,7 @@ class HaddockModule(BaseCNSModule):
 
         # Prepare the jobs
         idx = 1
-        structure_list = []
+        self.output_models = []
         self.log("Preparing jobs...")
         for combination in models_to_dock:
 
@@ -77,7 +77,7 @@ class HaddockModule(BaseCNSModule):
                 # Create a model for the expected output
                 model = PDBFile(output_pdb_fname, path=self.path)
                 model.topology = [e.topology for e in combination]
-                structure_list.append(model)
+                self.output_models.append(model)
 
                 job = CNSJob(inp_file, log_fname, envvars=self.envvars)
                 jobs.append(job)
@@ -95,7 +95,7 @@ class HaddockModule(BaseCNSModule):
         _weight_keys = ("w_vdw", "w_elec", "w_desolv", "w_air", "w_bsa")
         weights = {e: self.params[e] for e in _weight_keys}
 
-        for model in structure_list:
+        for model in self.output_models:
             if model.is_present():
                 # Score the model
                 haddock_score = HaddockModel(
@@ -105,14 +105,4 @@ class HaddockModule(BaseCNSModule):
 
                 model.score = haddock_score
 
-        # Save module information
-        io = ModuleIO()
-        io.add(structure_list, "o")
-        faulty = io.check_faulty()
-        tolerance = self.params["tolerance"]
-        if faulty > tolerance:
-            _msg = (
-                f"{faulty:.2f}% of output was not generated for this module "
-                f"and tolerance was set to {tolerance:.2f}%.")
-            self.finish_with_error(_msg)
-        io.save()
+        self.export_ouput_models(faulty_tolerance=self.params["tolerance"])

--- a/src/haddock/modules/scoring/emscoring/__init__.py
+++ b/src/haddock/modules/scoring/emscoring/__init__.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 from haddock.gear.haddockmodel import HaddockModel
 from haddock.libs.libcns import prepare_cns_input, prepare_expected_pdb
-from haddock.libs.libontology import ModuleIO
 from haddock.libs.libsubprocess import CNSJob
 from haddock.modules import get_engine
 from haddock.modules.base_cns_module import BaseCNSModule
@@ -40,7 +39,7 @@ class HaddockModule(BaseCNSModule):
         except Exception as e:
             self.finish_with_error(e)
 
-        scored_structure_list = []
+        self.output_models = []
         for model_num, model in enumerate(models_to_score, start=1):
             scoring_inp = prepare_cns_input(
                 model_num,
@@ -57,7 +56,7 @@ class HaddockModule(BaseCNSModule):
             expected_pdb = prepare_expected_pdb(
                 model, model_num, ".", "emscoring"
                 )
-            scored_structure_list.append(expected_pdb)
+            self.output_models.append(expected_pdb)
 
             job = CNSJob(scoring_inp, scoring_out, envvars=self.envvars)
 
@@ -75,7 +74,7 @@ class HaddockModule(BaseCNSModule):
         weights = {e: self.params[e] for e in _weight_keys}
 
         # Check for generated output, fail it not all expected files are found
-        for pdb in scored_structure_list:
+        for pdb in self.output_models:
             if pdb.is_present():
                 haddock_score = HaddockModel(pdb.file_name).calc_haddock_score(
                     **weights
@@ -87,7 +86,7 @@ class HaddockModule(BaseCNSModule):
         self.log(f"Saving output to {output_fname}")
         with open(output_fname, "w") as fh:
             fh.write(f"structure\toriginal_name\tscore{linesep}")
-            for pdb in scored_structure_list:
+            for pdb in self.output_models:
                 # temporary solution to get the original name
                 #  here one .pdb = one .psf and the .psf is not changed by
                 #  the module so use its name as the original one
@@ -96,14 +95,4 @@ class HaddockModule(BaseCNSModule):
                     f"{pdb.file_name}\t{original_name}\t{pdb.score}{linesep}"
                     )
 
-        # Save module information
-        io = ModuleIO()
-        io.add(scored_structure_list, "o")
-        faulty = io.check_faulty()
-        tolerance = self.params["tolerance"]
-        if faulty > tolerance:
-            _msg = (
-                f"{faulty:.2f}% of output was not generated for this module "
-                f"and tolerance was set to {tolerance:.2f}%.")
-            self.finish_with_error(_msg)
-        io.save()
+        self.export_ouput_models(faulty_tolerance=self.params["tolerance"])

--- a/src/haddock/modules/scoring/mdscoring/__init__.py
+++ b/src/haddock/modules/scoring/mdscoring/__init__.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 from haddock.gear.haddockmodel import HaddockModel
 from haddock.libs.libcns import prepare_cns_input, prepare_expected_pdb
-from haddock.libs.libontology import ModuleIO
 from haddock.libs.libsubprocess import CNSJob
 from haddock.modules import get_engine
 from haddock.modules.base_cns_module import BaseCNSModule
@@ -40,7 +39,7 @@ class HaddockModule(BaseCNSModule):
         except Exception as e:
             self.finish_with_error(e)
 
-        scored_structure_list = []
+        self.output_models = []
         for model_num, model in enumerate(models_to_score, start=1):
             scoring_inp = prepare_cns_input(
                 model_num,
@@ -57,7 +56,7 @@ class HaddockModule(BaseCNSModule):
             expected_pdb = prepare_expected_pdb(
                 model, model_num, ".", "mdscoring"
                 )
-            scored_structure_list.append(expected_pdb)
+            self.output_models.append(expected_pdb)
 
             job = CNSJob(scoring_inp, scoring_out, envvars=self.envvars)
 
@@ -75,7 +74,7 @@ class HaddockModule(BaseCNSModule):
         weights = {e: self.params[e] for e in _weight_keys}
 
         # Check for generated output, fail it not all expected files are found
-        for pdb in scored_structure_list:
+        for pdb in self.output_models:
             if pdb.is_present():
                 haddock_score = HaddockModel(pdb.file_name).calc_haddock_score(
                     **weights
@@ -87,7 +86,7 @@ class HaddockModule(BaseCNSModule):
         self.log(f"Saving output to {output_fname}")
         with open(output_fname, "w") as fh:
             fh.write(f"structure\toriginal_name\tscore{linesep}")
-            for pdb in scored_structure_list:
+            for pdb in self.output_models:
                 # temporary solution to get the original name
                 #  here one .pdb = one .psf and the .psf is not changed by
                 #  the module so use its name as the original one
@@ -96,14 +95,4 @@ class HaddockModule(BaseCNSModule):
                     f"{pdb.file_name}\t{original_name}\t{pdb.score}{linesep}"
                     )
 
-        # Save module information
-        io = ModuleIO()
-        io.add(scored_structure_list, "o")
-        faulty = io.check_faulty()
-        tolerance = self.params["tolerance"]
-        if faulty > tolerance:
-            _msg = (
-                f"{faulty:.2f}% of output was not generated for this module "
-                f"and tolerance was set to {tolerance:.2f}%.")
-            self.finish_with_error(_msg)
-        io.save()
+        self.export_ouput_models(faulty_tolerance=self.params["tolerance"])

--- a/src/haddock/modules/topology/topoaa/__init__.py
+++ b/src/haddock/modules/topology/topoaa/__init__.py
@@ -10,7 +10,7 @@ from haddock.libs.libcns import (
     prepare_output,
     prepare_single_input,
     )
-from haddock.libs.libontology import Format, ModuleIO, PDBFile, TopologyFile
+from haddock.libs.libontology import Format, PDBFile, TopologyFile
 from haddock.libs.libstructure import make_molecules
 from haddock.libs.libsubprocess import CNSJob
 from haddock.modules import get_engine
@@ -193,15 +193,5 @@ class HaddockModule(BaseCNSModule):
                 expected[i][j] = pdb
 
         # Save module information
-        io = ModuleIO()
-        for i in expected:
-            io.add(expected[i], "o")
-
-        faulty = io.check_faulty()
-        tolerance = self.params["tolerance"]
-        if faulty > tolerance:
-            _msg = (
-                f"{faulty:.2f}% of output was not generated for this module "
-                f"and tolerance was set to {tolerance:.2f}%.")
-            self.finish_with_error(_msg)
-        io.save()
+        self.output_models = list(expected.values())
+        self.export_ouput_models(faulty_tolerance=self.params["tolerance"])


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and you comply with the following criteria:

- [ ] You have stick to Python. Talk with us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [ ] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [ ] You structured the code into small functions as much as possible. You can use classes if there's a (state) purpose
- [ ] code follows our coding style
- [ ] You wrote tests for the new code
- [ ] `tox` tests pass. *Run `tox` command inside the repository folder*
- [ ] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [ ] PR does not add any *install dependencies* unless permission granted by the HADDOCK team
- [ ] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---

Cleaning `ModuleIO` duplicated code from the modules. Kudos to @douweschulte and Ivar who spotted this immediately and for the other discussions/requests on module's interoperability. More PRs soon.
