### PR TITLE
Have fuzzy matching on user supplied parameters and paths

### DIFF
--- a/src/haddock/gear/prepare_run.py
+++ b/src/haddock/gear/prepare_run.py
@@ -1,6 +1,7 @@
 """Logic pertraining to preparing the run files and folders."""
 import importlib
 import itertools as it
+import os
 import shutil
 import string
 import sys
@@ -8,7 +9,6 @@ from contextlib import contextmanager, suppress
 from copy import deepcopy
 from functools import lru_cache, wraps
 from pathlib import Path
-import os
 
 from haddock import contact_us, haddock3_source_path, log
 from haddock.core.defaults import RUNDIR, max_molecules_allowed

--- a/src/haddock/gear/prepare_run.py
+++ b/src/haddock/gear/prepare_run.py
@@ -221,11 +221,13 @@ def validate_modules_params(modules_params):
 
         if diff:
             matched = fuzzy_match(diff, defaults.keys())
-            pretty_print = lambda set: f" * \'{set[0]}\' did you mean \'{set[1]}\'?"
+            def pretty_print(match): 
+                return f" * \'{match[0]}\' did you mean \'{match[1]}\'?"
             eol = '\n'
             _msg = (
                 'The following parameters do not match any expected '
-                f'parameters for module {module_name!r}: {eol.join(map(pretty_print, matched))}.'
+                f'parameters for module {module_name!r}: '
+                f'{eol.join(map(pretty_print, matched))}.'
                 )
             raise ConfigurationError(_msg)
 
@@ -394,7 +396,8 @@ def validate_module_names_are_not_mispelled(params):
             if module_name not in module_names:
                 matched = fuzzy_match([module_name], module_names)
                 emsg = (
-                    f"Module {param_name!r} is not a valid module name, did you mean {matched[0][1]}?. "
+                    f"Module {param_name!r} is not a valid module name,"
+                    f" did you mean {matched[0][1]}?. "
                     f"Valid modules are: {', '.join(module_names)}."
                     )
                 raise ValueError(emsg)
@@ -530,8 +533,9 @@ def populate_mol_parameters(modules_params):
 def check_if_path_exists(path):
     """
     Check if a path exists and raises an error if it does not exist.
-    For example given this path "../config/project_01/file.txt" it would return
-    the following path ("../config", "project-01", "project_01").
+
+    For example given this path "../config/project_01/file.txt" it would find
+    the following path "../config/project-01".
 
     Parameters
     ----------
@@ -539,7 +543,7 @@ def check_if_path_exists(path):
         The path to check.
 
     Returns
-    ----------
+    -------
     None
         If the path does exist.
 
@@ -559,35 +563,40 @@ def check_if_path_exists(path):
     for part in elements:
         next_folder = reconstituted_path + os.sep + part
         if not os.path.exists(next_folder):
-            error = (reconstituted_path, fuzzy_match([part], os.listdir(reconstituted_path))[0][1], part)
+            error = (reconstituted_path, fuzzy_match([part], 
+                os.listdir(reconstituted_path))[0][1], part)
             break
 
     msg = (f"The following file could not be found: \'{path}\'."
-           f"In the folder \'{error[0]}\' the following \'{error[1]}\' is the closest match to the supplied \'{error[2]}\', did you mean to open this?")
+           f"In the folder \'{error[0]}\' the following \'{error[1]}\' "
+           f"is the closest match to the supplied \'{error[2]}\', did "
+           "you mean to open this?")
     raise ValueError(msg)
 
 
 def fuzzy_match(user_input, possibilities):
     """
-    Fuzzy match the given user input to the given possibilities to find the closest possibility.
+    Find the closest possibility to the user supplied input.
 
     Parameters
     ----------
     user_input : list(string)
         List of strings with the faulty input given by the user.
     possibilities : list(string)
-        List of strings with all possible options that would be valid in this context.
+        List of strings with all possible options that would be
+        valid in this context.
 
     Returns
-    ----------
+    -------
     list(string, string)
-        The closest string from the possibilities to each string of the user_input. With as first 
-        element of the tuple the user_input string, and as second element the matched possibility.
+        The closest string from the possibilities to each string of the
+        `user_input`. With as first element of the tuple the user_input
+        string, and as second element the matched possibility.
     """
     results = list()
 
     for user_word in user_input:
-        best = (2^63 - 1, "")
+        best = (2**63 - 1, "")
         for possibility in possibilities:
             distance = levenshtein_distance(user_input, possibility)
             if distance < best[0]:
@@ -600,7 +609,9 @@ def fuzzy_match(user_input, possibilities):
 def levenshtein_distance(left, right):
     """
     Get the Levenshtein distance between two strings.
-    For the definitions see Wikipedia: https://en.wikipedia.org/wiki/Levenshtein_distance.
+
+    For the definitions see Wikipedia:
+    https://en.wikipedia.org/wiki/Levenshtein_distance.
 
     Parameters
     ----------
@@ -610,7 +621,7 @@ def levenshtein_distance(left, right):
         The second string.
 
     Returns
-    ----------
+    -------
     int
         The Levenshtein distance between the two strings.
     """

--- a/src/haddock/gear/prepare_run.py
+++ b/src/haddock/gear/prepare_run.py
@@ -221,8 +221,10 @@ def validate_modules_params(modules_params):
 
         if diff:
             matched = fuzzy_match(diff, defaults.keys())
-            def pretty_print(match): 
+
+            def pretty_print(match):
                 return f" * \'{match[0]}\' did you mean \'{match[1]}\'?"
+
             eol = '\n'
             _msg = (
                 'The following parameters do not match any expected '
@@ -563,8 +565,8 @@ def check_if_path_exists(path):
     for part in elements:
         next_folder = reconstituted_path + os.sep + part
         if not os.path.exists(next_folder):
-            error = (reconstituted_path, fuzzy_match([part], 
-                os.listdir(reconstituted_path))[0][1], part)
+            error = (reconstituted_path, fuzzy_match([part],
+                     os.listdir(reconstituted_path))[0][1], part)
             break
 
     msg = (f"The following file could not be found: \'{path}\'."

--- a/src/haddock/gear/prepare_run.py
+++ b/src/haddock/gear/prepare_run.py
@@ -559,9 +559,11 @@ def check_if_path_exists(path):
     if os.path.exists(path):
         return None
 
-    reconstituted_path = ""
+    reconstituted_path = "./"
     error = ("", "", "")
     elements = Path(path).parts
+    if elements[0] == ".":
+        elements = elements[1:]
     for part in elements:
         next_folder = Path(reconstituted_path, part)
         if not next_folder.exists():
@@ -603,7 +605,7 @@ def fuzzy_match(user_input, possibilities):
             distance = levenshtein_distance(user_input, possibility)
             if distance < best[0]:
                 best = (distance, possibility)
-        results += (user_word, best[1])
+        results += [(user_word, best[1])]
 
     return results
 
@@ -635,7 +637,7 @@ def levenshtein_distance(left, right):
         if a[0] == b[0]:
             return lev(a[1:], b[1:])
         return 1 + min(
-            lev(a[1:0], b),
+            lev(a[1:], b),
             lev(a, b[1:]),
             lev(a[1:], b[1:]))
 

--- a/tests/test_gear_prepare_run.py
+++ b/tests/test_gear_prepare_run.py
@@ -148,12 +148,18 @@ def test_check_if_path_exists():
     Path("file_02.txt").unlink()
 
 
-def test_fuzzy_match():
+@pytest.mark.parametrize(
+    "user_input,expected",
+    [
+        ("long-fromat", [("long-fromat", "long-format")]),
+        (["loong-format", "verboese"], [("loong-format", "long-format"), ("verboese", "verbose")]),
+        ("middle-format", [("middle-format", "long-format")]),
+        ("out", [("out", "output-dir")]),
+        ]
+    )
+def test_fuzzy_match(user_input, expected):
     possibilities = ["long-format", "short-format", "verbose", "output-dir"]
-    assert fuzzy_match(["loong-format", "verboese"], possibilities) == \
-        [("loong-format", "long-format"), ("verboese", "verbose")]
-    assert fuzzy_match("long-fromat", possibilities) == \
-        [("long-fromat", "long-format")]
+    assert fuzzy_match(user_input, possibilities) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/test_gear_prepare_run.py
+++ b/tests/test_gear_prepare_run.py
@@ -1,10 +1,15 @@
 """Test prepare run module."""
 from math import isnan
+from multiprocessing.sharedctypes import Value
+from pathlib import Path
 
 import pytest
 
 from haddock.gear.prepare_run import (
+    check_if_path_exists,
+    fuzzy_match,
     get_expandable_parameters,
+    levenshtein_distance,
     populate_mol_parameters,
     populate_topology_molecule_params,
     )
@@ -126,3 +131,39 @@ def test_populate_mol_params():
     assert "mol_shape_3" in params["flexref"]
     assert not ("mol_shape_4" in params["flexref"])
     assert not params["caprieval"]
+
+
+def test_check_if_path_exists():
+    Path("file_01.txt").write_text("a")
+    Path("file_02.txt").write_text("a")
+    check_if_path_exists("file_01.txt")
+    check_if_path_exists("file_02.txt")
+
+    with pytest.raises(ValueError) as err:
+        check_if_path_exists("file-01.txt")
+        end = ("the following \'file_01.txt\' is the closest match to the "
+               "supplied \'file-01.txt\', did you mean to open this?")
+        assert str(err).endswith(end)
+
+    Path("file_01.txt").unlink()
+    Path("file_02.txt").unlink()
+
+
+def test_fuzzy_match():
+    possibilities = ["long-format", "short-format", "verbose", "output-dir"]
+    assert fuzzy_match(["loong-format", "verboese"], possibilities) == \
+        [("loong-format", "long-format"), ("verboese", "verbose")]
+    assert fuzzy_match("long-fromat", possibilities) == \
+        [("long-fromat", "long-format")]
+
+@pytest.mark.parametrize(
+    "a,b,expected",
+    [
+        ("", "", 0),
+        ("hello", "hello", 0),
+        ("kitten", "sitting", 3),
+        ("Saturday", "Sunday", 3),
+        ]
+    )
+def test_levenshtein_distance(a, b, expected):
+    assert levenshtein_distance(a, b) == expected

--- a/tests/test_gear_prepare_run.py
+++ b/tests/test_gear_prepare_run.py
@@ -152,7 +152,8 @@ def test_check_if_path_exists():
     "user_input,expected",
     [
         ("long-fromat", [("long-fromat", "long-format")]),
-        (["loong-format", "verboese"], [("loong-format", "long-format"), ("verboese", "verbose")]),
+        (["loong-format", "verboese"], 
+            [("loong-format", "long-format"), ("verboese", "verbose")]),
         ("middle-format", [("middle-format", "long-format")]),
         ("out", [("out", "output-dir")]),
         ]

--- a/tests/test_gear_prepare_run.py
+++ b/tests/test_gear_prepare_run.py
@@ -1,6 +1,5 @@
 """Test prepare run module."""
 from math import isnan
-from multiprocessing.sharedctypes import Value
 from pathlib import Path
 
 import pytest
@@ -155,6 +154,7 @@ def test_fuzzy_match():
         [("loong-format", "long-format"), ("verboese", "verbose")]
     assert fuzzy_match("long-fromat", possibilities) == \
         [("long-fromat", "long-format")]
+
 
 @pytest.mark.parametrize(
     "a,b,expected",


### PR DESCRIPTION
Closes #373.

You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and you comply with the following criteria:

- [x] You have stick to Python. Talk with us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [x] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [x] You structured the code into small functions as much as possible. You can use classes if there's a (state) purpose
- [x] code follows our coding style
- [x] You wrote tests for the new code
- [ ] `tox` tests pass. *Run `tox` command inside the repository folder*
- [ ] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [x] PR does not add any *install dependencies* unless permission granted by the HADDOCK team
- [x] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---

As discussed yesterday. This PR adds nice error messages for users to see when a parameter/file is mistyped what parameter/file/path is the closest to their supplied parameter/file. This enhances the user experience because it is much easier to spot the difference between `project_01` and `project_o1` if it is printed out on your screen.
