### PR TITLE
Zerofill

### DIFF
--- a/src/haddock/libs/libutil.py
+++ b/src/haddock/libs/libutil.py
@@ -281,6 +281,16 @@ def get_number_from_path_stem(path):
     return int(number)
 
 
+def get_number_of_digits(num):
+    """
+    Get the number of digits of a number.
+
+    10 has two digits.
+    100 has three digits.
+    """
+    return len(str(num))
+
+
 def sort_numbered_paths(*paths):
     """
     Sort input paths to tail number.

--- a/src/haddock/libs/libutil.py
+++ b/src/haddock/libs/libutil.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 from copy import deepcopy
 from functools import partial
+from math import log10, ceil
 from os import cpu_count
 from pathlib import Path
 
@@ -288,7 +289,8 @@ def get_number_of_digits(num):
     10 has two digits.
     100 has three digits.
     """
-    return len(str(num))
+    # also: return len(str(num)) :-)
+    return max(ceil(log10(num + 1)), 1)
 
 
 def sort_numbered_paths(*paths):

--- a/src/haddock/libs/libutil.py
+++ b/src/haddock/libs/libutil.py
@@ -7,7 +7,7 @@ import subprocess
 import sys
 from copy import deepcopy
 from functools import partial
-from math import log10, ceil
+from math import ceil, log10
 from os import cpu_count
 from pathlib import Path
 

--- a/src/haddock/libs/libworkflow.py
+++ b/src/haddock/libs/libworkflow.py
@@ -46,6 +46,7 @@ class Workflow:
 
         # Create the list of steps contained in this workflow
         self.steps = []
+        num_of_modules = len(str(len(modules_parameters)))
         _items = enumerate(modules_parameters.items())
         for num_stage, (stage_name, params) in _items:
             log.info(f"Reading instructions of [{stage_name}] step")
@@ -59,6 +60,7 @@ class Workflow:
                 _ = Step(
                     get_module_name(stage_name),
                     order=num_stage,
+                    digits=num_of_modules,
                     **params_up,
                     )
                 self.steps.append(_)
@@ -75,14 +77,15 @@ class Step:
             self,
             module_name,
             order=None,
+            digits=2,
             **config_params,
             ):
         self.config = config_params
         self.module_name = module_name
         self.order = order
 
-        self.working_path = \
-            Path(zero_fill(self.order, digits=2) + "_" + self.module_name)
+        folder_number = zero_fill(self.order, digits=digits)
+        self.working_path = Path(folder_number + "_" + self.module_name)
 
     def execute(self):
         """Execute simulation step."""

--- a/src/haddock/libs/libworkflow.py
+++ b/src/haddock/libs/libworkflow.py
@@ -9,6 +9,7 @@ from haddock.core.exceptions import HaddockError, StepError
 from haddock.gear.config_reader import get_module_name
 from haddock.libs.libutil import (
     convert_seconds_to_min_sec,
+    get_number_of_digits,
     recursive_dict_update,
     zero_fill,
     )
@@ -46,7 +47,7 @@ class Workflow:
 
         # Create the list of steps contained in this workflow
         self.steps = []
-        num_of_modules = len(str(len(modules_parameters)))
+        num_of_modules = get_number_of_digits(len(modules_parameters))
         _items = enumerate(modules_parameters.items())
         for num_stage, (stage_name, params) in _items:
             log.info(f"Reading instructions of [{stage_name}] step")

--- a/src/haddock/modules/__init__.py
+++ b/src/haddock/modules/__init__.py
@@ -198,7 +198,8 @@ class BaseHaddockModule(ABC):
 
     def previous_path(self):
         """Give the path from the previous calculation."""
-        previous = sorted(list(self.path.resolve().parent.glob('[0-9][0-9]*/')))
+        # https://regex101.com/r/4qRTjn/1
+        previous = sorted(list(self.path.resolve().parent.glob('[0-9]*/')))
         try:
             return previous[self.order - 1]
         except IndexError:

--- a/src/haddock/modules/__init__.py
+++ b/src/haddock/modules/__init__.py
@@ -198,7 +198,7 @@ class BaseHaddockModule(ABC):
 
     def previous_path(self):
         """Give the path from the previous calculation."""
-        # https://regex101.com/r/4qRTjn/1
+        # [0-9]* below is not a regex, is a bash wildkey
         previous = sorted(list(self.path.resolve().parent.glob('[0-9]*/')))
         try:
             return previous[self.order - 1]

--- a/tests/test_libutil.py
+++ b/tests/test_libutil.py
@@ -8,6 +8,7 @@ from haddock.libs.libutil import (
     extract_keys_recursive,
     file_exists,
     get_number_from_path_stem,
+    get_number_of_digits,
     non_negative_int,
     recursive_dict_update,
     sort_numbered_paths,
@@ -165,3 +166,16 @@ def test_extract_keys_recursive(inp, expected):
     """Test extract keys recursive."""
     result = set(extract_keys_recursive(inp))
     assert result == expected
+
+
+@pytest.mark.parametrize(
+    "num,expected",
+    [
+        (0, 1),
+        (1, 1),
+        (22, 2),
+        (335, 3),
+        ]
+    )
+def test_get_number_of_digits(num, expected):
+    assert get_number_of_digits(num) == expected

--- a/tests/test_libutil.py
+++ b/tests/test_libutil.py
@@ -174,6 +174,8 @@ def test_extract_keys_recursive(inp, expected):
         (0, 1),
         (1, 1),
         (22, 2),
+        (99, 2),
+        (100, 3),
         (335, 3),
         ]
     )


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and you comply with the following criteria:

- [x] You have stick to Python. Talk with us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [x] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [x] You structured the code into small functions as much as possible. You can use classes if there's a (state) purpose
- [x] code follows our coding style
- [x] You wrote tests for the new code
- [x] `tox` tests pass. *Run `tox` command inside the repository folder*
- [x] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [x] PR does not add any *install dependencies* unless permission granted by the HADDOCK team
- [x] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---

Modules folders are now zerofilled according to to the number of modules. If there are less than 10 modules, module folder will be prefix with only one digit. More than 10 modules, would be prefixed with 0, and so on. Thanks @douweschulte for the input :wink:
