### PR TITLE
Max number of molecules defined in a single place - the config

### DIFF
--- a/src/haddock/__init__.py
+++ b/src/haddock/__init__.py
@@ -13,6 +13,7 @@ add_syserr_handler(log)
 
 haddock3_source_path = Path(__file__).resolve().parent
 haddock3_repository_path = haddock3_source_path.parents[1]
+core_path = Path(haddock3_source_path, "core")
 toppar_path = Path(haddock3_source_path, "cns", "toppar")
 modules_defaults_path = Path(haddock3_source_path, "modules", "defaults.yaml")
 

--- a/src/haddock/core/defaults.py
+++ b/src/haddock/core/defaults.py
@@ -3,7 +3,9 @@ import string
 import sys
 from pathlib import Path
 
-from haddock import haddock3_repository_path, log
+import yaml
+
+from haddock import core_path, haddock3_repository_path, log
 
 
 # Locate the CNS binary
@@ -30,4 +32,7 @@ valid_run_dir_chars = string.ascii_letters + string.digits + "._-/\\"
 
 RUNDIR = "run_dir"
 
-max_molecules_allowed = 20
+with open(Path(core_path, "mandatory.yaml"), 'r') as fin:
+    _ycfg = yaml.safe_load(fin)
+max_molecules_allowed = _ycfg["molecules"]["maxitems"]
+del _ycfg

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,7 @@
+"""Test the core module."""
+
+from haddock.core.defaults import max_molecules_allowed
+
+
+def test_max_molecules_allowed():
+    assert max_molecules_allowed == 20


### PR DESCRIPTION
the maximum number of molecules allowed is now defined in a single place: the `mandatory.yaml` configuration file.
