### PR TITLE
Corrects edge case in zero filling modules folder names

### DIFF
--- a/src/haddock/libs/libutil.py
+++ b/src/haddock/libs/libutil.py
@@ -293,6 +293,21 @@ def get_number_of_digits(num):
     return max(ceil(log10(num + 1)), 1)
 
 
+def get_zerofill_for_modules(modules):
+    """
+    Get a the prefix zerofill for modules.
+
+    If there are 5 modules, zerofill digits is 1.
+    If there are 10 modules, zerofill digits is 1 because counting
+    starts at 0 (for topoaa).
+    If there are 100 modules, zerofill digits is 2 because counting
+    starts at 0 (for topoaa).
+
+    This function is used in combination with `zero_fill`.
+    """
+    return max(1, get_number_of_digits(len(modules) - 1))
+
+
 def sort_numbered_paths(*paths):
     """
     Sort input paths to tail number.

--- a/src/haddock/libs/libutil.py
+++ b/src/haddock/libs/libutil.py
@@ -305,7 +305,7 @@ def get_zerofill_for_modules(modules):
 
     This function is used in combination with `zero_fill`.
     """
-    return max(1, get_number_of_digits(len(modules) - 1))
+    return get_number_of_digits(len(modules) - 1)
 
 
 def sort_numbered_paths(*paths):

--- a/src/haddock/libs/libworkflow.py
+++ b/src/haddock/libs/libworkflow.py
@@ -9,7 +9,7 @@ from haddock.core.exceptions import HaddockError, StepError
 from haddock.gear.config_reader import get_module_name
 from haddock.libs.libutil import (
     convert_seconds_to_min_sec,
-    get_number_of_digits,
+    get_zerofill_for_modules,
     recursive_dict_update,
     zero_fill,
     )
@@ -47,7 +47,7 @@ class Workflow:
 
         # Create the list of steps contained in this workflow
         self.steps = []
-        num_of_modules = get_number_of_digits(len(modules_parameters))
+        mod_zerofill = get_zerofill_for_modules(modules_parameters)
         _items = enumerate(modules_parameters.items())
         for num_stage, (stage_name, params) in _items:
             log.info(f"Reading instructions of [{stage_name}] step")
@@ -61,7 +61,7 @@ class Workflow:
                 _ = Step(
                     get_module_name(stage_name),
                     order=num_stage,
-                    digits=num_of_modules,
+                    digits=mod_zerofill,
                     **params_up,
                     )
                 self.steps.append(_)

--- a/tests/test_libutil.py
+++ b/tests/test_libutil.py
@@ -9,6 +9,7 @@ from haddock.libs.libutil import (
     file_exists,
     get_number_from_path_stem,
     get_number_of_digits,
+    get_zerofill_for_modules,
     non_negative_int,
     recursive_dict_update,
     sort_numbered_paths,
@@ -181,3 +182,23 @@ def test_extract_keys_recursive(inp, expected):
     )
 def test_get_number_of_digits(num, expected):
     assert get_number_of_digits(num) == expected
+
+
+@pytest.mark.parametrize(
+    "mods,expected",
+    [
+        [[f"mod{i}" for i in range(1)], 1],
+        [[f"mod{i}" for i in range(5)], 1],
+        [[f"mod{i}" for i in range(10)], 1],
+        [[f"mod{i}" for i in range(11)], 2],
+        [[f"mod{i}" for i in range(100)], 2],
+        [[f"mod{i}" for i in range(101)], 3],
+        ]
+    )
+def test_get_zerofill_for_modules(mods, expected):
+    """
+    Test zerofill for modules.
+
+    Here "mod#" strings represent modules. The number prefix means nothing.
+    """
+    assert get_zerofill_for_modules(mods) == expected

--- a/tests/test_libutil.py
+++ b/tests/test_libutil.py
@@ -194,6 +194,8 @@ def test_get_number_of_digits(num, expected):
         [[f"mod{i}" for i in range(99)], 2],
         [[f"mod{i}" for i in range(100)], 2],
         [[f"mod{i}" for i in range(101)], 3],
+        [[f"mod{i}" for i in range(1000)], 3],
+        [[f"mod{i}" for i in range(1001)], 4],
         ]
     )
 def test_get_zerofill_for_modules(mods, expected):

--- a/tests/test_libutil.py
+++ b/tests/test_libutil.py
@@ -191,6 +191,7 @@ def test_get_number_of_digits(num, expected):
         [[f"mod{i}" for i in range(5)], 1],
         [[f"mod{i}" for i in range(10)], 1],
         [[f"mod{i}" for i in range(11)], 2],
+        [[f"mod{i}" for i in range(99)], 2],
         [[f"mod{i}" for i in range(100)], 2],
         [[f"mod{i}" for i in range(101)], 3],
         ]


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and you comply with the following criteria:

- [x] You have stick to Python. Talk with us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [x] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [x] You structured the code into small functions as much as possible. You can use classes if there's a (state) purpose
- [x] code follows our coding style
- [x] You wrote tests for the new code
- [x] `tox` tests pass. *Run `tox` command inside the repository folder*
- [x] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [x] PR does not add any *install dependencies* unless permission granted by the HADDOCK team
- [x] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---

Corrects edge cases in #378 when having 10 modules because module count starts at `0`.
