### PR TITLE
modules prefix to defaults

### DIFF
--- a/src/haddock/core/defaults.py
+++ b/src/haddock/core/defaults.py
@@ -36,3 +36,8 @@ with open(Path(core_path, "mandatory.yaml"), 'r') as fin:
     _ycfg = yaml.safe_load(fin)
 max_molecules_allowed = _ycfg["molecules"]["maxitems"]
 del _ycfg
+
+# Different parts of the code need to glob the run directory to search
+# for modules folders. The bash search prefix for module folders is
+# defined below.
+modules_folder_prefix = "[0-9]*/"

--- a/src/haddock/gear/restart_run.py
+++ b/src/haddock/gear/restart_run.py
@@ -2,6 +2,7 @@
 from argparse import ArgumentTypeError
 from functools import partial
 
+from haddock.core.defaults import modules_folder_prefix
 from haddock.libs.libutil import non_negative_int, remove_folder
 
 
@@ -53,7 +54,7 @@ def remove_folders_after_number(run_dir, num):
         representation.
     """
     num = _arg_non_neg_int(num)
-    previous = sorted(list(run_dir.resolve().glob('[0-9][0-9]*/')))
+    previous = sorted(list(run_dir.resolve().glob(modules_folder_prefix)))
     for folder in previous[num:]:
         remove_folder(folder)
     return

--- a/src/haddock/modules/__init__.py
+++ b/src/haddock/modules/__init__.py
@@ -5,7 +5,7 @@ from functools import partial
 from pathlib import Path
 
 from haddock import EmptyPath, log, modules_defaults_path
-from haddock.core.defaults import MODULE_IO_FILE
+from haddock.core.defaults import MODULE_IO_FILE, modules_folder_prefix
 from haddock.core.exceptions import ConfigurationError
 from haddock.gear.config_reader import read_config
 from haddock.gear.yaml2cfg import read_from_yaml_config
@@ -226,8 +226,8 @@ class BaseHaddockModule(ABC):
 
     def previous_path(self):
         """Give the path from the previous calculation."""
-        # [0-9]* below is not a regex, is a bash wildkey
-        previous = sorted(list(self.path.resolve().parent.glob('[0-9]*/')))
+        previous = list(self.path.resolve().parent.glob(modules_folder_prefix))
+        previous.sort()
         try:
             return previous[self.order - 1]
         except IndexError:


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and you comply with the following criteria:

- [x] You have stick to Python. Talk with us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [x] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [x] You structured the code into small functions as much as possible. You can use classes if there's a (state) purpose
- [x] code follows our coding style
- [x] You wrote tests for the new code
- [x] `tox` tests pass. *Run `tox` command inside the repository folder*
- [x] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [x] PR does not add any *install dependencies* unless permission granted by the HADDOCK team
- [x] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---

#378 broke `--restart` option for some cases.
Corrects and updates definitions for module's folders numeric prefix.
