### PR TITLE
Improve docs and tests for a part of the `setup_run` function

### DIFF
--- a/src/haddock/gear/expandable_parameters.py
+++ b/src/haddock/gear/expandable_parameters.py
@@ -396,8 +396,31 @@ def read_mol_parameters(
 
 
 def remove_trail_idx(param):
-    """Remove the trailing integer from a parameter."""
-    return "_".join(param.split("_")[:-1])
+    """
+    Remove the trailing integer from a parameter.
+
+    If trail is defined by an underscore "_".
+
+    Examples
+    --------
+    remove_trail_idx('some_parameter_1')
+    >>> 'some_parameter'
+
+    remove_trail_idx('some_parameter')
+    >>> 'some_parameter'
+
+    remove_trail_idx('parameter')
+    >>> 'parameter'
+
+    Parameters
+    ----------
+    param : str
+        A parameter name.
+    """
+    under_parts = param.split("_")
+    if under_parts[-1].isdigit():
+        return "_".join(param.split("_")[:-1])
+    return param
 
 
 def make_param_name_single_index(param_parts):

--- a/src/haddock/gear/expandable_parameters.py
+++ b/src/haddock/gear/expandable_parameters.py
@@ -417,9 +417,9 @@ def remove_trail_idx(param):
     param : str
         A parameter name.
     """
-    under_parts = param.split("_")
-    if under_parts[-1].isdigit():
-        return "_".join(param.split("_")[:-1])
+    under_parts = param.rpartition("_")
+    if under_parts[2].isdigit():
+        return under_parts[0]
     return param
 
 

--- a/src/haddock/gear/prepare_run.py
+++ b/src/haddock/gear/prepare_run.py
@@ -134,6 +134,7 @@ def setup_run(workflow_path, restart_from=None):
 
     # populate topology molecules
     populate_topology_molecule_params(modules_params["topoaa"])
+
     populate_mol_parameters(modules_params)
 
     # validations
@@ -508,26 +509,46 @@ def populate_topology_molecule_params(topoaa):
 
 def populate_mol_parameters(modules_params):
     """
-    Populate modules parameters.
+    Populate modules subdictionaries with the needed molecule `mol_` parameters.
+
+    The `mol_` prefixed parameters is a subclass of the expandable parameters.
+
+    See `gear.expandable_parameters`.
+
+    Modules require these parameters to be repeated for the number of input
+    molecules.
+
+    This function adds `mol_` parameters to the user input parameters,
+    one per each `molecule`.
 
     Parameters
     ----------
     modules_params : dict
-        A dictionary containing the parameters for all modules.
+        A dictionary containing only modules' keys:subdictionaries
+        parameters. That is, without the general parameters.
 
     Returns
     -------
     None
         Alter the dictionary in place.
     """
+    # the starting number of the `mol_` parameters is 1 by CNS definition.
+    num_mols = range(1, len(modules_params["topoaa"]["molecules"]) + 1)
     for module_name, _ in modules_params.items():
+
+        # read the modules default parameters
         defaults = _read_defaults(module_name)
 
+        # if there are no `mol_` parameters in the modules default values,
+        # the `mol_params` generator will be empty and the for-loop below
+        # won't run.
         mol_params = (p for p in list(defaults.keys()) if is_mol_parameter(p))
-        num_mols = range(1, len(modules_params["topoaa"]["molecules"]) + 1)
 
         for param, i in it.product(mol_params, num_mols):
             param_name = remove_trail_idx(param)
+
+            # the `setdefault` grants that the value is only added if
+            # the parameter is not present.
             modules_params[module_name].setdefault(
                 f"{param_name}_{i}",
                 defaults[param],

--- a/tests/test_gear_expandable_parameters.py
+++ b/tests/test_gear_expandable_parameters.py
@@ -653,6 +653,7 @@ def test_read_mol_params(inp, default, expected):
         ("some_parameter_1", "some_parameter"),
         ("some_parameter_0", "some_parameter"),
         ("some_parameter_99", "some_parameter"),
+        ("some_parameter_0_2", "some_parameter_0"),
         ("parameter_99", "parameter"),
         ("parameter99", "parameter99"),
         ("some_parameter", "some_parameter"),

--- a/tests/test_gear_expandable_parameters.py
+++ b/tests/test_gear_expandable_parameters.py
@@ -21,6 +21,7 @@ from haddock.gear.expandable_parameters import (
     rejoin_parts_multiple_index,
     rejoin_parts_single_index,
     remove_ghost_groups,
+    remove_trail_idx,
     type_simplest_ep,
     )
 from haddock.gear.yaml2cfg import read_from_yaml_config
@@ -644,3 +645,21 @@ def test_read_mol_params(inp, default, expected):
     result = read_mol_parameters(inp, default, max_mols=10)
     assert result == expected
     assert isinstance(result, set)
+
+
+@pytest.mark.parametrize(
+    "param, expected",
+    [
+        ("some_parameter_1", "some_parameter"),
+        ("some_parameter_0", "some_parameter"),
+        ("some_parameter_99", "some_parameter"),
+        ("parameter_99", "parameter"),
+        ("parameter99", "parameter99"),
+        ("some_parameter", "some_parameter"),
+        ("parameter", "parameter"),
+        ]
+    )
+def test_remove_trail_idx(param, expected):
+    """Test remove trail index from parameter."""
+    result = remove_trail_idx(param)
+    assert result == expected


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and you comply with the following criteria:

- [ ] You have stick to Python. Talk with us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [ ] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [ ] You structured the code into small functions as much as possible. You can use classes if there's a (state) purpose
- [ ] code follows our coding style
- [ ] You wrote tests for the new code
- [x] `tox` tests pass. *Run `tox` command inside the repository folder*
- [x] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [ ] PR does not add any *install dependencies* unless permission granted by the HADDOCK team
- [ ] PR does not break licensing
- [x] Your PR is about writing documentation for already existing code :fire:
- [x] Your PR is about writing tests for already existing code :godmode:

---

While developing for #382, I found this part of the code poorly documented. Here, I add docs, tests, and correct a minor implementation.
