### PR TITLE
Ignore `WAT` residues in `caprieval`

### DIFF
--- a/src/haddock/modules/analysis/caprieval/capri.py
+++ b/src/haddock/modules/analysis/caprieval/capri.py
@@ -21,7 +21,7 @@ from haddock.libs.libontology import PDBFile
 from haddock.libs.libpdb import split_by_chain
 
 
-RES_TO_BE_IGNORED = ["SHA"]
+RES_TO_BE_IGNORED = ["SHA", "WAT"]
 
 PROT_RES = [
     "ALA",
@@ -1107,7 +1107,7 @@ def dump_as_izone(fname, numbering_dic):
                     f"{os.linesep}"
                     )
                 fh.write(izone_str)
-    
+
 # # debug only
 # def write_coord_dic(output_name, coord_dic):
 #     """Add a dummy atom to a PDB file according to a list of coordinates."""


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and you comply with the following criteria:

- [X] You have stick to Python. Talk with us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [X] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [X] You structured the code into small functions as much as possible. You can use classes if there's a (state) purpose
- [X] code follows our coding style
- [ ] You wrote tests for the new code
- [X] `tox` tests pass. *Run `tox` command inside the repository folder*
- [X] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [X] PR does not add any *install dependencies* unless permission granted by the HADDOCK team
- [X] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---

This PR adds `WAT` to the list of residues to be ignored when calculating the capri metrics and closes #398, this allows `caprieval` to be executed after any module that adds water molecules to the models.
