### PR TITLE
Remove solvent molecules from the output of `mdscoring`

### DIFF
--- a/examples/scoring/mdscoring-test.cfg
+++ b/examples/scoring/mdscoring-test.cfg
@@ -23,5 +23,6 @@ tolerance = 20
 contactairs = true
 ssdihed = "alphabeta"
 dnarest_on = true
+#keepwater = true
 
 # ====================================================================

--- a/src/haddock/modules/scoring/mdscoring/cns/mdscoring.cns
+++ b/src/haddock/modules/scoring/mdscoring/cns/mdscoring.cns
@@ -423,10 +423,18 @@ inline @MODULE:print_coorheader.cns
 
 coor sele= (not name H* and not resn ANI and not resn XAN and not resn DAN) orient end
 
-write coordinates format=pdbo output=$output_pdb_filename end
+write coordinates sele=(not (resn WA* or resn HOH or resn TIP* or resn DMS)) format=pdbo output=$output_pdb_filename end
 
 set message=normal echo=on end
 
 display OUTPUT: $output_pdb_filename
 
+if ($refine.keepwater eq true) then
+    evaluate ($filename= $output_pdb_filename - ".pdb" + "_solvent.pdb")
+    write coordinates sele=(all) format=pdbo output=$filename end
+end if
+
+display OUTPUT: $output_pdb_filename
+
 stop
+


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and you comply with the following criteria:

- [ ] You have stick to Python. Talk with us before adding other programming languages to HADDOCK3
- [X] Your PR is about CNS
- [ ] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [ ] You structured the code into small functions as much as possible. You can use classes if there's a (state) purpose
- [ ] code follows our coding style
- [ ] You wrote tests for the new code
- [ ] `tox` tests pass. *Run `tox` command inside the repository folder*
- [X] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [X] PR does not add any *install dependencies* unless permission granted by the HADDOCK team
- [X] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---

Modified the `mdscoring` script to avoid writing the solvent unless `keepwater` is set to true in the config file.

***

This PR fixes #400 