### PR TITLE
Bugfix for numbering reference between model and receptor

### DIFF
--- a/tests/test_module_caprieval.py
+++ b/tests/test_module_caprieval.py
@@ -867,7 +867,7 @@ def test_align_seq():
     with tempfile.TemporaryDirectory() as tmpdirname:
 
         observed_numb_dic = align_seq(ref, mod, tmpdirname)
-        expected_numb_dic = {"B": {1: 101, 2: 102, 3: 110, 5: 112}}
+        expected_numb_dic = {"B": {101: 1, 102: 2, 110: 3, 112: 5}}
 
         assert observed_numb_dic == expected_numb_dic
 


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and you comply with the following criteria:

- [X] You have stick to Python. Talk with us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [X] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [X] You structured the code into small functions as much as possible. You can use classes if there's a (state) purpose
- [X] code follows our coding style
- [X] You wrote tests for the new code
- [X] `tox` tests pass. *Run `tox` command inside the repository folder*
- [X] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [X] PR does not add any *install dependencies* unless permission granted by the HADDOCK team
- [X] PR does not break licensing
- [X] Your PR is about writing documentation for already existing code :fire:
- [X] Your PR is about writing tests for already existing code :godmode:

---

Before the alignment was just taking sections that overlap, now it should correctly use the numbering reference, also improved a bit the readability of the sequence alignment function and updated the tests.