### PR TITLE
Implement PDBTraceback

### DIFF
--- a/src/haddock/clis/cli.py
+++ b/src/haddock/clis/cli.py
@@ -151,6 +151,8 @@ def main(
         # Main loop of execution
         workflow.run()
 
+        workflow.traceback()
+
     # Finish
     end = time()
     elapsed = convert_seconds_to_min_sec(end - start)

--- a/src/haddock/gear/traceback.py
+++ b/src/haddock/gear/traceback.py
@@ -1,0 +1,45 @@
+"""Traces the input PDBs accross the modules."""
+import os
+
+
+class Traceback:
+    """Class that represents the PDB traceback."""
+
+    def __init__(self, io_data):
+        self.model_data, self.module_list = self.read_io_data(io_data)
+
+    @staticmethod
+    def read_io_data(io_data):
+        """Read the IO data from modules and organize it per-model."""
+        model_dict = {}
+        module_list = []
+        for module_name in io_data:
+            if '0_topoaa' in module_name:
+                # ignore topoaa
+                continue
+            module_list.append(module_name)
+            model_container = io_data[module_name].retrieve_models(
+                individualize=True)
+            for model in model_container:
+                if model.ori_name not in model_dict:
+                    model_dict[model.ori_name] = {}
+                model_dict[model.ori_name][module_name] = model.score
+
+        return model_dict, module_list
+
+    def dump(self, output_f=None):
+        """Dump the traceback info to a file."""
+        header = 'model_name\t' + "\t".join(self.module_list)
+        with open(output_f, 'w') as fh:
+            fh.write(header + os.linesep)
+            for model in self.model_data:
+                row = ""
+                row += f"{model}\t"
+                for module in self.module_list:
+                    try:
+                        value = self.model_data[model][module]
+                        value_str = f"{value:.2f}"
+                    except KeyError:
+                        value_str = '-'
+                    row += f"{value_str}\t"
+                fh.write(row + os.linesep)

--- a/src/haddock/libs/libcns.py
+++ b/src/haddock/libs/libcns.py
@@ -357,4 +357,8 @@ def prepare_expected_pdb(model_obj, model_nb, path, identifier):
         pdb.topology = [p.topology for p in model_obj]
     else:
         pdb.topology = model_obj.topology
+
+    if model_obj.ori_name is not None:
+        pdb.ori_name = model_obj.ori_name
+
     return pdb

--- a/src/haddock/libs/libworkflow.py
+++ b/src/haddock/libs/libworkflow.py
@@ -7,7 +7,9 @@ from time import time
 from haddock import log
 from haddock.core.exceptions import HaddockError, StepError
 from haddock.gear.config_reader import get_module_name
+from haddock.gear.traceback import Traceback
 from haddock.gear.zerofill import zero_fill
+from haddock.libs.libontology import ModuleIO
 from haddock.libs.libutil import (
     convert_seconds_to_min_sec,
     recursive_dict_update,
@@ -30,6 +32,18 @@ class WorkflowManager:
         """High level workflow composer."""
         for step in self.recipe.steps[self.start:]:
             step.execute()
+
+    def traceback(self):
+        """Produce a human-readable traceback of the PDBs."""
+        io_dic = {}
+        for step_number, step in enumerate(self.recipe.steps):
+            io = ModuleIO()
+            step_io_file = Path(step.working_path, 'io.json')
+            io.load(step_io_file)
+            io_dic[f'{step_number}_{step.module_name}'] = io
+
+        trace = Traceback(io_dic)
+        trace.dump(output_f='traceback.tsv')
 
 
 class Workflow:

--- a/src/haddock/modules/sampling/rigidbody/__init__.py
+++ b/src/haddock/modules/sampling/rigidbody/__init__.py
@@ -77,6 +77,8 @@ class HaddockModule(BaseCNSModule):
                 # Create a model for the expected output
                 model = PDBFile(output_pdb_fname, path=self.path)
                 model.topology = [e.topology for e in combination]
+                model.ori_name = '+'.join([m.ori_name for m in combination])
+                model.ori_name += f'_{_i}'
                 self.output_models.append(model)
 
                 job = CNSJob(inp_file, log_fname, envvars=self.envvars)


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and you comply with the following criteria:

- [X] You have stick to Python. Talk with us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [X] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [X] You structured the code into small functions as much as possible. You can use classes if there's a (state) purpose
- [X] code follows our coding style
- [ ] You wrote tests for the new code
- [X] `tox` tests pass. *Run `tox` command inside the repository folder*
- [X] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [X] PR does not add any *install dependencies* unless permission granted by the HADDOCK team
- [X] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---

Implement #402 by adding a way to track the score changes of the input PDBs across modules;

```tsv
model_name	1_rigidbody	2_caprieval	3_seletop	4_flexref	5_caprieval
e2aP_1F3G+hpr_ensemble_1_0	-9.78	-9.78	-	-	-	
e2aP_1F3G+hpr_ensemble_1_1	-14.10	-14.10	-	-	-	
e2aP_1F3G+hpr_ensemble_2_0	-25.24	-25.24	-25.24	-161.85	-161.85	
e2aP_1F3G+hpr_ensemble_2_1	-33.05	-33.05	-33.05	-206.32	-206.32	
e2aP_1F3G+hpr_ensemble_3_0	-15.46	-15.46	-	-	-	
e2aP_1F3G+hpr_ensemble_3_1	-5.21	-5.21	-	-	-	
e2aP_1F3G+hpr_ensemble_4_0	-14.96	-14.96	-	-	-	
e2aP_1F3G+hpr_ensemble_4_1	-22.55	-22.55	-	-	-	
e2aP_1F3G+hpr_ensemble_5_0	-13.03	-13.03	-	-	-	
e2aP_1F3G+hpr_ensemble_5_1	-24.43	-24.43	-24.43	-224.63	-224.63	
e2aP_1F3G+hpr_ensemble_6_0	-22.87	-22.87	-22.87	-123.28	-123.28	
e2aP_1F3G+hpr_ensemble_6_1	-21.58	-21.58	-	-	-	
e2aP_1F3G+hpr_ensemble_7_0	-17.55	-17.55	-	-	-	
e2aP_1F3G+hpr_ensemble_7_1	-15.51	-15.51	-	-	-	
e2aP_1F3G+hpr_ensemble_8_0	-22.49	-22.49	-	-	-	
e2aP_1F3G+hpr_ensemble_8_1	-24.73	-24.73	-24.73	-169.73	-169.73	
e2aP_1F3G+hpr_ensemble_9_0	-14.90	-14.90	-	-	-	
e2aP_1F3G+hpr_ensemble_9_1	-12.46	-12.46	-	-	-	
e2aP_1F3G+hpr_ensemble_10_0	-21.95	-21.95	-	-	-	
e2aP_1F3G+hpr_ensemble_10_1	-20.79	-20.79	-	-	-	
```

```tsv
model_name  1_emscoring 2_mdscoring 3_caprieval
model_11 -186.88 -202.08 -202.08 
model_20 -105.26 -114.24 -114.24 
model_112 -199.35 -217.36 -217.36 
model_200 -193.23 -210.68 -210.68 
model_500 -178.97 -194.50 -194.50
```

The score for analysis modules is simply a repetition of the score assigned by the module before.