### PR TITLE
Correct small (future) bug in reading `self_contained` parameter

### DIFF
--- a/src/haddock/modules/base_cns_module.py
+++ b/src/haddock/modules/base_cns_module.py
@@ -41,7 +41,7 @@ class BaseCNSModule(BaseHaddockModule):
         self.add_parent_to_paths()
         self.envvars = self.default_envvars()
 
-        if params['self_contained']:
+        if self.params['self_contained']:
             self.make_self_contained()
 
         with working_directory(self.path):

--- a/tests/test_libutil.py
+++ b/tests/test_libutil.py
@@ -127,6 +127,14 @@ def test_recursive_dict_update():
     assert c == {"a": 2, "b": {"c": 2, "d": {"e": 4}}, "z": {"z1": _list}}
 
 
+def test_recursive_dict_update_empty():
+    """Test recursive dict update."""
+    a = {"a": 1, "b": {"c": 2, "d": {"e": 3}}}
+    c = recursive_dict_update(a, {})
+    assert a is not c
+    assert a == c
+
+
 @pytest.mark.parametrize(
     "seconds,expected",
     [


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and you comply with the following criteria:

- [x] You have stick to Python. Talk with us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [x] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [x] You structured the code into small functions as much as possible. You can use classes if there's a (state) purpose
- [x] code follows our coding style
- [x] You wrote tests for the new code
- [x] `tox` tests pass. *Run `tox` command inside the repository folder*
- [x] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [ ] PR does not add any *install dependencies* unless permission granted by the HADDOCK team
- [ ] PR does not break licensing
- [ ] This PR adds documentation for already existing code :fire:
- [x] Your PR is about writing tests for already existing code :godmode:

---

This bug did **not** cause any problems in the past. But was causing problems with #409. Decided to solve it in a separate PR for simplicity.
