### PR TITLE
amend threshold behavior in clustfcc

### DIFF
--- a/src/haddock/modules/analysis/clustfcc/__init__.py
+++ b/src/haddock/modules/analysis/clustfcc/__init__.py
@@ -154,7 +154,8 @@ class HaddockModule(BaseHaddockModule):
             for clt_id in clt_dic:
                 score_l = [p.score for p in clt_dic[clt_id]]
                 score_l.sort()
-                top4_score = sum(score_l[:threshold]) / float(threshold)
+                denom = float(min(threshold, len(score_l)))
+                top4_score = sum(score_l[:threshold]) / denom
                 score_dic[clt_id] = top4_score
 
             sorted_score_dic = sorted(score_dic.items(), key=lambda k: k[1])


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and you comply with the following criteria:

- [x] You have stick to Python. Talk with us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [ ] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [ ] You structured the code into small functions as much as possible. You can use classes if there's a (state) purpose
- [x] code follows our coding style
- [ ] You wrote tests for the new code
- [x] `tox` tests pass. *Run `tox` command inside the repository folder*
- [x] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [x] PR does not add any *install dependencies* unless permission granted by the HADDOCK team
- [x] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---
corrected denominator in `clustfcc` #411 
