### PR TITLE
Additional unit tests and newline improvements in `config_writer`

### DIFF
--- a/src/haddock/gear/config_writer.py
+++ b/src/haddock/gear/config_writer.py
@@ -104,10 +104,16 @@ def convert_config(
     # `mol*` start with `mol`
     sorted_keys = sorted(valid_keys, key=_is_dict)
 
-    for key, value in sorted_keys:
+    for i, (key, value) in enumerate(sorted_keys):
 
         module_key = get_module_name(key)
         if module_key in module_names:
+
+            # used to get an extra line when writing the second module
+            # header
+            if i > 0:
+                yield ""
+
             yield f"[{module_key}]"
             yield from convert_config(
                 value,
@@ -118,10 +124,12 @@ def convert_config(
             continue
 
         elif isinstance(value, collections.abc.Mapping):
-            yield ""
             if _module_key is None:
+                yield ""
                 yield f"[{key}]"
             else:
+                # module's subkeys should follow without an extra
+                # newline
                 yield f"[{_module_key}.{key}]"
             yield from convert_config(value)
             continue

--- a/tests/test_gear_config_writer.py
+++ b/tests/test_gear_config_writer.py
@@ -157,7 +157,6 @@ param6 = nan
 param7 = "string"
 param8 = []
 param9 = []
-
 [module.sub1]
 param5 = 50'''
 

--- a/tests/test_modules_general.py
+++ b/tests/test_modules_general.py
@@ -233,6 +233,7 @@ molecules = [
 
 cns_exec = "path1"
 ncores = 8
+
 [topoaa]
 param1 = 1
 param2 = 1.0
@@ -245,16 +246,57 @@ param4 = [
 
 param6 = nan
 param7 = "string"
-
 [topoaa.sub1]
 param5 = 50'''
 
 
 def test_save_config():
-    fpath = Path("save_config_test.cfg")
+    fpath = Path("save_config_test_case1.cfg")
     save_config(case_1, fpath)
     result = fpath.read_text()
     assert result == case_1_text
+    fpath.unlink()
+
+
+case_topoaa = {
+    "topoaa": {
+        "param1": 1,
+        "param2": 1.0,
+        "param3": False,
+        "param4": ["a", "b", "c"],
+        "sub1": {"param5": 50},
+        "param6": float('nan'),
+        "param7": "string",
+        },
+    "rigidbody": {
+        "param1": 10,
+        },
+    }
+
+case_topoaa_txt = '''[topoaa]
+param1 = 1
+param2 = 1.0
+param3 = false
+param4 = [
+    "a",
+    "b",
+    "c"
+    ]
+
+param6 = nan
+param7 = "string"
+[topoaa.sub1]
+param5 = 50
+
+[rigidbody]
+param1 = 10'''
+
+
+def test_save_config_header():
+    fpath = Path("save_config_test_header.cfg")
+    save_config(case_topoaa, fpath)
+    result = fpath.read_text()
+    assert result == case_topoaa_txt
     fpath.unlink()
 
 
@@ -287,7 +329,6 @@ param4 = [
 
 param6 = nan
 param7 = "string"
-
 [topoaa.sub1]
 param5 = 50'''
 


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and you comply with the following criteria:

- [x] You have stick to Python. Talk with us before adding other programming languages to HADDOCK3
- [x] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [x] You structured the code into small functions as much as possible. You can use classes if there's a (state) purpose
- [x] code follows our coding style
- [x] You wrote tests for the new code
- [x] `tox` tests pass. *Run `tox` command inside the repository folder*
- [x] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [x] PR does not add any *install dependencies* unless permission granted by the HADDOCK team
- [x] PR does not break licensing
- [x] Your PR is about writing documentation for already existing code :fire:
- [x] Your PR is about writing tests for already existing code :godmode:

---

* related to #407, #409
* Add more unit tests to `config_writer` to further confirm https://github.com/haddocking/haddock3/pull/409#issuecomment-1114568693 (everything was working)
* Improves new lines spacing parameters and headers in config writing. 

@sverhoeven 