### PR TITLE
updates CI to flake8-print v5

### DIFF
--- a/examples/compare_runs.py
+++ b/examples/compare_runs.py
@@ -48,7 +48,7 @@ from pathlib import Path
 try:
     from haddock.gear.config_reader import read_config
 except Exception:
-    print(  # noqa: T001
+    print(  # noqa: T201
         "Haddock3 could not be imported. "
         "Please activate the haddock3 python environment.",
         file=sys.stderr,
@@ -56,7 +56,7 @@ except Exception:
     sys.exit(1)
 
 
-printf = partial(print, flush=True)  # noqa: T002
+printf = partial(print, flush=True)  # noqa: T202
 
 
 examples = (
@@ -326,12 +326,12 @@ def compare_examples(examples, devel, reference):
         run_dir = params["run_dir"]
         run_name = str(Path(folder, run_dir))
 
-        print(  # noqa: T001
+        print(  # noqa: T201
             os.linesep,
             f" {run_name} ".center(80, "*"),
             os.linesep,
             flush=True,
-            )  # noqa: T001
+            )  # noqa: T201
 
         dev_run_dir = Path(devel, folder, run_dir)
         ref_run_dir = Path(reference, folder, run_dir)

--- a/examples/run_tests.py
+++ b/examples/run_tests.py
@@ -34,7 +34,7 @@ try:
     from haddock.gear.config_reader import read_config
     from haddock.libs.libio import working_directory
 except Exception:
-    print(  # noqa: T001
+    print(  # noqa: T201
         "Haddock3 could not be imported. "
         "Please activate the haddock3 python environment.",
         file=sys.stderr,
@@ -92,12 +92,12 @@ def main(examples, break_on_errors=True):
     """Run all the examples."""
     for folder, file_ in examples:
 
-        print(  # noqa: T001
+        print(  # noqa: T201
             os.linesep,
             f" {file_.upper()} ".center(80, "*"),
             os.linesep,
             flush=True,
-            )  # noqa: T001
+            )  # noqa: T201
 
         with working_directory(folder):
 

--- a/src/haddock/clis/cli_cfg.py
+++ b/src/haddock/clis/cli_cfg.py
@@ -80,7 +80,7 @@ def main(module, explevel):
     ycfg = read_from_yaml(cfg)
 
     new_config = yaml2cfg_text(ycfg, module, explevel)
-    print(new_config, file=sys.stdout, flush=True)  # noqa: T001
+    print(new_config, file=sys.stdout, flush=True)  # noqa: T201
 
     return 0
 

--- a/tox.ini
+++ b/tox.ini
@@ -58,7 +58,7 @@ commands_post =
 skip_install = true
 deps =
     flake8>=4
-    flake8-print
+    flake8-print>=5
     flake8-docstrings
     flake8-bugbear
     pygments
@@ -134,10 +134,10 @@ ignore =
     W503
     D412
     D105
-per-file-ignores = 
+per-file-ignores =
     setup.py:E501
     src/haddock/clis/cli_bm.py:E128
-    src/haddock/clis/cli_dmn.py:T001
+    src/haddock/clis/cli_dmn.py:T201
     tests/*:D103
 docstring-convention = numpy
 


### PR DESCRIPTION
Updates CI to the new [flake8-print](https://pypi.org/project/flake8-print/) v5, which changed the error codes. See its changelog.
