### PR TITLE
Reduce `pytest` verbosity

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,9 @@ To contribute to the HADDOCK3's Python shell, follow these steps:
     (should) use our `tox` environments to test your code. Use the
     following commands from the main repository folder:
 
-    1.  `tox -e py39` runs tests in Python 3.9 environment.
+    1.  `tox -e py39` runs tests in Python 3.9 environment. If you tox
+    to report test names and status for every single test (high verbosity) use
+    `tox -e py39 -- -vv`.
     2.  `tox -e lint` shows you errors in the code style.
     3.  `tox -e build` simulates building the HADDOCK3 package.
     4.  Run the above altogether with the simple `tox` command

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,7 @@ commands_pre =
     coverage erase
 # execute pytest
 commands =
-    pytest --cov --cov-report=term-missing --cov-append --cov-config=.coveragerc -vv --hypothesis-show-statistics {posargs}
+    pytest --cov --cov-report=term-missing --cov-append --cov-config=.coveragerc --hypothesis-show-statistics {posargs}
 # after executing the pytest assembles the coverage reports
 commands_post = 
     coverage report


### PR DESCRIPTION
As the number of unit tests increases, the current `pytest` command in `tox` is becoming very verbose. This PR reduces the verbosity of `tox -e py39` command. If you want fully verbosity, run `tox -e py39 -- -vv`. Also updated the docs.