### PR TITLE
Improves method to find step folders in a run directory

### DIFF
--- a/src/haddock/core/defaults.py
+++ b/src/haddock/core/defaults.py
@@ -36,8 +36,3 @@ with open(Path(core_path, "mandatory.yaml"), 'r') as fin:
     _ycfg = yaml.safe_load(fin)
 max_molecules_allowed = _ycfg["molecules"]["maxitems"]
 del _ycfg
-
-# Different parts of the code need to glob the run directory to search
-# for modules folders. The bash search prefix for module folders is
-# defined below.
-modules_folder_prefix = "[0-9]*/"

--- a/src/haddock/gear/restart_run.py
+++ b/src/haddock/gear/restart_run.py
@@ -2,8 +2,8 @@
 from argparse import ArgumentTypeError
 from functools import partial
 
-from haddock.core.defaults import modules_folder_prefix
 from haddock.libs.libutil import non_negative_int, remove_folder
+from haddock.modules import get_module_steps_folders
 
 
 _help_cli = """Restart the run from a given step. Previous folders from
@@ -54,7 +54,7 @@ def remove_folders_after_number(run_dir, num):
         representation.
     """
     num = _arg_non_neg_int(num)
-    previous = sorted(list(run_dir.resolve().glob(modules_folder_prefix)))
+    previous = get_module_steps_folders(run_dir.resolve())
     for folder in previous[num:]:
         remove_folder(folder)
     return

--- a/src/haddock/modules/__init__.py
+++ b/src/haddock/modules/__init__.py
@@ -427,7 +427,7 @@ def get_module_steps_folders(folder):
     list of str
         List containing strings with the names of the step folders.
     """
-    folders = [p for p in Path(folder).glob() if p.is_dir()]
+    folders = [p for p in Path(folder).iterdir() if p.is_dir()]
     fr = re.compile(step_folder_regex)
-    steps = sorted(f for f in folders if fr.search(f))
+    steps = sorted(f for f in folders if fr.search(str(f)))
     return steps

--- a/src/haddock/modules/__init__.py
+++ b/src/haddock/modules/__init__.py
@@ -437,7 +437,7 @@ def get_module_steps_folders(folder):
     list of str
         List containing strings with the names of the step folders.
     """
-    folders = [p.name for p in Path(folder).iterdir() if p.is_dir()]
+    folders = (p.name for p in Path(folder).iterdir() if p.is_dir())
     steps = sorted(
         (f for f in folders if step_folder_regex_re.search(f)),
         key=lambda x: int(x.split("_")[0]),

--- a/src/haddock/modules/__init__.py
+++ b/src/haddock/modules/__init__.py
@@ -60,7 +60,17 @@ _step_folder_regex = tuple(
     )
 step_folder_regex = "(" + "|".join(_step_folder_regex) + ")"
 """
-Regular expression to match module folders in a run directory.
+String for regular expression to match module folders in a run directory.
+
+It will match folders with a numeric prefix followed by underscore ("_")
+followed by the name of a module.
+
+Example: https://regex101.com/r/roHls9/1
+"""
+
+step_folder_regex_re = re.compile(step_folder_regex)
+"""
+Compiled regular expression from :py:const:`step_folder_regex`.
 
 It will match folders with a numeric prefix followed by underscore ("_")
 followed by the name of a module.
@@ -427,7 +437,9 @@ def get_module_steps_folders(folder):
     list of str
         List containing strings with the names of the step folders.
     """
-    folders = [p for p in Path(folder).iterdir() if p.is_dir()]
-    fr = re.compile(step_folder_regex)
-    steps = sorted(f for f in folders if fr.search(str(f)))
+    folders = [p.name for p in Path(folder).iterdir() if p.is_dir()]
+    steps = sorted(
+        (f for f in folders if step_folder_regex_re.search(f)),
+        key=lambda x: int(x.split("_")[0]),
+        )
     return steps

--- a/src/haddock/modules/__init__.py
+++ b/src/haddock/modules/__init__.py
@@ -255,7 +255,7 @@ class BaseHaddockModule(ABC):
         if self.order == 0:
             return ModuleIO()
         io = ModuleIO()
-        previous_io = self.previous_path() / filename
+        previous_io = Path(self.previous_path(), filename)
         if previous_io.is_file():
             io.load(previous_io)
         return io
@@ -265,7 +265,7 @@ class BaseHaddockModule(ABC):
         previous = get_module_steps_folders(self.path.resolve().parent)
 
         try:
-            return previous[self.order - 1]
+            return Path(previous[self.order - 1])
         except IndexError:
             return self.path
 

--- a/src/haddock/modules/__init__.py
+++ b/src/haddock/modules/__init__.py
@@ -53,6 +53,20 @@ config_readers = {
     ".cfg": read_config,
     }
 
+_folder_regex = tuple(
+    r"[0-9]+_" + mod_name
+    for mod_name in modules_category.keys()
+    )
+step_folder_regex = "(" + "|".join(_folder_regex) + ")"
+"""
+Regular expression to match module folders in a run directory.
+
+It will match folders with a numeric prefix followed by underscore ("_")
+followed by the name of a module.
+
+Example: https://regex101.com/r/roHls9/1
+"""
+
 
 @contextmanager
 def _not_valid_config():

--- a/tests/test_modules_general.py
+++ b/tests/test_modules_general.py
@@ -4,6 +4,7 @@ Test general implementation in haddock3 modules.
 Ensures all modules follow the same compatible architecture.
 """
 import importlib
+import shutil
 from pathlib import Path
 
 import pytest
@@ -16,6 +17,7 @@ from haddock.modules import (
     _not_valid_config,
     category_hierarchy,
     config_readers,
+    get_module_steps_folders,
     modules_category,
     save_config,
     save_config_ignored,
@@ -339,3 +341,16 @@ def test_save_config_ignored():
     result = fpath.read_text()
     assert result == case_2_text
     fpath.unlink()
+
+
+def test_get_module_steps_folders():
+    rd = Path("run_dir_test")
+    rd.mkdir()
+    Path(rd, '0_topoaa').mkdir()
+    Path(rd, '150_flexref').mkdir()
+    Path(rd, '1_rigidbody').mkdir()
+    Path(rd, '2_nothing').mkdir()
+    Path(rd, 'data').mkdir()
+    result = get_module_steps_folders(rd)
+    shutil.rmtree(rd)
+    assert result == ['0_topoaa', '1_rigidbody', '150_flexref']


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and you comply with the following criteria:

- [x] You have stick to Python. Talk with us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [x] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [x] You structured the code into small functions as much as possible. You can use classes if there's a (state) purpose
- [x] code follows our coding style
- [x] You wrote tests for the new code
- [x] `tox` tests pass. *Run `tox` command inside the repository folder*
- [x] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [x] PR does not add any *install dependencies* unless permission granted by the HADDOCK team
- [x] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---

While preparing #425, I realized the way we search for step folders (`0_topoaa`, `1_rigidbody`, etc...) in a run directory can be improved because before we were considering only folders starting with a number. Now, we consider folders starting with a number, plus `_`, and that are named the same as modules.
