### PR TITLE
Corrects bug in `--restart`

### DIFF
--- a/examples/run_tests.py
+++ b/examples/run_tests.py
@@ -112,7 +112,7 @@ def main(examples, break_on_errors=True):
                 )
 
             # perform a restart step
-            if file_ ==  "docking-protein-protein-test.cfg":
+            if file_ == "docking-protein-protein-test.cfg":
                 subprocess.run(
                     f"haddock3 {file_} --restart 5",
                     shell=True,

--- a/examples/run_tests.py
+++ b/examples/run_tests.py
@@ -111,6 +111,16 @@ def main(examples, break_on_errors=True):
                 stderr=sys.stderr,
                 )
 
+            # perform a restart step
+            if file_ ==  "docking-protein-protein-test.cfg":
+                subprocess.run(
+                    f"haddock3 {file_} --restart 5",
+                    shell=True,
+                    check=break_on_errors,
+                    stdout=sys.stdout,
+                    stderr=sys.stderr,
+                    )
+
     return
 
 

--- a/src/haddock/gear/restart_run.py
+++ b/src/haddock/gear/restart_run.py
@@ -1,6 +1,7 @@
 """Features to allow run restart from a given step."""
 from argparse import ArgumentTypeError
 from functools import partial
+from pathlib import Path
 
 from haddock.libs.libutil import non_negative_int, remove_folder
 from haddock.modules import get_module_steps_folders
@@ -56,5 +57,5 @@ def remove_folders_after_number(run_dir, num):
     num = _arg_non_neg_int(num)
     previous = get_module_steps_folders(run_dir.resolve())
     for folder in previous[num:]:
-        remove_folder(folder)
+        remove_folder(Path(run_dir, folder))
     return

--- a/src/haddock/libs/libutil.py
+++ b/src/haddock/libs/libutil.py
@@ -87,7 +87,7 @@ def copy_files_to_dir(paths, directory):
 
 def remove_folder(folder):
     """Remove a folder if it exists."""
-    if folder.exists():
+    if Path(folder).exists():
         log.warning(f'{folder} exists and it will be REMOVED!')
         shutil.rmtree(folder)
 


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and you comply with the following criteria:

- [x] You have stick to Python. Talk with us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [x] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [x] You structured the code into small functions as much as possible. You can use classes if there's a (state) purpose
- [x] code follows our coding style
- [x] You wrote tests for the new code
- [x] `tox` tests pass. *Run `tox` command inside the repository folder*
- [ ] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [x] PR does not add any *install dependencies* unless permission granted by the HADDOCK team
- [x] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---

* Corrects a bug in `--restart` introduced after #427
* Add `--restart` test to `run_tests.py`

If I would tell @douweschulte the amount of tests we would need to avoid these bugs that would be captured at compile time in Rust... :stuck_out_tongue_closed_eyes: Joking. Python dynamic typing is great :-D
