### PR TITLE
Allows single entries in `molecules` parameter

### DIFF
--- a/src/haddock/gear/prepare_run.py
+++ b/src/haddock/gear/prepare_run.py
@@ -418,7 +418,7 @@ def create_data_dir(run_dir):
 @with_config_error
 def copy_molecules_to_topology(molecules, topoaa_params):
     """Copy molecules to mandatory topology module."""
-    topoaa_params['molecules'] = list(map(Path, molecules))
+    topoaa_params['molecules'] = list(map(Path, transform_to_list(molecules)))
 
 
 def copy_molecules_to_data_dir(data_dir, topoaa_params):

--- a/tests/test_gear_prepare_run.py
+++ b/tests/test_gear_prepare_run.py
@@ -6,6 +6,7 @@ import pytest
 
 from haddock.gear.prepare_run import (
     check_if_path_exists,
+    copy_molecules_to_topology,
     fuzzy_match,
     get_expandable_parameters,
     populate_mol_parameters,
@@ -160,3 +161,18 @@ def test_check_if_path_exists():
 def test_fuzzy_match(user_input, expected):
     possibilities = ["long-format", "short-format", "verbose", "output-dir"]
     assert fuzzy_match(user_input, possibilities) == expected
+
+
+@pytest.mark.parametrize(
+    "molecules,expected",
+    [
+        ("mol1.pdb", 1),
+        (["mol1.pdb", "mol2.pdb"], 2),
+        ],
+    )
+def test_copy_mols_to_topo_dir(molecules, expected):
+    d = {}
+    copy_molecules_to_topology(molecules, d)
+    assert "molecules" in d
+    assert len(d["molecules"]) == expected
+    assert all(isinstance(m, Path) for m in d["molecules"])


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and you comply with the following criteria:

- [x] You have stick to Python. Talk with us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [x] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [x] You structured the code into small functions as much as possible. You can use classes if there's a (state) purpose
- [x] code follows our coding style
- [x] You wrote tests for the new code
- [x] `tox` tests pass. *Run `tox` command inside the repository folder*
- [x] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [x] PR does not add any *install dependencies* unless permission granted by the HADDOCK team
- [x] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---

Allows specifying single string when only one molecule is given as input. Hence, both cases are allowed:

```toml
molecules = ["mol1.pdb"]
```

or 

```toml
molecules = "mol1.pdb"
```
