### PR TITLE
Add user documentation on configuration files

### DIFF
--- a/docs/reference/gear/config_reader.rst
+++ b/docs/reference/gear/config_reader.rst
@@ -1,5 +1,5 @@
-Config Reader
-=============
+Workflow Configuration file reader
+==================================
 
 .. automodule:: haddock.gear.config_reader
    :members:

--- a/docs/reference/gear/config_writer.rst
+++ b/docs/reference/gear/config_writer.rst
@@ -1,5 +1,5 @@
-Config Writer
-=============
+Workflow configuration file writer
+==================================
 
 .. automodule:: haddock.gear.config_writer
    :members:

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -3,8 +3,7 @@ Tutorials
 
 Here we provide an index of the available HADDOCK3 tutorials. Some tutorials
 explain the different functionalities of the program and how to approach them.
-While, at the end, we explain how to apply HADDOCK3 in the different simulation
-scenarios.
+At the end, we explain how to apply HADDOCK3 in the different simulation scenarios.
 
 HADDOCK3 functionalities
 ------------------------

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -1,11 +1,25 @@
 Tutorials
 =========
 
-Below, a list of the HADDOCK3 tutorials:
+Here we provide an index of the available HADDOCK3 tutorials. Some tutorials
+explain the different functionalities of the program and how to approach them.
+While, at the end, we explain how to apply HADDOCK3 in the different simulation
+scenarios.
+
+HADDOCK3 functionalities
+------------------------
 
 .. toctree::
    :maxdepth: 1
 
+   user_config
    continuing_runs
-   benchmark
    mpi
+
+Tutorials for developers
+------------------------
+
+.. toctree::
+   :maxdepth: 1
+
+   benchmark

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -1,9 +1,9 @@
-Tutorials
+Examples
 =========
 
-Here we provide an index of the available HADDOCK3 tutorials. Some tutorials
-explain the different functionalities of the program and how to approach them.
-At the end, we explain how to apply HADDOCK3 in the different simulation scenarios.
+Here we provide an index of the available HADDOCK3 examples. Some examples
+illustrate the different functionalities of the program and how to approach them.
+At the end, we explain how to use HADDOCK3 in the various simulation scenarios.
 
 HADDOCK3 functionalities
 ------------------------

--- a/docs/tutorials/user_config.rst
+++ b/docs/tutorials/user_config.rst
@@ -48,15 +48,15 @@ parameters.
 
 .. note::
 
-    If you are a developer and wish to indagate further, the HADDOCK3
+    If you are a developer and wish to know more details, the HADDOCK3
     configuration files follow the TOML syntax. However they are not TOML files.
     HADDOCK3 implements its own parser with additional features not covered by
     TOML but needed for this project. See :ref:`Workflow Configuration
     file reader`.
 
 
-HADDOCK3 will use the default values for those parameters not specified by the
-user.
+Each module does have default parameters defined and HADDOCK3 will use those default values unless those are specificied and changed by the
+user in the configuration file.
 
 To obtain the list of all parameters for each module, you can use the
 ``haddock-cfg`` command-line. For example, to list all parameters from the

--- a/docs/tutorials/user_config.rst
+++ b/docs/tutorials/user_config.rst
@@ -51,7 +51,7 @@ parameters.
     If you are a developer and wish to indagate further, the HADDOCK3
     configuration files follow the TOML syntax. However they are not TOML files.
     HADDOCK3 implements its own parser with additional features not covered by
-    TOML but that were needed for this project. See :ref:`Workflow Configuration
+    TOML but needed for this project. See :ref:`Workflow Configuration
     file reader`.
 
 

--- a/docs/tutorials/user_config.rst
+++ b/docs/tutorials/user_config.rst
@@ -108,7 +108,7 @@ described inside a step will affect only that step. For example:
     
     [flexref]
     # flexref jobs are bound to generate one model per job
-    # therefore, we can specify the 'concat' parameter specific for flexref
+    # therefore, we can specify the 'concat' parameter specifically for flexref
     concat = 1
     ambig_fname = "data/mol1.tbl"
     

--- a/docs/tutorials/user_config.rst
+++ b/docs/tutorials/user_config.rst
@@ -55,9 +55,8 @@ parameters.
     file reader`.
 
 
-To configure each workflow step, you need to define only the parameters
-differing from the module's default values. Hence, HADDOCK3 will use the default
-values for those parameters not specified by the user.
+HADDOCK3 will use the default values for those parameters not specified by the
+user.
 
 To obtain the list of all parameters for each module, you can use the
 ``haddock-cfg`` command-line. For example, to list all parameters from the

--- a/docs/tutorials/user_config.rst
+++ b/docs/tutorials/user_config.rst
@@ -96,10 +96,6 @@ described inside a step will affect only that step. For example:
     mode = "hpc"
     concat = 5
 
-    # all steps will use at most 24 threads
-    # except if specified in the step's params - see 'flexref'
-    ncores = 24
-
     [topoaa]
     autohis = false
 
@@ -114,8 +110,6 @@ described inside a step will affect only that step. For example:
     # flexref jobs are bound to generate one model per job
     # therefore, we can specify the 'concat' parameter specific for flexref
     concat = 1
-    # here, we allow this step to use up to 48 threads
-    ncores = 48
     ambig_fname = "data/mol1.tbl"
     
     [caprieval]

--- a/docs/tutorials/user_config.rst
+++ b/docs/tutorials/user_config.rst
@@ -1,0 +1,132 @@
+Workflow configuration files
+============================
+
+Users can configure HADDOCK3 workflows through human-readable text files. The
+configuration file is divided into two sections. The first contains the general
+**mandatory** and **optional** parameters. The second section contains the
+configuration parameters for each **step** in the workflow. The workflow steps
+are defined by a title header with the module's name to execute followed by its
+parameters.
+
+.. code:: toml
+
+    # first section: general parameters =======
+    # mandatory parameters
+    run_dir = "run1-test"
+
+    molecules =  [
+        "data/mol1.pdb",
+        "data/mol2.pdb"
+        ]
+
+    # optional parameters
+    ncores = 40
+
+    # second section: step parameters =======
+    # each workflow step executes a HADDOCK3 module
+    # the step's header is the name of the module
+    # the step's paramereters are defined below its header
+    [topoaa]
+    autohis = false
+    [topoaa.mol1]
+    nhisd = 0
+    nhise = 1
+    hise_1 = 75
+    [topoaa.mol2]
+    nhisd = 1
+    hisd_1 = 76
+    nhise = 1
+    hise_1 = 15
+
+    [rigidbody]
+    tolerance = 20
+    ambig_fname = "data/mol1.tbl"
+    sampling = 20
+
+    [caprieval]
+    reference_fname = "data/mol1-mol2.pdb"
+
+.. note::
+
+    If you are a developer and wish to indagate further, the HADDOCK3
+    configuration files follow the TOML syntax. However they are not TOML files.
+    HADDOCK3 implements its own parser with additional features not covered by
+    TOML but that were needed for this project. See :ref:`Workflow Configuration
+    file reader`.
+
+
+To configure each workflow step, you need to define only the parameters
+differing from the module's default values. Hence, HADDOCK3 will use the default
+values for those parameters not specified by the user.
+
+To obtain the list of all parameters for each module, you can use the
+``haddock-cfg`` command-line. For example, to list all parameters from the
+*All-atom topology* module (``topoaa``):
+
+.. code:: bash
+
+    haddock-cfg -m topoaa
+
+    # or to write the output to a file
+    haddock-cfg -m topoaa > topoaa_defaults.cfg
+
+    # obtain help on `haddoc-cfg` CLI
+    haddock-cfg -h
+
+The HADDOCK3 workflow will follow the order of the steps defined in the
+configuration file, reading from top to bottom. For the example above, that
+would be: ``topoaa``, ``rigidbody``, ``caprieval``. Therefore, to edit/add/remove
+steps in a HADDOCK3 workflow, you simply need to add/remove/edit the text blocks
+referring to each module.
+
+Moreover, you can define the general **optional** parameters in the global scope of the
+workflow or specifically for each module. Optional parameters defined in the
+general scope of the configuration files affect all modules. While those
+described inside a step will affect only that step. For example:
+
+.. code:: toml
+
+    run_dir = "run1-test"
+
+    molecules =  [
+        "data/mol1.pdb",
+        "data/mol2.pdb"
+        ]
+
+    # all steps will use at most 40 CPU threads
+    ncores = 40
+
+    [topoaa]
+    autohis = false
+
+    [rigidbody]
+    # while rigidbody is blocked to use only 10 CPU threads
+    ncores = 10
+    ambig_fname = "data/mol1.tbl"
+    sampling = 20
+
+    [caprieval]
+    reference_fname = "data/mol1-mol2.pdb"
+
+Inside the `examples
+<https://github.com/haddocking/haddock3/tree/main/examples>`_ subfolders you will
+a panoply of examples of workflow configuration files (``.cfg``).
+
+Here is a list of all available :ref:`Modules`.
+
+Finally, if you are a developer and wish to use HADDOCK3 as a library to read
+and write configuration files please see the related Python modules:
+
+* :ref:`Workflow configuration file reader`
+* :ref:`Workflow configuration file writer`
+
+For example, to read a workflow configuration file:
+
+.. code:: python
+
+    from pathlib import Path
+
+    from haddock.gear.config_reader import read_config
+
+    config_path = Path("path", "to", "config.cfg")
+    config_dict = read_config(config_path)

--- a/docs/tutorials/user_config.rst
+++ b/docs/tutorials/user_config.rst
@@ -93,7 +93,12 @@ described inside a step will affect only that step. For example:
         ]
 
     # each .job will produce 5 (or less) models
+    mode = "hpc"
     concat = 5
+
+    # all steps will use at most 24 threads
+    # except if specified in the step's params - see 'flexref'
+    ncores = 24
 
     [topoaa]
     autohis = false
@@ -107,7 +112,10 @@ described inside a step will affect only that step. For example:
     
     [flexref]
     # flexref jobs are bound to generate one model per job
+    # therefore, we can specify the 'concat' parameter specific for flexref
     concat = 1
+    # here, we allow this step to use up to 48 threads
+    ncores = 48
     ambig_fname = "data/mol1.tbl"
     
     [caprieval]

--- a/docs/tutorials/user_config.rst
+++ b/docs/tutorials/user_config.rst
@@ -92,18 +92,24 @@ described inside a step will affect only that step. For example:
         "data/mol2.pdb"
         ]
 
-    # all steps will use at most 40 CPU threads
-    ncores = 40
+    # each .job will produce 5 (or less) models
+    concat = 5
 
     [topoaa]
     autohis = false
 
     [rigidbody]
-    # while rigidbody is blocked to use only 10 CPU threads
-    ncores = 10
     ambig_fname = "data/mol1.tbl"
     sampling = 20
 
+    [caprieval]
+    reference_fname = "data/mol1-mol2.pdb"
+    
+    [flexref]
+    # flexref jobs are bound to generate one model per job
+    concat = 1
+    ambig_fname = "data/mol1.tbl"
+    
     [caprieval]
     reference_fname = "data/mol1-mol2.pdb"
 

--- a/src/haddock/gear/config_reader.py
+++ b/src/haddock/gear/config_reader.py
@@ -1,12 +1,15 @@
 """
-In-house implementation of toml-like variation config files for HADDOCK3.
+Implementation of a TOML-like configuration file for HADDOCK3.
 
-(Likely) It does not implement all features of TOML files, but it does
-implement the toml features needed for HADDOCK3 and, especially, needed
-features for HADDOCK3. The config reader:
+HADDOCK3 user configuration files follow TOML syntax plus additional
+features required for HADDOCK3. Therefore, we have implemented our own
+TOML-like parser to accommodate the extra featured needed for HADDOCK3.
 
-* Accepts repeated keys.
-    * Blocks can have repeated names, for example:
+The most relevant features of HADDOCK3 user configuration files are:
+
+**Accepts repeated keys:** blocks can have repeated names, for example:
+
+.. code:: toml
 
         [topoaa]
         # parameters here...
@@ -23,18 +26,28 @@ features for HADDOCK3. The config reader:
         [caprieval]
         # parameters here...
 
-* Allows in-line comments:
-    `parameter = value # some comment`
+**Allows in-line comments:**
 
-* Allowed values:
-    * strings
-    * numbers
-    * null/none
-    * nan
-    * lists defined in one lines
-    * lists defined in multiple lines (require empty line after the list
-      definition)
-    * datetime.fromisoformat
+.. code:: toml
+
+    [module]
+    parameter = value # some comment
+
+**The following types are implemented**:
+
+* strings
+* numbers
+* null/none
+* ``nan``
+* lists defined in one lines
+* lists defined in multiple lines (require empty line after the list
+  definition)
+* `datetime.fromisoformat`
+
+**To efficiently use this module, see functions:**
+
+* :py:func:`haddock.gear.config_reader.read_config`
+* :py:func:`haddock.gear.config_reader.get_module_name`
 """
 import ast
 import re
@@ -275,9 +288,23 @@ class MultilineListDefinitionError(Exception):
 
 
 # main public API
-def read_config(f):
-    """Parse HADDOCK3 config file to a dictionary."""
-    with open(f, 'r') as fin:
+def read_config(fpath):
+    """
+    Read HADDOCK3 configure file to a dictionary.
+
+    Parameters
+    ----------
+    fpath : str or :external:py:class:`pathlib.Path`
+        Path to user configuration file.
+
+    Returns
+    -------
+    dictionary
+        Representing the user configuration file where first level of
+        keys are the module names. Repeated modules will have a numeric
+        suffix, for example: ``module.1``.
+    """
+    with open(fpath, 'r') as fin:
         return _read_config(fin)
 
 
@@ -290,6 +317,13 @@ def _read_config(fin):
     fin : a openned file content generator
         A generator expressing the content of a file in lines. Cannot be
         a list.
+
+    Returns
+    -------
+    dictionary
+        Representing the user configuration file where first level of
+        keys are the module names. Repeated modules will have a numeric
+        suffix, for example: ``module.1``.
     """
     # main dictionary to store the configuration
     d = {}

--- a/src/haddock/gear/config_reader.py
+++ b/src/haddock/gear/config_reader.py
@@ -3,7 +3,7 @@ Implementation of a TOML-like configuration file for HADDOCK3.
 
 HADDOCK3 user configuration files follow TOML syntax plus additional
 features required for HADDOCK3. Therefore, we have implemented our own
-TOML-like parser to accommodate the extra featured needed for HADDOCK3.
+TOML-like parser to accommodate the extra features needed for HADDOCK3.
 
 The most relevant features of HADDOCK3 user configuration files are:
 

--- a/src/haddock/gear/config_writer.py
+++ b/src/haddock/gear/config_writer.py
@@ -1,18 +1,16 @@
 """
 Convert HADDOCK3 config dictionaries to user configuration files.
 
-The functions implemented here have a general character.  For them to be
+The functions implemented here have a general character. For them to be
 functional within the HADDOCK3 scope you need to provide additional
-input arguments.  All the details are explained in the function's
+input arguments. All the details are explained in the function's
 docstrings (help).
 
 If you look for equal functions but already pre-prepared for HADDOCK3
-modules, see the functions with the same names under `haddock.modules`.
+modules, see the functions:
 
-FUNCTIONS:
-
-- convert_config
-- save_config
+* :py:func:`haddock.modules.convert_config`
+* :py:func:`haddock.modules.save_config`
 """
 import collections.abc
 import os
@@ -72,15 +70,14 @@ def convert_config(
         This function uses itself recursively. `_module_key` is for
         internal usage only.
 
-    See Also
-    --------
-    To use a HADDOCK3's modules specific version of this function, see the
-    `haddock.modules.convert_config` function.
-
     Yields
     ------
     str
         Line by line for the HADDOCK3 user configuration file.
+
+    See Also
+    --------
+    :py:func:`haddock.modules.convert_config`.
     """
     # can't do
     # ignore_params = set() or ignore_params
@@ -230,8 +227,7 @@ def save_config(params, path, module_name=None, **kwargs):
 
     See Also
     --------
-    To use a HADDOCK3's modules specific version of this function, see the
-    `haddock.modules.save_config` function.
+    :py:func:`haddock.modules.save_config`.
     """
     if module_name:
         if not isinstance(module_name, str):

--- a/src/haddock/modules/__init__.py
+++ b/src/haddock/modules/__init__.py
@@ -401,7 +401,9 @@ def save_config_ignored(*args, **kwargs):
     """
     Save HADDOCK3 configuration dictionary to user config file.
 
-    Ignores the :py:data:`haddock.modules.non_mandatory_general_parameters_defaults` parameters.
+    Ignores the
+    :py:data:`haddock.modules.non_mandatory_general_parameters_defaults`
+    parameters.
 
     Useful to keep clean versions of the modules' specific parameters.
 

--- a/src/haddock/modules/__init__.py
+++ b/src/haddock/modules/__init__.py
@@ -339,29 +339,38 @@ def get_engine(mode, params):
             )
 
 
-convert_config = partial(
-    _convert_config,
-    ignore_params=non_mandatory_general_parameters_defaults,
-    module_names=set(modules_category.keys()),
-    )
-convert_config.__doc__ = \
+def convert_config(params):
     """
-    Convert a module's parameters to a HADDOCK3 user config file text.
+    Convert a module's parameters dictionary to a HADDOCK3 user config text.
 
     This function is a generator.
 
     Examples
     --------
-    >>> gen = convert_config(parameters_dict)
+    >>> gen = convert_config(params)
     >>> text = os.linesep.join(gen)
     >>> with open("params.cfg", "w") as fout:
     >>>     fout.write(text)
+
+    Parameters
+    ----------
+    params : dictionary
+        The dictionary containing the parameters.
 
     Yields
     ------
     str
         Line by line for the HADDOCK3 user configuration file.
+
+    See Also
+    --------
+    :py:func:`haddock.gear.config_writer.convert_config`.
     """
+    return _convert_config(
+        params,
+        ignore_params=non_mandatory_general_parameters_defaults,
+        module_names=set(modules_category.keys()),
+        )
 
 
 def save_config(*args, **kwargs):
@@ -379,6 +388,10 @@ def save_config(*args, **kwargs):
 
     path : str or pathlib.Path
         File name where to save the configuration file.
+
+    See Also
+    --------
+    :py:func:`haddock.gear.config_writer.save_config`.
     """
     kwargs.setdefault("module_names", set(modules_category.keys()))
     return _save_config(*args, **kwargs)
@@ -388,7 +401,7 @@ def save_config_ignored(*args, **kwargs):
     """
     Save HADDOCK3 configuration dictionary to user config file.
 
-    Ignores the `non_mandatory_general_parameters_defaults` parameters.
+    Ignores the :py:data:`haddock.modules.non_mandatory_general_parameters_defaults` parameters.
 
     Useful to keep clean versions of the modules' specific parameters.
 
@@ -399,6 +412,11 @@ def save_config_ignored(*args, **kwargs):
 
     path : str or pathlib.Path
         File name where to save the configuration file.
+
+    See Also
+    --------
+    :py:func:`save_config`
+    :py:func:`haddock.gear.config_writer.save_config`.
     """
     kwargs.setdefault("module_names", set(modules_category.keys()))
     kwargs.setdefault(


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and you comply with the following criteria:

- [x] Your PR is about writing documentation for already existing code :fire:


---

* Adds user documentation on how to use, read, and write configuration files
* Improves related functions and modules docstrings
* Closes #372 

Generate the documentation locally. You will find the new documentation under `Tutorials` -> `Workflow configuration files`.

To review here on GitHub, the most relevant file is `docs/tutorials/user_config.rst`.