### PR TITLE
Populate `mol_` expandable parameters when using `--extend-run`

### DIFF
--- a/src/haddock/modules/__init__.py
+++ b/src/haddock/modules/__init__.py
@@ -11,7 +11,6 @@ from haddock.core.exceptions import ConfigurationError
 from haddock.gear.config_reader import read_config
 from haddock.gear.config_writer import convert_config as _convert_config
 from haddock.gear.config_writer import save_config as _save_config
-from haddock.gear.expandable_parameters import populate_mol_parameters_in_module
 from haddock.gear.parameters import config_mandatory_general_parameters
 from haddock.gear.yaml2cfg import read_from_yaml_config
 from haddock.libs.libhpc import HPCScheduler
@@ -203,14 +202,6 @@ class BaseHaddockModule(ABC):
         log.info(f'Running [{self.name}] module')
 
         self.update_params(**params)
-
-        if self._num_of_input_molecules:
-            populate_mol_parameters_in_module(
-                self._params,
-                self._num_of_input_molecules,
-                self._original_params,
-                )
-
         self.add_parent_to_paths()
 
         with working_directory(self.path):

--- a/src/haddock/modules/base_cns_module.py
+++ b/src/haddock/modules/base_cns_module.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from haddock import log
 from haddock import toppar_path as global_toppar
 from haddock.core.defaults import cns_exec as global_cns_exec
+from haddock.gear.expandable_parameters import populate_mol_parameters_in_module
 from haddock.libs.libio import working_directory
 from haddock.modules import BaseHaddockModule
 
@@ -38,6 +39,14 @@ class BaseCNSModule(BaseHaddockModule):
         log.info(f'Running [{self.name}] module')
 
         self.update_params(**params)
+
+        if self._num_of_input_molecules:
+            populate_mol_parameters_in_module(
+                self._params,
+                self._num_of_input_molecules,
+                self._original_params,
+                )
+
         self.add_parent_to_paths()
         self.envvars = self.default_envvars()
 

--- a/src/haddock/modules/base_cns_module.py
+++ b/src/haddock/modules/base_cns_module.py
@@ -40,6 +40,7 @@ class BaseCNSModule(BaseHaddockModule):
 
         self.update_params(**params)
 
+        # the `mol_*` parameters exist only for CNS jobs.
         if self._num_of_input_molecules:
             populate_mol_parameters_in_module(
                 self._params,

--- a/tests/test_gear_expandable_parameters.py
+++ b/tests/test_gear_expandable_parameters.py
@@ -12,9 +12,11 @@ from haddock.gear.expandable_parameters import (
     get_mol_parameters,
     get_multiple_index_groups,
     get_single_index_groups,
+    get_trail_index,
     is_mol_parameter,
     make_param_name_multiple_index,
     make_param_name_single_index,
+    populate_mol_parameters_in_module,
     read_mol_parameters,
     read_multiple_idx_groups_user_config,
     read_single_idx_groups_user_config,
@@ -664,3 +666,28 @@ def test_remove_trail_idx(param, expected):
     """Test remove trail index from parameter."""
     result = remove_trail_idx(param)
     assert result == expected
+
+
+@pytest.mark.parametrize(
+    "in_,expected",
+    [
+        ("some_parameter_1", "1"),
+        ("some_parameter_1_1", "1"),
+        ("some_parameter1", None),
+        ("some_parameter_1-1", None),
+        ("some_parameter", None),
+        ],
+    )
+def test_get_trail_index(in_, expected):
+    result = get_trail_index(in_)
+    assert result == expected
+
+
+def test_populate_mol_parameters():
+    d = {"mol_fix_1": 5, "mol_fix_2": 15}
+    populate_mol_parameters_in_module(d, 5, {"mol_fix_1": 10})
+    assert d["mol_fix_1"]== 5
+    assert d["mol_fix_2"]== 15
+    assert d["mol_fix_3"]== 10
+    assert d["mol_fix_4"]== 10
+    assert d["mol_fix_5"]== 10

--- a/tests/test_gear_expandable_parameters.py
+++ b/tests/test_gear_expandable_parameters.py
@@ -686,8 +686,8 @@ def test_get_trail_index(in_, expected):
 def test_populate_mol_parameters():
     d = {"mol_fix_1": 5, "mol_fix_2": 15}
     populate_mol_parameters_in_module(d, 5, {"mol_fix_1": 10})
-    assert d["mol_fix_1"]== 5
-    assert d["mol_fix_2"]== 15
-    assert d["mol_fix_3"]== 10
-    assert d["mol_fix_4"]== 10
-    assert d["mol_fix_5"]== 10
+    assert d["mol_fix_1"] == 5
+    assert d["mol_fix_2"] == 15
+    assert d["mol_fix_3"] == 10
+    assert d["mol_fix_4"] == 10
+    assert d["mol_fix_5"] == 10


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and you comply with the following criteria:

- [x] You have stick to Python. Talk with us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [x] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [x] You structured the code into small functions as much as possible. You can use classes if there's a (state) purpose
- [x] code follows our coding style
- [ ] You wrote tests for the new code
- [x] `tox` tests pass. *Run `tox` command inside the repository folder*
- [x] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [x] PR does not add any *install dependencies* unless permission granted by the HADDOCK team
- [x] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---

Closes #449 

The `mol_` parameters is a class of the expandable parameters that gets populated at the `prepare_run` level by reading the number of molecules from the `molecules` parameter in the config file. However, when using the `--extend-run` option, this step is not produced. This PR adds the logic to expand the parameters accordingly.
