### PR TITLE
Update `MANIFEST.in`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -18,6 +18,12 @@ prune examples
 prune src/fcc
 prune tests
 
+# exclude params*.rst documentation that is generated with
+# `tox -e docs`
+exclude docs/modules/*/params/*.rst
+exclude docs/reference/core/mandatory_parameters.rst
+exclude docs/modules/general_module_params.rst
+
 global-exclude *.py[cod] __pycache__/* *.so *.dylib 
 global-exclude tags
 global-exclude *.swp


### PR DESCRIPTION
Update `MANIFEST.in` file to exclude the `params*.rst` files generated during `tox -e docs`. In this way `tox -e build` does not give an error when testing locally.

@rvhonorato if tests pass, accept and merge. :+1: