### PR TITLE
amended clt_threshold behavior

### DIFF
--- a/src/haddock/modules/analysis/caprieval/capri.py
+++ b/src/haddock/modules/analysis/caprieval/capri.py
@@ -2,7 +2,6 @@
 import os
 import shutil
 import tempfile
-from math import sqrt
 from pathlib import Path
 
 import numpy as np
@@ -648,7 +647,7 @@ def rearrange_ss_capri_output(
         write_nested_dic_to_file(data, output_name)
 
 
-def calc_stats(data, n):
+def calc_stats(data):
     """
     Calculate the mean and stdev.
 
@@ -656,8 +655,6 @@ def calc_stats(data, n):
     ----------
     data : list
         List of values.
-    n : int
-        Number of values to be used for the calculation.
 
     Returns
     -------
@@ -666,9 +663,8 @@ def calc_stats(data, n):
     stdev : float
         Standard deviation of the values.
     """
-    mean = sum(data) / n
-    var = sum((x - mean) ** 2 for x in data) / n
-    stdev = sqrt(var)
+    mean = np.mean(data)
+    stdev = np.std(data)
     return mean, stdev
 
 
@@ -697,7 +693,7 @@ def capri_cluster_analysis(
         try:
             score_array = [
                 e[1].score for e in clt_data[element][:clt_threshold]]
-            score_mean, score_stdev = calc_stats(score_array, clt_threshold)
+            score_mean, score_stdev = calc_stats(score_array)
         except KeyError:
             score_mean = float("nan")
             score_stdev = float("nan")
@@ -705,14 +701,14 @@ def capri_cluster_analysis(
         try:
             irmsd_array = [
                 e[0].irmsd for e in clt_data[element][:clt_threshold]]
-            irmsd_mean, irmsd_stdev = calc_stats(irmsd_array, clt_threshold)
+            irmsd_mean, irmsd_stdev = calc_stats(irmsd_array)
         except KeyError:
             irmsd_mean = float("nan")
             irmsd_stdev = float("nan")
 
         try:
             fnat_array = [e[0].fnat for e in clt_data[element][:clt_threshold]]
-            fnat_mean, fnat_stdev = calc_stats(fnat_array, clt_threshold)
+            fnat_mean, fnat_stdev = calc_stats(fnat_array)
         except KeyError:
             fnat_mean = float("nan")
             fnat_stdev = float("nan")
@@ -720,7 +716,7 @@ def capri_cluster_analysis(
         try:
             lrmsd_array = [
                 e[0].lrmsd for e in clt_data[element][:clt_threshold]]
-            lrmsd_mean, lrmsd_stdev = calc_stats(lrmsd_array, clt_threshold)
+            lrmsd_mean, lrmsd_stdev = calc_stats(lrmsd_array)
         except KeyError:
             lrmsd_mean = float("nan")
             lrmsd_stdev = float("nan")
@@ -728,7 +724,7 @@ def capri_cluster_analysis(
         try:
             dockq_array = [
                 e[0].dockq for e in clt_data[element][:clt_threshold]]
-            dockq_mean, dockq_stdev = calc_stats(dockq_array, clt_threshold)
+            dockq_mean, dockq_stdev = calc_stats(dockq_array)
         except KeyError:
             dockq_mean = float("nan")
             dockq_stdev = float("nan")

--- a/tests/test_module_caprieval.py
+++ b/tests/test_module_caprieval.py
@@ -374,7 +374,7 @@ def test_rearrange_ss_capri_output():
 
 def test_calc_stats():
     """Test the calculation of statistics."""
-    observed_mean, observed_std = calc_stats([2, 2, 4, 5], 4)
+    observed_mean, observed_std = calc_stats([2, 2, 4, 5])
     assert round_two_dec(observed_mean) == 3.25
     assert round_two_dec(observed_std) == 1.3
 


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and you comply with the following criteria:

- [x] You have stick to Python. Talk with us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [ ] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [ ] You structured the code into small functions as much as possible. You can use classes if there's a (state) purpose
- [ ] code follows our coding style
- [ ] You wrote tests for the new code
- [ ] `tox` tests pass. *Run `tox` command inside the repository folder*
- [ ] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [ ] PR does not add any *install dependencies* unless permission granted by the HADDOCK team
- [ ] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---

Closes #386. @amjjbonvin Now the calculation of the cluster-based caprieval scores is correct even if the cluster is underpopulated.