### PR TITLE
remove duplicated entry in `clustfcc.txt`

### DIFF
--- a/src/haddock/modules/analysis/clustfcc/__init__.py
+++ b/src/haddock/modules/analysis/clustfcc/__init__.py
@@ -202,7 +202,6 @@ class HaddockModule(BaseHaddockModule):
             for cluster_rank, _e in enumerate(sorted_score_dic, start=1):
                 cluster_id, _ = _e
                 center_pdb = clt_centers[cluster_id]
-                clt_dic[cluster_id].append(center_pdb)
                 model_score_l = [(e.score, e) for e in clt_dic[cluster_id]]
                 model_score_l.sort()
                 subset_score_l = [e[0] for e in model_score_l][:threshold]


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and you comply with the following criteria:

- [X] You have stick to Python. Talk with us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [ ] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [ ] You structured the code into small functions as much as possible. You can use classes if there's a (state) purpose
- [X] code follows our coding style
- [ ] You wrote tests for the new code
- [ ] `tox` tests pass. *Run `tox` command inside the repository folder*
- [ ] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [X] PR does not add any *install dependencies* unless permission granted by the HADDOCK team
- [X] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---

Remove duplicated entry in `clustfcc.txt`

## wrong
```
-----------------------------------------------
Cluster 7 (#4, n=6, top4_avg_score = -14.53 +-1.51)

clt_rank	model_name	score
1	rigidbody_6.pdb	-16.44
2	rigidbody_33.pdb	-15.37
3	rigidbody_28.pdb	-13.90
4	rigidbody_80.pdb	-12.42	*
5	rigidbody_80.pdb	-12.42	*
6	rigidbody_50.pdb	-10.54
```
## fixed
```
-----------------------------------------------
Cluster 7 (#4, n=5, top4_avg_score = -14.53 +-1.51)

clt_rank	model_name	score
1	rigidbody_6.pdb	-16.44
2	rigidbody_33.pdb	-15.37
3	rigidbody_28.pdb	-13.90
4	rigidbody_80.pdb	-12.42	*
5	rigidbody_50.pdb	-10.54
```
