### PR TITLE
Corrects bug in `--restart` option

### DIFF
--- a/src/haddock/gear/prepare_run.py
+++ b/src/haddock/gear/prepare_run.py
@@ -243,7 +243,7 @@ def setup_run(
     elif restarting_from:
         # copies only the input molecules needed
         _keys = list(modules_params.keys())
-        _partial_params = {k: modules_params[k] for k in _keys}
+        _partial_params = {k: modules_params[k] for k in _keys[restart_from:]}
         copy_input_files_to_data_dir(
             data_dir,
             _partial_params,


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and you comply with the following criteria:

- [x] You have stick to Python. Talk with us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [x] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [x] You structured the code into small functions as much as possible. You can use classes if there's a (state) purpose
- [x] code follows our coding style
- [x] You wrote tests for the new code
- [x] `tox` tests pass. *Run `tox` command inside the repository folder*
- [x] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [x] PR does not add any *install dependencies* unless permission granted by the HADDOCK team
- [x] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---

The `--restart` option was considering the restart number when copying files to the `data` dir, which forced the creation of too many folders that had no meaning in the workflow, for example:

```
drwxrwxr-x  2 joao joao 4096 Jun  6 11:44 00_topoaa/
drwxrwxr-x  2 joao joao 4096 Jun  6 11:44 01_caprieval/
drwxrwxr-x  2 joao joao 4096 Jun  6 11:44 02_caprieval/
drwxrwxr-x  2 joao joao 4096 Jun  6 11:44 03_flexref/
drwxrwxr-x  2 joao joao 4096 Jun  6 11:44 04_caprieval/
drwxrwxr-x  2 joao joao 4096 Jun  6 11:44 05_emref/
drwxrwxr-x  2 joao joao 4096 Jun  6 11:44 06_caprieval/
drwxrwxr-x  2 joao joao 4096 Jun  6 11:44 07_caprieval/
drwxrwxr-x  2 joao joao 4096 Jun  6 11:44 08_caprieval/
drwxrwxr-x  2 joao joao 4096 Jun  6 13:45 12_caprieval/
drwxrwxr-x  2 joao joao 4096 Jun  6 13:45 15_caprieval/
drwxrwxr-x  2 joao joao 4096 Jun  6 13:45 16_flexref/
drwxrwxr-x  2 joao joao 4096 Jun  6 13:45 17_caprieval/
drwxrwxr-x  2 joao joao 4096 Jun  6 13:45 18_emref/
drwxrwxr-x  2 joao joao 4096 Jun  6 13:45 19_caprieval/
drwxrwxr-x  2 joao joao 4096 Jun  6 13:45 23_caprieval/
drwxrwxr-x  2 joao joao 4096 Jun  6 13:45 25_caprieval/
```

This behaviour is now corrected, and `--restart` works as expected.
