### PR TITLE
Support toml with repeated modules

### DIFF
--- a/src/haddock/gear/config_reader.py
+++ b/src/haddock/gear/config_reader.py
@@ -79,7 +79,7 @@ from haddock.libs.libfunc import false, give_same, nan, none, true
 
 # Captures the main headers.
 # https://regex101.com/r/9urqti/1
-_main_header_re = re.compile(r'^ *\[(\w+)\]', re.ASCII)
+_main_header_re = re.compile(r'^ *\[\'?(\w+)(?:\.\d+\')?\]', re.ASCII)
 
 # Captures sub-headers
 # https://regex101.com/r/6OpJJ8/1

--- a/tests/test_config_reader.py
+++ b/tests/test_config_reader.py
@@ -34,6 +34,7 @@ def on_linux():
     [
         ('[header]', 'header'),
         ('[under_scores_work]', 'under_scores_work'),
+        ("['header.3']", 'header')
         ],
     )
 def test_main_header_re(line, expected):
@@ -647,6 +648,24 @@ _config_example_dict_3 = {
         }
     }
 
+_config_example_4 = """
+[headerone]
+val = 10
+
+['headerone.2']
+val = 20
+
+['headerone.3']
+val = 30
+
+"""
+
+_config_example_dict_4 = {
+    "headerone": {'val': 10},
+    "headerone.1": {'val': 20},
+    "headerone.2": {'val': 30},
+    }
+
 
 @pytest.mark.parametrize(
     'config,expected',
@@ -654,6 +673,7 @@ _config_example_dict_3 = {
         (_config_example_1, _config_example_dict_1),
         (_config_example_2, _config_example_dict_2),
         (_config_example_3, _config_example_dict_3),
+        (_config_example_4, _config_example_dict_4),
         ],
     )
 def test_read_config(config, expected):


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and you comply with the following criteria:

- [x] You have stick to Python. Talk with us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [ ] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [x] You structured the code into small functions as much as possible. You can use classes if there's a (state) purpose
- [x] code follows our coding style
- [x] You wrote tests for the new code
- [x] `tox` tests pass. *Run `tox` command inside the repository folder*
- [ ] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [x] PR does not add any *install dependencies* unless permission granted by the HADDOCK team
- [x] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---

In https://github.com/i-VRESSE/workflow-builder I use a [toml library](https://www.npmjs.com/package/@ltd/j-toml) to write the config file. The toml library does not support repeats of the same header. To repeat headers I need to make them unique by appending an index and putting quotes around the module name. 

This PR adds support to haddock3 to parse config file like:

```toml
[headerone]
val = 10

['headerone.2']
val = 20

['headerone.3']
val = 30
```
to
```python
{
  "headerone": {'val': 10},
  "headerone.1": {'val': 20},
  "headerone.2": {'val': 30},
}
```

This config file can be written or loaded by any standard compliant toml library and should make it easier for haddock3 config files to be produced or consumed by other programs.
