### PR TITLE
Allows `topoaa` to run in different parts of the workflow

### DIFF
--- a/src/haddock/libs/libpdb.py
+++ b/src/haddock/libs/libpdb.py
@@ -47,7 +47,7 @@ def split_ensemble(pdb_file_path, dest=None):
         Destination folder.
     """
     dest = Path.cwd()
-    assert pdb_file_path.is_file()
+    assert pdb_file_path.is_file(), pdb_file_path
     with open(pdb_file_path) as input_handler:
         with working_directory(dest):
             split_model(input_handler)

--- a/src/haddock/libs/libstructure.py
+++ b/src/haddock/libs/libstructure.py
@@ -1,19 +1,40 @@
 """Molecular data structures."""
+from functools import partial
 from pathlib import Path
 
 
 class Molecule:
-    """Input molecule, usually a PDB file."""
+    """
+    Input molecule, usually a PDB file.
 
-    def __init__(self, file_name, segid=None):
+    Parameters
+    ----------
+    file_name : :external:py:class:`pathlib.Path`
+        The path to the molecule file.
+
+    segid : int, optional
+        The ID of the segment. Defaults to ``None``.
+
+    no_parent : boolean
+        Whether to add the parent path ``..`` to the
+        :py:attribute:`haddock.libs.libstructure.Molecule.with_parent`.
+        When set to true, the ``with_parent`` attribute returns the same
+        as ``file_name``.
+    """
+
+    def __init__(self, file_name, segid=None, no_parent=False):
         # the rest of the code is too dependent on the Path API
-        assert isinstance(file_name, Path), "`file_name` must be pathlib.Path"
+        assert isinstance(file_name, Path), \
+            f"`file_name` must be pathlib.Path: {type(file_name)} given"
 
         self.file_name = file_name
         self.segid = segid
-        self.with_parent = Path('..', file_name)
+        if no_parent:
+            self.with_parent = file_name
+        else:
+            self.with_parent = Path('..', file_name)
 
 
-def make_molecules(paths):
+def make_molecules(paths, **kwargs):
     """Get input molecules from the data stream."""
-    return list(map(Molecule, paths))
+    return list(map(partial(Molecule, **kwargs), paths))

--- a/src/haddock/modules/topology/topoaa/__init__.py
+++ b/src/haddock/modules/topology/topoaa/__init__.py
@@ -87,10 +87,7 @@ class HaddockModule(BaseCNSModule):
         with open(ensemble_f, 'r') as fh:
             for line in fh.readlines():
                 if line.startswith("REMARK") and "9" in line:
-                    try:
-                        model_num = int(line.split('MODEL')[-1].split()[0])
-                    except ValueError:
-                        continue
+                    model_num = int(line.split('MODEL')[-1].split()[0])
                     md5 = line.split()[-1]
                     md5_dic[model_num] = md5
         return md5_dic

--- a/src/haddock/modules/topology/topoaa/__init__.py
+++ b/src/haddock/modules/topology/topoaa/__init__.py
@@ -95,13 +95,18 @@ class HaddockModule(BaseCNSModule):
     def _run(self):
         """Execute module."""
         if self.order == 0:
+            # topoaa is the first step in the workflow
             molecules = make_molecules(self.params.pop('molecules'))
 
         else:
-            # in case topoaa is not the first step
-            # it takes the input molecules from the previous step and
-            # when topoaa is not the first step, we only need the first model
-            # because all models will have the same identity.
+            # in case topoaa is not the first step it reads the input
+            # molecules from the previous step but it only takes the
+            # first model because all models will have the same
+            # identity, as is the case for all PDBs created by rigidbody.
+            # In these cases, it is likely that each PDB contains the
+            # complex structure instead of the separated chains.
+            # Currently, we have not implemented a way to split chains
+            # and recreate the topology of the chains separately.
             _molecules = self.previous_io.retrieve_models()[0]
             molecules = make_molecules([_molecules.rel_path], no_parent=True)
 

--- a/src/haddock/modules/topology/topoaa/__init__.py
+++ b/src/haddock/modules/topology/topoaa/__init__.py
@@ -87,14 +87,26 @@ class HaddockModule(BaseCNSModule):
         with open(ensemble_f, 'r') as fh:
             for line in fh.readlines():
                 if line.startswith("REMARK") and "9" in line:
-                    model_num = int(line.split('MODEL')[-1].split()[0])
+                    try:
+                        model_num = int(line.split('MODEL')[-1].split()[0])
+                    except ValueError:
+                        continue
                     md5 = line.split()[-1]
                     md5_dic[model_num] = md5
         return md5_dic
 
     def _run(self):
         """Execute module."""
-        molecules = make_molecules(self.params.pop('molecules'))
+        if self.order == 0:
+            molecules = make_molecules(self.params.pop('molecules'))
+
+        else:
+            # in case topoaa is not the first step
+            # it takes the input molecules from the previous step and
+            # when topoaa is not the first step, we only need the first model
+            # because all models will have the same identity.
+            _molecules = self.previous_io.retrieve_models()[0]
+            molecules = make_molecules([_molecules.rel_path], no_parent=True)
 
         # extracts `input` key from params. The `input` keyword needs to
         # be treated separately


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and you comply with the following criteria:

- [x] You have stick to Python. Talk with us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [x] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [x] You structured the code into small functions as much as possible. You can use classes if there's a (state) purpose
- [x] code follows our coding style
- [x] You wrote tests for the new code
- [x] `tox` tests pass. *Run `tox` command inside the repository folder*
- [ ] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [x] PR does not add any *install dependencies* unless permission granted by the HADDOCK team
- [x] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---

* Allow `topoaa` to be used in any part of the workflow
* when `topoaa` is not the first step, it will take the input from the previous module
* in the above case, (likely) the input molecule will contain the multiple chains (molecules) in the form of a complex. In these cases, `topoaa` does **not** split the molecules and, instead, creates the topology for the complex as a whole.

It's difficult to predict all possible scenarios from here onward. Do you know any other? Otherwise, we can merge and continue developing as the project progresses.