### PR TITLE
Corrects check modules names in config on startup

### DIFF
--- a/src/haddock/gear/prepare_run.py
+++ b/src/haddock/gear/prepare_run.py
@@ -164,6 +164,8 @@ def setup_run(
         params,
         )
 
+    validate_module_names_are_not_misspelled(params)
+
     # separate general from modules' parameters
     _modules_keys = identify_modules(params)
     general_params = remove_dict_keys(params, _modules_keys)
@@ -177,7 +179,6 @@ def setup_run(
 
         general_params[RUNDIR] = extend_run
 
-    validate_module_names_are_not_misspelled(modules_params)
     check_if_modules_are_installed(modules_params)
     check_specific_validations(general_params)
 
@@ -549,7 +550,7 @@ def validate_module_names_are_not_misspelled(params):
                 matched = fuzzy_match([module_name], module_names)
                 emsg = (
                     f"Module {param_name!r} is not a valid module name,"
-                    f" did you mean {matched[0][1]}?. "
+                    f" did you mean {matched[0][1]!r}?. "
                     f"Valid modules are: {', '.join(module_names)}."
                     )
                 raise ValueError(emsg)


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and you comply with the following criteria:

- [x] You have stick to Python. Talk with us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [x] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [x] You structured the code into small functions as much as possible. You can use classes if there's a (state) purpose
- [x] code follows our coding style
- [ ] You wrote tests for the new code
- [x] `tox` tests pass. *Run `tox` command inside the repository folder*
- [ ] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [x] PR does not add any *install dependencies* unless permission granted by the HADDOCK team
- [x] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---

Corrects the moment when the module's names are checked in the configuration file.
