### PR TITLE
Update CI workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,9 @@
 # this action must be synchronized with version-bump-and-package.yml
-name: Package Build
+name: build
 
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
 
@@ -19,7 +21,7 @@ jobs:
         submodules: recursive
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2.2.2
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -28,5 +30,5 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         pip install virtualenv tox
 
-    - name: Test Build
+    - name: build
       run: tox -e build

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,21 +8,24 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash -l {0}
+    runs-on: ${{ matrix.platform }}
+    strategy:
+      matrix:
+        platform: [ubuntu-latest, macos-latest]
+        python-version: [3.9]
+
     steps:
     - uses: actions/checkout@v2
-    - uses: conda-incubator/setup-miniconda@v2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
       with:
-        activate-environment: test
-        python-version: 3.9
-        channels: conda-forge
+        python-version: ${{ matrix.python-version }}
 
     - name: Install dependencies
       run: |
-        conda install pip setuptools wheel tox
+        python -m pip install --upgrade pip setuptools wheel
+        pip install virtualenv tox
 
-    - name: Test with tox
+    - name: docs
       run: tox -e docs

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,14 +12,14 @@ jobs:
     runs-on: ${{ matrix.platform }}
     strategy:
       matrix:
-        platform: [ubuntu-latest]
+        platform: [ubuntu-latest, macos-latest]
         python-version: [3.9]
 
     steps:
     - uses: actions/checkout@v2
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2.2.2
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -28,5 +28,5 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         pip install virtualenv tox
 
-    - name: Test Lint
+    - name: lint
       run: tox -e lint

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: unittests py39
+name: tests
 
 on:
   push:
@@ -12,6 +12,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest]
+        python-version: [3.9]
 
     steps:
     - uses: actions/checkout@v2
@@ -19,14 +20,14 @@ jobs:
         submodules: recursive
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2.2.2
+      uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: ${{ matrix.python-version }}
 
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel
-        pip install coverage[toml] tox
+        pip install virtualenv tox
 
     - name: Install FCC
       run: |
@@ -39,10 +40,8 @@ jobs:
         ./Makefile 2>%1 >/dev/null || true
         cd -
 
-
-    - name: Test
-      if: always()
-      run: tox -e py39
+    - name: unit tests
+      run: tox -e test
 
     # from https://github.com/codecov/codecov-action
     - name: Upload coverage to Codecov

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,9 +38,9 @@ To contribute to the HADDOCK3's Python shell, follow these steps:
     (should) use our `tox` environments to test your code. Use the
     following commands from the main repository folder:
 
-    1.  `tox -e py39` runs tests in Python 3.9 environment. If you tox
+    1.  `tox -e test` runs tests in current python version. If you tox
     to report test names and status for every single test (high verbosity) use
-    `tox -e py39 -- -vv`.
+    `tox -e test -- -vv`.
     2.  `tox -e lint` shows you errors in the code style.
     3.  `tox -e build` simulates building the HADDOCK3 package.
     4.  Run the above altogether with the simple `tox` command
@@ -130,8 +130,8 @@ you create new `*.py` files you should create a new test file of the
 same name, `test_new_file_name.py`. Aim at 100% test coverage for the
 code you have created. Write tests according to [pytest][pytest]. You
 can see examples in our `test_*.py` files. You can run the tests using
-the `tox -e py39` commands explained above. Or, if you want to run the
-tests for a singly file use `tox -e py39 -- tests/test_myfile.py`.
+the `tox -e test` commands explained above. Or, if you want to run the
+tests for a singly file use `tox -e test -- tests/test_myfile.py`.
 
 ### 1.3 Dependencies
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
-Welcome to the HADDOCK3-Beta version
+Welcome to the HADDOCK3-Beta version.
 
 The `main` branch represents the latest state of HADDOCK v3. Currently,
 stable beta version.
+
+[![unit tests](https://github.com/haddocking/haddock3/workflows/tests/badge.svg?branch=main)](https://github.com/haddocking/haddock3/actions?workflow=tests)
+[![build](https://github.com/haddocking/haddock3/workflows/build/badge.svg?branch=main)](https://github.com/haddocking/haddock3/actions?workflow=build)
+[![docs](https://github.com/haddocking/haddock3/workflows/docs/badge.svg?branch=main)](https://github.com/haddocking/haddock3/actions?workflow=docs)
 
 * * *
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,19 +5,18 @@ ignore_basepython_conflict = true
 # execute `tox` in the command-line
 # bellow you will find explanations for all environments
 envlist =
-    py39
-    docs
     build
+    docs
     lint
+    test
 
 # configures which environments run with each python version
 [testenv]
 basepython =
-    {py39}: {env:TOXPYTHON:python3.9}
-    {build,lint,radon,safety,docs}: {env:TOXPYTHON:python3}
+    {build,test,lint,radon,safety,docs}: {env:TOXPYTHON:python3}
 passenv = *
 
-[testenv:py39]
+[testenv:test]
 setenv =
     PYTHONPATH={toxinidir}/tests
     PYTHONUNBUFFERED=yes
@@ -41,18 +40,10 @@ commands_pre =
 commands =
     pytest --cov --cov-report=term-missing --cov-append --cov-config=.coveragerc --hypothesis-show-statistics {posargs}
 # after executing the pytest assembles the coverage reports
-commands_post = 
+commands_post =
     coverage report
     coverage html
     coverage xml
-
-#[testenv:py39]
-#setenv = {[testenv:py38]setenv}
-#usedevelop = {[testenv:py38]usedevelop}
-#deps = {[testenv:py38]deps}
-#commands_pre = {[testenv:py38]commands_pre}
-#commands = {[testenv:py38]commands}
-#commands_post = {[testenv:py38]commands_post}
 
 [testenv:lint]
 skip_install = true
@@ -64,7 +55,6 @@ deps =
     pygments
     isort
 commands =
-    #flake8 {posargs:src/haddock tests setup.py docs}
     flake8 {posargs:src/haddock tests setup.py examples/run_tests.py examples/compare_runs.py}
     isort --verbose --check-only --diff {posargs:src/haddock tests setup.py examples/run_tests.py examples/compare_runs.py}
 
@@ -102,7 +92,6 @@ usedevelop = true
 deps =
     -r{toxinidir}/devtools/docs-requirements.txt
 commands =
-    #python {toxinidir}/devtools/build_defaults_rst.py
     sphinx-build {posargs:-E} -b html docs haddock3-docs
     #sphinx-build -b linkcheck docs haddock3-docs
 
@@ -111,7 +100,7 @@ commands =
 [testenv:radon]
 skip_install = true
 deps = radon
-commands = 
+commands =
     radon cc -s --total-average --no-assert {posargs:src/haddock}
     radon mi -m -s {posargs:src/haddock}
 
@@ -129,11 +118,11 @@ commands = safety check
 [flake8]
 max_line_length = 80
 hang-closing = true
-ignore = 
+ignore =
+    D105
+    D412
     W293
     W503
-    D412
-    D105
 per-file-ignores =
     setup.py:E501
     src/haddock/clis/cli_bm.py:E128
@@ -150,11 +139,12 @@ include_trailing_comma = true
 lines_after_imports = 2
 sections=FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 known_first_party = haddock
-known_third_party = 
-    gdock
-    lightdock
+known_third_party =
     fcc
-    jsonpickle
-    numpy
+    gdock
     hypothesis
+    jsonpickle
+    lightdock
+    numpy
     pytest
+    yaml


### PR DESCRIPTION
Update CI workflows according to https://github.com/joaomcteixeira/python-project-skeleton/releases/tag/v0.9.2

The major change, `tox -e py39` is now `tox -e test`, thus making the `tox` testing not require specifying the python version.

Added also badges to the README file.