### PR TITLE
Improves mandatory parameter check

### DIFF
--- a/src/haddock/gear/prepare_run.py
+++ b/src/haddock/gear/prepare_run.py
@@ -348,11 +348,11 @@ def validate_modules_params(modules_params, max_mols):
             max_mols,
             )
 
-        all_parameters = \
-            set.union(set(extract_keys_recursive(defaults)),
-                      set(config_mandatory_general_parameters),
-                      set(non_mandatory_general_parameters_defaults.keys()),
-                      expandable_params)
+        all_parameters = set.union(
+            set(extract_keys_recursive(defaults)),
+            set(non_mandatory_general_parameters_defaults.keys()),
+            expandable_params,
+            )
 
         diff = set(extract_keys_recursive(args)) - all_parameters
 

--- a/src/haddock/modules/topology/topoaa/defaults.yaml
+++ b/src/haddock/modules/topology/topoaa/defaults.yaml
@@ -154,3 +154,14 @@ mol1:
   long: You can expand this parameter and associated sub-parameters to the other input molecules. For example,
         if you input three molecules, you can define mol1, mol2, and mol3
         subparameters. Those not defined will be populated with the defaults.
+molecules:
+  default: False
+  type: boolean
+  title: Input molecules
+  short: Path to the input molecules.
+  long: This parameter is a general mandatory parameter but is masked here to
+    allow parameter validation while preparing the run. Therefore, the default
+    and type values of this parameter are meaningless.
+  explevel: hidden
+  group: molecules
+

--- a/tests/test_module_topoaa.py
+++ b/tests/test_module_topoaa.py
@@ -28,7 +28,11 @@ def test_variable_defaults_are_nan_in_mol1(param):
 
 def test_there_is_only_one_mol():
     """Test there is only one mol parameter in topoaa."""
-    r = set(p for p in DEFAULT_DICT if p.startswith("mol"))
+    r = set(
+        p
+        for p in DEFAULT_DICT
+        if p.startswith("mol") and p[3].isdigit()
+        )
     assert len(r) == 1
 
 


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and you comply with the following criteria:

- [x] You have stick to Python. Talk with us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [x] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [x] You structured the code into small functions as much as possible. You can use classes if there's a (state) purpose
- [x] code follows our coding style
- [x] You wrote tests for the new code
- [x] `tox` tests pass. *Run `tox` command inside the repository folder*
- [x] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [x] PR does not add any *install dependencies* unless permission granted by the HADDOCK team
- [x] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---

Improves checking step parameters. Before, the mandatory parameters were getting accepted in the steps definitions, and that is not correct.
Adds the `molecules` parameter to `topoaa` as `hidden` bypass to facilitate the checking.