### PR TITLE
added chain-matching AlignError

### DIFF
--- a/src/haddock/libs/libalign.py
+++ b/src/haddock/libs/libalign.py
@@ -228,9 +228,12 @@ def load_coords(pdb_f, atoms, filter_resdic=None, numbering_dic=None):
                     idx += 1
     chain_ranges = {}
     for chain in chain_dic:
-        min_idx = min(chain_dic[chain])
-        max_idx = max(chain_dic[chain])
-        chain_ranges[chain] = (min_idx, max_idx)
+        if chain_dic[chain] == []:
+            raise ALIGNError(f"Chain matching error on {pdb_f}, chain {chain}")
+        else:
+            min_idx = min(chain_dic[chain])
+            max_idx = max(chain_dic[chain])
+            chain_ranges[chain] = (min_idx, max_idx)
     return coord_dic, chain_ranges
 
 

--- a/src/haddock/libs/libalign.py
+++ b/src/haddock/libs/libalign.py
@@ -228,7 +228,9 @@ def load_coords(pdb_f, atoms, filter_resdic=None, numbering_dic=None):
                     idx += 1
     chain_ranges = {}
     for chain in chain_dic:
-        if chain_dic[chain] == []:
+        if not chain_dic[chain]:
+            # this may happen when filter_resdic is defined on a different set
+            # of chains
             raise ALIGNError(f"Chain matching error on {pdb_f}, chain {chain}")
         else:
             min_idx = min(chain_dic[chain])

--- a/tests/test_libalign.py
+++ b/tests/test_libalign.py
@@ -5,6 +5,8 @@ from pathlib import Path
 
 import numpy as np
 
+import pytest
+
 from haddock.libs.libalign import (
     align_seq,
     calc_rmsd,
@@ -180,6 +182,18 @@ def test_load_coords():
     expected_chain_ranges = {"B": (0, 19)}
 
     assert observed_chain_ranges == expected_chain_ranges
+
+
+def test_error_load_coords():
+    """
+    Test the chain-matching error on loading the coordinates
+    with an uncompatible resdic.
+    """
+    filter_resdic = {'A': [1, 2, 3, 4, 5]} # protein has only chain B
+    pdb_f = Path(golden_data, "protein.pdb")
+    atoms = get_atoms(pdb_f)
+    with pytest.raises(Exception):
+        load_coords(pdb_f, atoms, filter_resdic)
 
 
 def test_get_atoms():

--- a/tests/test_libalign.py
+++ b/tests/test_libalign.py
@@ -4,7 +4,6 @@ import tempfile
 from pathlib import Path
 
 import numpy as np
-
 import pytest
 
 from haddock.libs.libalign import (
@@ -185,11 +184,8 @@ def test_load_coords():
 
 
 def test_error_load_coords():
-    """
-    Test the chain-matching error on loading the coordinates
-    with an uncompatible resdic.
-    """
-    filter_resdic = {'A': [1, 2, 3, 4, 5]} # protein has only chain B
+    """Test the chain-matching error with an uncompatible resdic."""
+    filter_resdic = {'A': [1, 2, 3, 4, 5]}  # protein has only chain B
     pdb_f = Path(golden_data, "protein.pdb")
     atoms = get_atoms(pdb_f)
     with pytest.raises(Exception):


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and you comply with the following criteria:

- [x] You have stick to Python. Talk with us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [ ] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [ ] You structured the code into small functions as much as possible. You can use classes if there's a (state) purpose
- [ ] code follows our coding style
- [ ] You wrote tests for the new code
- [x] `tox` tests pass. *Run `tox` command inside the repository folder*
- [x] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [x] PR does not add any *install dependencies* unless permission granted by the HADDOCK team
- [x] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---

Closes #472 by adding a call to an AlignError. It does not stop caprieval, but rather the `capri_ss.tsv` file is still produced for all those models that do not show an evident (empty chain) chain-matching error.