### PR TITLE
Improve two titles in documentation

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,4 +1,4 @@
-# Examples
+# Workflow Examples
 
 The HADDOCK3 `examples/` directory contains various subdirectories and config files
 corresponding to different types of complexes, scenarios and data.

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -1,5 +1,5 @@
-Examples
-=========
+Advanced features
+=================
 
 Here we provide an index of the available HADDOCK3 examples. Some examples
 illustrate the different functionalities of the program and how to approach them.

--- a/docs/tutorials/index.rst
+++ b/docs/tutorials/index.rst
@@ -1,7 +1,7 @@
 Advanced features
 =================
 
-Here we provide an index of the available HADDOCK3 examples. Some examples
+Here we provide an index of the available HADDOCK3 advanced features. Some examples
 illustrate the different functionalities of the program and how to approach them.
 At the end, we explain how to use HADDOCK3 in the various simulation scenarios.
 


### PR DESCRIPTION
There were two "Examples" titles in the docs. This corrects it.
