### PR TITLE
Added `exit` module

### DIFF
--- a/docs/modules/extras/exit.rst
+++ b/docs/modules/extras/exit.rst
@@ -1,0 +1,12 @@
+Exit module
+===========
+
+.. automodule:: haddock.modules.extras.exit
+   :members:
+   :show-inheritance:
+   :inherited-members:
+
+Default parameters
+------------------
+
+.. include:: params/exit.rst

--- a/docs/modules/extras/index.rst
+++ b/docs/modules/extras/index.rst
@@ -1,0 +1,7 @@
+Extra modules
+=============
+
+.. toctree::
+   :maxdepth: 1
+
+   exit

--- a/docs/modules/index.rst
+++ b/docs/modules/index.rst
@@ -13,6 +13,7 @@ composed in *steps*, and each step is a HADDOCK3 module. There are modules for
    refinement/index
    scoring/index
    analysis/index
+   extras/index
 
 Parent code for modules
 -----------------------

--- a/examples/compare_runs.py
+++ b/examples/compare_runs.py
@@ -75,6 +75,7 @@ examples = (
     ("docking-protein-protein"     , "docking-protein-protein-test.cfg"),  # noqa: E203, E501
     ("docking-protein-protein"     , "docking-protein-protein-cltsel-test.cfg"),  # noqa: E203, E501
     ("docking-protein-protein"     , "docking-protein-protein-mdref-test.cfg"),  # noqa: E203, E501
+    ("docking-protein-protein"     , "docking-exit-test.cfg"),  # noqa: E203, E501
     ("refine-complex"              , "refine-complex-test.cfg"),  # noqa: E203, E501
     ("scoring"                     , "emscoring-test.cfg"),  # noqa: E203, E501
     ("scoring"                     , "mdscoring-test.cfg"),  # noqa: E203, E501

--- a/examples/docking-protein-protein/docking-exit-test.cfg
+++ b/examples/docking-protein-protein/docking-exit-test.cfg
@@ -1,0 +1,69 @@
+# ====================================================================
+# Protein-protein docking example with NMR-derived ambiguous interaction restraints
+
+# directory in which the scoring will be done
+run_dir = "run1-exit"
+ncores = 40
+mode = "local"
+clean = True
+# CNS executable path - optional
+# cns_exec = "path/to/bin/cns"
+
+# molecules to be docked
+molecules =  [
+    "data/e2aP_1F3G.pdb",
+    "data/hpr_ensemble.pdb"
+    ]
+
+# ====================================================================
+# Parameters for each stage are defined below, prefer full paths
+# ====================================================================
+[topoaa]
+#tolerance = 20
+autohis = false
+[topoaa.mol1]
+nhisd = 0
+nhise = 1
+hise_1 = 75
+[topoaa.mol2]
+nhisd = 1
+hisd_1 = 76
+nhise = 1
+hise_1 = 15
+
+[rigidbody]
+tolerance = 20
+ambig_fname = "data/e2a-hpr_air.tbl"
+sampling = 20
+
+[exit]
+
+[caprieval]
+#tolerance = 20
+reference_fname = "data/e2a-hpr_1GGR.pdb"
+
+[seletop]
+#tolerance = 20
+select = 5
+
+[flexref]
+tolerance = 20
+ambig_fname = "data/e2a-hpr_air.tbl"
+
+[caprieval]
+#tolerance = 20
+reference_fname = "data/e2a-hpr_1GGR.pdb"
+
+[emref]
+tolerance = 20
+ambig_fname = "data/e2a-hpr_air.tbl"
+
+[caprieval]
+#tolerance = 20
+reference_fname = "data/e2a-hpr_1GGR.pdb"
+
+[clustfcc]
+#tolerance = 20
+
+# ====================================================================
+

--- a/examples/docking-protein-protein/docking-extend-run-exit-test.cfg
+++ b/examples/docking-protein-protein/docking-extend-run-exit-test.cfg
@@ -1,6 +1,6 @@
 # how to reproduce manually
 # haddock3-copy -r run1-test -m 0 4 -o run2
-# haddock3 docking-protein-protein-test-start-from-cp.cfg --extend-run run2
+# haddock3 docking-extend-run-exit-test.cfg --extend-run run2
 # ====================================================================
 clean = true
 

--- a/examples/docking-protein-protein/docking-extend-run-exit-test.cfg
+++ b/examples/docking-protein-protein/docking-extend-run-exit-test.cfg
@@ -1,0 +1,44 @@
+# how to reproduce manually
+# haddock3-copy -r run1-test -m 0 4 -o run2
+# haddock3 docking-protein-protein-test-start-from-cp.cfg --extend-run run2
+# ====================================================================
+clean = true
+
+[caprieval]
+reference_fname = "data/e2a-hpr_1GGR.pdb"
+
+[emref]
+tolerance = 20
+ambig_fname = "data/e2a-hpr_air.tbl"
+
+[exit]
+
+[caprieval]
+reference_fname = "data/e2a-hpr_1GGR.pdb"
+
+[clustfcc]
+
+[caprieval]
+reference_fname = "data/e2a-hpr_1GGR.pdb"
+
+[emref]
+tolerance = 20
+ambig_fname = "data/e2a-hpr_air.tbl"
+
+[caprieval]
+reference_fname = "data/e2a-hpr_1GGR.pdb"
+
+[clustfcc]
+
+[caprieval]
+reference_fname = "data/e2a-hpr_1GGR.pdb"
+
+[emref]
+tolerance = 20
+ambig_fname = "data/e2a-hpr_air.tbl"
+
+[caprieval]
+reference_fname = "data/e2a-hpr_1GGR.pdb"
+
+[clustfcc]
+

--- a/examples/docking-protein-protein/docking-restart-exit-test.cfg
+++ b/examples/docking-protein-protein/docking-restart-exit-test.cfg
@@ -1,0 +1,57 @@
+# how to reproduce manually
+# haddock3 docking-protein-protein-test.cfg
+# cp -r run1-test run1-restart-exit
+# haddock3 docking-restart-exit-test.cfg --restart 3
+# ====================================================================
+run_dir = "run1-restart-exit"
+ncores = 40
+mode = "local"
+
+# molecules to be docked
+molecules =  [
+    "data/e2aP_1F3G.pdb",
+    "data/hpr_ensemble.pdb"
+    ]
+
+[topoaa]
+#tolerance = 20
+autohis = false
+[topoaa.mol1]
+nhisd = 0
+nhise = 1
+hise_1 = 75
+[topoaa.mol2]
+nhisd = 1
+hisd_1 = 76
+nhise = 1
+hise_1 = 15
+
+[rigidbody]
+tolerance = 20
+ambig_fname = "data/e2a-hpr_air.tbl"
+sampling = 20
+
+[caprieval]
+reference_fname = "data/e2a-hpr_1GGR.pdb"
+
+[seletop]
+select = 5
+
+[exit]
+
+[flexref]
+tolerance = 20
+ambig_fname = "data/e2a-hpr_air.tbl"
+
+[caprieval]
+reference_fname = "data/e2a-hpr_1GGR.pdb"
+
+[emref]
+tolerance = 20
+ambig_fname = "data/e2a-hpr_air.tbl"
+
+[caprieval]
+reference_fname = "data/e2a-hpr_1GGR.pdb"
+
+[clustfcc]
+

--- a/examples/run_tests.py
+++ b/examples/run_tests.py
@@ -61,6 +61,7 @@ examples = (
     ("docking-protein-protein"     , "docking-protein-protein-test.cfg"),  # noqa: E203, E501
     ("docking-protein-protein"     , "docking-protein-protein-cltsel-test.cfg"),  # noqa: E203, E501
     ("docking-protein-protein"     , "docking-protein-protein-mdref-test.cfg"),  # noqa: E203, E501
+    ("docking-protein-protein"     , "docking-exit-test.cfg"),  # noqa: E203, E501
     ("refine-complex"              , "refine-complex-test.cfg"),  # noqa: E203, E501
     ("scoring"                     , "emscoring-test.cfg"),  # noqa: E203, E501
     ("scoring"                     , "mdscoring-test.cfg"),  # noqa: E203, E501
@@ -125,7 +126,7 @@ def main(examples, break_on_errors=True):
                     stderr=sys.stderr,
                     )
 
-            # perform a restart step from 0
+                # perform a restart step from 0
                 subprocess.run(
                     f"haddock3 {file_} --restart 0",
                     shell=True,
@@ -134,6 +135,7 @@ def main(examples, break_on_errors=True):
                     stderr=sys.stderr,
                     )
 
+                # test --extend-run
                 rmtree("run2", ignore_errors=True)
                 subprocess.run(
                     "haddock3-copy -r run1-test -m 0 4 -o run2",
@@ -145,6 +147,41 @@ def main(examples, break_on_errors=True):
 
                 subprocess.run(
                     "haddock3 docking-protein-protein-test-start-from-cp.cfg --extend-run run2",  # noqa: E501
+                    shell=True,
+                    check=break_on_errors,
+                    stdout=sys.stdout,
+                    stderr=sys.stderr,
+                    )
+
+                # test exit with extend-run
+                rmtree("run2", ignore_errors=True)
+                subprocess.run(
+                    "haddock3-copy -r run1-test -m 0 4 -o run2",
+                    shell=True,
+                    check=break_on_errors,
+                    stdout=sys.stdout,
+                    stderr=sys.stderr,
+                    )
+
+                subprocess.run(
+                    "haddock3 docking-extend-run-exit-test.cfg --extend-run run2",  # noqa: E501
+                    shell=True,
+                    check=break_on_errors,
+                    stdout=sys.stdout,
+                    stderr=sys.stderr,
+                    )
+
+                # test exit with --restart
+                subprocess.run(
+                    "cp -r run1-test run1-restart-exit",
+                    shell=True,
+                    check=break_on_errors,
+                    stdout=sys.stdout,
+                    stderr=sys.stderr,
+                    )
+
+                subprocess.run(
+                    "haddock3 docking-restart-exit-test.cfg --restart",
                     shell=True,
                     check=break_on_errors,
                     stdout=sys.stdout,

--- a/src/haddock/core/exceptions.py
+++ b/src/haddock/core/exceptions.py
@@ -47,3 +47,9 @@ class SetupError(HaddockError):
     """Set up error."""
 
     pass
+
+
+class HaddockTermination(HaddockError):
+    """Terminates HADDOCK."""
+
+    pass

--- a/src/haddock/libs/libworkflow.py
+++ b/src/haddock/libs/libworkflow.py
@@ -21,9 +21,12 @@ class WorkflowManager:
     """Read and execute workflows."""
 
     def __init__(self, workflow_params, start=0, **other_params):
-        self.start = start
+        self.start = 0 if start is None else start
         self.recipe = Workflow(workflow_params, start=0, **other_params)
-        self._terminated = None
+        # terminate is used to synchronize the `clean` option with the
+        # `exit` module. If the `exit` module is removed in the future,
+        # you can also remove and clean the `terminate` part here.
+        self._terminated = 0
 
     def run(self):
         """High level workflow composer."""
@@ -33,12 +36,21 @@ class WorkflowManager:
             try:
                 step.execute()
             except HaddockTermination:
-                self._terminated = i + 1
+                self._terminated = i
                 break
 
-    def clean(self):
-        """Clean steps."""
-        for step in self.recipe.steps[:self._terminated]:
+    def clean(self, terminated=None):
+        """
+        Clean steps.
+
+        Parameters
+        ----------
+        terminated : int, None
+            At which index of the workflow to stop the cleaning. If ``None``,
+            uses the internal class configuration.
+        """
+        terminated = self._terminated if terminated is None else terminated
+        for step in self.recipe.steps[:terminated]:
             step.clean()
 
 

--- a/src/haddock/modules/__init__.py
+++ b/src/haddock/modules/__init__.py
@@ -42,6 +42,7 @@ category_hierarchy = [
     "refinement",
     "scoring",
     "analysis",
+    "extras",
     ]
 
 # this dictionary defines non-mandatory general parameters that can be defined

--- a/src/haddock/modules/extras/exit/__init__.py
+++ b/src/haddock/modules/extras/exit/__init__.py
@@ -1,0 +1,53 @@
+"""
+Exit module.
+
+Stop the workflow when this module is reached.
+
+Examples
+--------
+
+```
+[topoaa]
+(...)
+
+[rigidbody]
+(...)
+
+[exit]  # <- workflow will stop here
+
+[flexref]
+(...)
+"""
+from pathlib import Path
+
+from haddock.core.exceptions import HaddockTermination
+from haddock.modules import BaseHaddockModule
+
+
+RECIPE_PATH = Path(__file__).resolve().parent
+DEFAULT_CONFIG = Path(RECIPE_PATH, "defaults.yaml")
+
+
+class HaddockModule(BaseHaddockModule):
+    """Stop the workflow when this module is reached."""
+
+    name = RECIPE_PATH.name
+
+    def __init__(
+            self,
+            order,
+            path,
+            *ignore,
+            init_params=DEFAULT_CONFIG,
+            **everything,
+            ):
+        super().__init__(order, path, init_params)
+
+    @classmethod
+    def confirm_installation(cls):
+        """Confirm if contact executable is compiled."""
+        return
+
+    def _run(self):
+        error = HaddockTermination(self.params["message"])
+        raise error

--- a/src/haddock/modules/extras/exit/__init__.py
+++ b/src/haddock/modules/extras/exit/__init__.py
@@ -6,18 +6,25 @@ Stop the workflow when this module is reached.
 Examples
 --------
 
-```
-[topoaa]
-(...)
+Consider the following config file example::
 
-[rigidbody]
-(...)
+    [topoaa]
+    (...)
 
-[exit]  # <- workflow will stop here
+    [rigidbody]
+    (...)
 
-[flexref]
-(...)
+    [exit]  # <- workflow will stop here
+
+    [flexref]
+    (...)
+
+The workflow will stop at ``[exit]`` and ``[flexref]`` will not be performed.
+
+You can also use this option combined with ``--restart`` and ``--extend-run``.
+See examples in ``examples/docking-protein-protein/*-exit-test.cfg`` files.
 """
+import shutil
 from pathlib import Path
 
 from haddock.core.exceptions import HaddockTermination
@@ -49,5 +56,8 @@ class HaddockModule(BaseHaddockModule):
         return
 
     def _run(self):
-        error = HaddockTermination(self.params["message"])
+        # removes the `exit` step folder
+        self.log(self.params["message"])
+        shutil.rmtree(Path.cwd())
+        error = HaddockTermination()
         raise error

--- a/src/haddock/modules/extras/exit/defaults.yaml
+++ b/src/haddock/modules/extras/exit/defaults.yaml
@@ -1,0 +1,10 @@
+message:
+  default: Stopping the workflow.
+  type: string
+  minchars: 0
+  maxchars: 1000
+  title: Exiting message.
+  short: The message to print when exiting.
+  long: The exit module stops the workflow.
+  group:
+  explevel: easy

--- a/src/haddock/modules/extras/exit/defaults.yaml
+++ b/src/haddock/modules/extras/exit/defaults.yaml
@@ -5,6 +5,6 @@ message:
   maxchars: 1000
   title: Exiting message.
   short: The message to print when exiting.
-  long: The exit module stops the workflow.
+  long: The message to print when exiting.
   group:
   explevel: easy


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and you comply with the following criteria:

- [x] You have stick to Python. Talk with us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [x] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [x] You structured the code into small functions as much as possible. You can use classes if there's a (state) purpose
- [x] code follows our coding style
- [x] You wrote tests for the new code
- [x] `tox` tests pass. *Run `tox` command inside the repository folder*
- [x] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [x] PR does not add any *install dependencies* unless permission granted by the HADDOCK team
- [x] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---

* Added an `[exit]` module.
* Adding this module to the workflow will stop the workflow at that step
* I decided to make a module following the same hierarchy as for other modules. I found that cleaner than implementing an `if` process in a `gear` because doing so would require rewriting some tests.
* works with `--restart` and `--extend-run`
