### PR TITLE
Improve running `topoaa` as an intermediate step in the workflow

### DIFF
--- a/src/haddock/modules/topology/topoaa/__init__.py
+++ b/src/haddock/modules/topology/topoaa/__init__.py
@@ -119,7 +119,7 @@ class HaddockModule(BaseCNSModule):
             # in case topoaa is not the first step, the topology is rebuilt for
             # each retrieved model
             _molecules = self.previous_io.retrieve_models()
-            molecules_paths = [el.rel_path for el in _molecules]
+            molecules_paths = [mol.rel_path for mol in _molecules]
             molecules = make_molecules(molecules_paths, no_parent=True)
 
         # extracts `input` key from params. The `input` keyword needs to


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and you comply with the following criteria:

- [x] You have stick to Python. Talk with us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [x] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [ ] You structured the code into small functions as much as possible. You can use classes if there's a (state) purpose
- [x] code follows our coding style
- [ ] You wrote tests for the new code
- [x] `tox` tests pass. *Run `tox` command inside the repository folder*
- [x] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [x] PR does not add any *install dependencies* unless permission granted by the HADDOCK team
- [x] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---

Closes #497. Now the topology is built for each one of the retrieved models.

As for testing: specific tests of this addition are not present in the project yet, because we don't want to the users to place `topoaa` modules randomly in the workflow. With the PR #482, a meaningful example of `topoaa` in the middle of a workflow is added.

Anyway, I tested the execution of two workflows: one is `topoaa-rigidbody-topoaa-caprieval`, and the other is `topoaa-rigidbody-caprieval`. Caprieval tables are identical, meaning the addition of `topoaa` didn't alter the output structures.