### PR TITLE
Correct function selection in `topoaa` when `order=0` and `limit` is used (or not)

### DIFF
--- a/src/haddock/modules/topology/topoaa/__init__.py
+++ b/src/haddock/modules/topology/topoaa/__init__.py
@@ -132,9 +132,12 @@ class HaddockModule(BaseCNSModule):
         # to facilite the for loop down the line, we create a list with the keys
         # of `mol_params` with inverted order (we will use .pop)
         mol_params_keys = list(mol_params.keys())[::-1]
-        if self.order == 0:
-            if self.params['limit']:
-                mol_params_get = mol_params_keys.pop
+
+        # limit is only useful when order == 0
+        if self.order == 0 and self.params['limit']:
+            mol_params_get = mol_params_keys.pop
+
+        # `else` is used in any case where limit is False.
         else:
             mol_params_get = partial(operator.getitem, mol_params_keys, -1)
 


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and you comply with the following criteria:

- [x] You have stick to Python. Talk with us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [x] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [x] You structured the code into small functions as much as possible. You can use classes if there's a (state) purpose
- [x] code follows our coding style
- [ ] You wrote tests for the new code
- [x] `tox` tests pass. *Run `tox` command inside the repository folder*
- [ ] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [x] PR does not add any *install dependencies* unless permission granted by the HADDOCK team
- [x] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---

* https://github.com/haddocking/haddock3/pull/261 introduced the `limit` parameter, for which `topoaa` started handling the models differently depending on the value of `limit`
* Recently, a lapse in https://github.com/haddocking/haddock3/pull/498 introduced a bug in which if `order=0` and `not limit`, the `mol_params_get` function is not defined.
* This PR solves this bug by correcting the `if-block` defining the `mol_params_get` function.
