### PR TITLE
Add missing parameter in `run_tests.py` after #494

### DIFF
--- a/examples/run_tests.py
+++ b/examples/run_tests.py
@@ -181,7 +181,7 @@ def main(examples, break_on_errors=True):
                     )
 
                 subprocess.run(
-                    "haddock3 docking-restart-exit-test.cfg --restart",
+                    "haddock3 docking-restart-exit-test.cfg --restart 3",
                     shell=True,
                     check=break_on_errors,
                     stdout=sys.stdout,


### PR DESCRIPTION
* added `--restart 3` to integration tests in `run_tests.py`. This was missing from #494 