### PR TITLE
Add documentation paragraph to `rigidbody` module description

### DIFF
--- a/docs/modules/sampling/rigidbody.rst
+++ b/docs/modules/sampling/rigidbody.rst
@@ -1,6 +1,3 @@
-Rigidbody sampling module
-=========================
-
 .. automodule:: haddock.modules.sampling.rigidbody
    :members:
    :show-inheritance:

--- a/src/haddock/modules/sampling/rigidbody/__init__.py
+++ b/src/haddock/modules/sampling/rigidbody/__init__.py
@@ -10,8 +10,8 @@ In this module, the interacting partners are treated as rigid bodies, meaning
 that all geometrical parameters such as bond lengths, bond angles, and dihedral
 angles are frozen. The partners are first separated in space and randomly rotated
 around their respective centres of mass. Afterwards, the molecules are brought 
-together by rigid-body energy minimisation with as only degrees of freedome rotations
-and translation. 
+together by rigid-body energy minimisation with rotations and translation
+as the only degrees of freedom
 
 The driving force for this energy minimisation is the energy function which 
 consists of the intermolecular van der Waals and electrostatic energy terms and the

--- a/src/haddock/modules/sampling/rigidbody/__init__.py
+++ b/src/haddock/modules/sampling/rigidbody/__init__.py
@@ -1,4 +1,27 @@
-"""Rigid-body docking module."""
+"""
+Rigid-body docking sampling module
+==================================
+
+This module does a **randomization of orientations and rigid-body
+minimization.** It corresponds to the classical ``it0`` step in the HADDOCK2.x
+series.
+
+In this module, the interacting partners are treated as rigid bodies, meaning
+that all geometrical parameters such as bond lengths, bond angles, and dihedral
+angles are frozen. Next, the partners are separated in space and rotated
+randomly about their centres of mass.
+
+Afterwards, partners are brought together and allowed to rotate and translate to
+optimize their interaction through a rigid-body energy minimization step.
+
+The energy function also considers ambiguous interaction restraints (AIRs) if
+input. Hence, AIRs are particularly important here as the resulting complexes
+will be biased towards them. For example, defining a stringent set of AIRs leads
+to a very narrow sampling of the conformational space, meaning that the
+generated poses will be very similar. Conversely, very sparse restraints (e.g.
+the entire surface of a partner) will result in very different solutions,
+displaying greater variability in the region of binding.
+"""
 from pathlib import Path
 
 from haddock.gear.haddockmodel import HaddockModel

--- a/src/haddock/modules/sampling/rigidbody/__init__.py
+++ b/src/haddock/modules/sampling/rigidbody/__init__.py
@@ -8,19 +8,22 @@ series.
 
 In this module, the interacting partners are treated as rigid bodies, meaning
 that all geometrical parameters such as bond lengths, bond angles, and dihedral
-angles are frozen. Next, the partners are separated in space and rotated
-randomly about their centres of mass.
+angles are frozen. The partners are first separated in space and randomly rotated
+around their respective centres of mass. Afterwards, the molecules are brought 
+together by rigid-body energy minimisation with as only degrees of freedome rotations and translation. 
 
-Afterwards, partners are brought together and allowed to rotate and translate to
-optimize their interaction through a rigid-body energy minimization step.
+The driving force for this energy minimisation is the energy function which 
+consists of the intermolecular van der Waals and electrostatic energy terms and the
+restraints defined to guide the docking. The restraints are distance-based and can consist
+of unambiguous or ambiguous interactions restraints (AIRS). In ab-initio docking mode those restraints
+can be automatically defined in various ways (e.g. between center of masses (CM restraints) or between
+randomly selected patches on the surface (random AIRs).
 
-The energy function also considers ambiguous interaction restraints (AIRs) if
-input. Hence, AIRs are particularly important here as the resulting complexes
-will be biased towards them. For example, defining a stringent set of AIRs leads
-to a very narrow sampling of the conformational space, meaning that the
-generated poses will be very similar. Conversely, very sparse restraints (e.g.
-the entire surface of a partner) will result in very different solutions,
-displaying greater variability in the region of binding.
+The definition of those restraints is particularly important as they effectively guide the minimisation 
+process. For example, with a stringent set of AIRs or unambiguous distance restraints, the solutions of the
+minimisation will converge much better and the sampling can be limited. In ab-initio mode, however, very diverse 
+solutions will be obtained and the sampling should be increased to make sure to sample enough the possible 
+interaction space
 """
 from pathlib import Path
 

--- a/src/haddock/modules/sampling/rigidbody/__init__.py
+++ b/src/haddock/modules/sampling/rigidbody/__init__.py
@@ -8,23 +8,25 @@ series.
 
 In this module, the interacting partners are treated as rigid bodies, meaning
 that all geometrical parameters such as bond lengths, bond angles, and dihedral
-angles are frozen. The partners are first separated in space and randomly rotated
-around their respective centres of mass. Afterwards, the molecules are brought 
-together by rigid-body energy minimisation with rotations and translation
-as the only degrees of freedom
+angles are frozen. The partners are first separated in space and randomly
+rotated around their respective centres of mass. Afterwards, the molecules are
+brought together by rigid-body energy minimisation with rotations and
+translation as the only degrees of freedom.
 
-The driving force for this energy minimisation is the energy function, which 
-consists of the intermolecular van der Waals and electrostatic energy terms and the
-restraints defined to guide the docking. The restraints are distance-based and can consist
-of unambiguous or ambiguous interactions restraints (AIRS). In ab-initio docking mode those 
-restraints can be automatically defined in various ways (e.g. between center of masses 
-(CM restraints) or between randomly selected patches on the surface (random AIRs).
+The driving force for this energy minimisation is the energy function, which
+consists of the intermolecular van der Waals and electrostatic energy terms and
+the restraints defined to guide the docking. The restraints are distance-based
+and can consist of unambiguous or ambiguous interactions restraints (AIRS). In
+*ab-initio* docking mode those restraints can be automatically defined in
+various ways; e.g. between center of masses (CM restraints) or between randomly
+selected patches on the surface (random AIRs).
 
-The definition of those restraints is particularly important as they effectively guide 
-the minimisation process. For example, with a stringent set of AIRs or unambiguous distance restraints, 
-the solutions of the minimisation will converge much better and the sampling can be limited. 
-In ab-initio mode, however, very diverse solutions will be obtained and the sampling should be 
-increased to make sure to sample enough the possible interaction space.
+The definition of those restraints is particularly important as they effectively
+guide the minimisation process. For example, with a stringent set of AIRs or
+unambiguous distance restraints, the solutions of the minimisation will converge
+much better and the sampling can be limited. In *ab-initio* mode, however, very
+diverse solutions will be obtained and the sampling should be increased to make
+sure to sample enough the possible interaction space.
 """
 from pathlib import Path
 

--- a/src/haddock/modules/sampling/rigidbody/__init__.py
+++ b/src/haddock/modules/sampling/rigidbody/__init__.py
@@ -13,7 +13,7 @@ around their respective centres of mass. Afterwards, the molecules are brought
 together by rigid-body energy minimisation with rotations and translation
 as the only degrees of freedom
 
-The driving force for this energy minimisation is the energy function which 
+The driving force for this energy minimisation is the energy function, which 
 consists of the intermolecular van der Waals and electrostatic energy terms and the
 restraints defined to guide the docking. The restraints are distance-based and can consist
 of unambiguous or ambiguous interactions restraints (AIRS). In ab-initio docking mode those 

--- a/src/haddock/modules/sampling/rigidbody/__init__.py
+++ b/src/haddock/modules/sampling/rigidbody/__init__.py
@@ -10,20 +10,21 @@ In this module, the interacting partners are treated as rigid bodies, meaning
 that all geometrical parameters such as bond lengths, bond angles, and dihedral
 angles are frozen. The partners are first separated in space and randomly rotated
 around their respective centres of mass. Afterwards, the molecules are brought 
-together by rigid-body energy minimisation with as only degrees of freedome rotations and translation. 
+together by rigid-body energy minimisation with as only degrees of freedome rotations
+and translation. 
 
 The driving force for this energy minimisation is the energy function which 
 consists of the intermolecular van der Waals and electrostatic energy terms and the
 restraints defined to guide the docking. The restraints are distance-based and can consist
-of unambiguous or ambiguous interactions restraints (AIRS). In ab-initio docking mode those restraints
-can be automatically defined in various ways (e.g. between center of masses (CM restraints) or between
-randomly selected patches on the surface (random AIRs).
+of unambiguous or ambiguous interactions restraints (AIRS). In ab-initio docking mode those 
+restraintscan be automatically defined in various ways (e.g. between center of masses 
+(CM restraints) or between randomly selected patches on the surface (random AIRs).
 
-The definition of those restraints is particularly important as they effectively guide the minimisation 
-process. For example, with a stringent set of AIRs or unambiguous distance restraints, the solutions of the
-minimisation will converge much better and the sampling can be limited. In ab-initio mode, however, very diverse 
-solutions will be obtained and the sampling should be increased to make sure to sample enough the possible 
-interaction space
+The definition of those restraints is particularly important as they effectively guide 
+the minimisation process. For example, with a stringent set of AIRs or unambiguous distance restraints, 
+the solutions of the minimisation will converge much better and the sampling can be limited. 
+In ab-initio mode, however, very diverse solutions will be obtained and the sampling should be 
+increased to make sure to sample enough the possible interaction space
 """
 from pathlib import Path
 

--- a/src/haddock/modules/sampling/rigidbody/__init__.py
+++ b/src/haddock/modules/sampling/rigidbody/__init__.py
@@ -17,7 +17,7 @@ The driving force for this energy minimisation is the energy function, which
 consists of the intermolecular van der Waals and electrostatic energy terms and the
 restraints defined to guide the docking. The restraints are distance-based and can consist
 of unambiguous or ambiguous interactions restraints (AIRS). In ab-initio docking mode those 
-restraintscan be automatically defined in various ways (e.g. between center of masses 
+restraints can be automatically defined in various ways (e.g. between center of masses 
 (CM restraints) or between randomly selected patches on the surface (random AIRs).
 
 The definition of those restraints is particularly important as they effectively guide 

--- a/src/haddock/modules/sampling/rigidbody/__init__.py
+++ b/src/haddock/modules/sampling/rigidbody/__init__.py
@@ -24,7 +24,7 @@ The definition of those restraints is particularly important as they effectively
 the minimisation process. For example, with a stringent set of AIRs or unambiguous distance restraints, 
 the solutions of the minimisation will converge much better and the sampling can be limited. 
 In ab-initio mode, however, very diverse solutions will be obtained and the sampling should be 
-increased to make sure to sample enough the possible interaction space
+increased to make sure to sample enough the possible interaction space.
 """
 from pathlib import Path
 

--- a/tox.ini
+++ b/tox.ini
@@ -130,6 +130,7 @@ per-file-ignores =
     src/haddock/clis/cli_dmn.py:T201
     tests/*.py:D103
     tests/test_gear_preprocessing.py:E501,D103,W291
+    src/haddock/modules/*/*/__init__.py:D205,D400
 docstring-convention = numpy
 
 


### PR DESCRIPTION

- [x] Your PR is about writing documentation for already existing code :fire:

---

I took the brief explanation of the `it0` step in the `local` tutorial for HADDOCK2.x and modified it slightly to fit as a short explanation for the `rigidbody` module.

Also, updated title in doc pages and added exceptions to doc linting in the pertinent files.

If you generate the docs `tox -e docs`, you'lll see this text renders in the HTML of the rigidbody page.

Feel welcome to edit further.

Cheers,
