### PR TITLE
add missing init file

### DIFF
--- a/docs/modules/extras/exit.rst
+++ b/docs/modules/extras/exit.rst
@@ -1,6 +1,3 @@
-Exit module
-===========
-
 .. automodule:: haddock.modules.extras.exit
    :members:
    :show-inheritance:

--- a/docs/modules/extras/index.rst
+++ b/docs/modules/extras/index.rst
@@ -1,6 +1,11 @@
 Extra modules
 =============
 
+.. automodule:: haddock.modules.extras
+
+List of available extra modules
+-------------------------------
+
 .. toctree::
    :maxdepth: 1
 

--- a/src/haddock/modules/extras/__init__.py
+++ b/src/haddock/modules/extras/__init__.py
@@ -1,0 +1,6 @@
+"""
+HADDOCK3 extra modules.
+
+The extra modules are modules that do not belong to any of the standard
+simulation categories but that help further configuring the workflow.
+"""

--- a/src/haddock/modules/extras/exit/__init__.py
+++ b/src/haddock/modules/extras/exit/__init__.py
@@ -1,7 +1,10 @@
 """
-Exit module.
+Exit module
+===========
 
-Stop the workflow when this module is reached.
+Stop the workflow when this module is reached. This allows users to execute
+only a certain initial part of the workflow without having to comment/uncomment
+the unwanted lines.
 
 Examples
 --------


### PR DESCRIPTION
* add the `__init__.py` file was missing in the extras from #494 
* add further documentation to the `exit` module