### PR TITLE
Correct typo in documentation

### DIFF
--- a/docs/modules/analysis/seletop.rst
+++ b/docs/modules/analysis/seletop.rst
@@ -1,5 +1,5 @@
-Select Top Modules module
-=========================
+Select Top Models module
+========================
 
 .. automodule:: haddock.modules.analysis.seletop
    :members:


### PR DESCRIPTION
Correct typo in module name in docs.