### PR TITLE
Removes `--verbosity` in `isort` lint check

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -57,7 +57,7 @@ deps =
     isort
 commands =
     flake8 {posargs:src/haddock tests setup.py examples/run_tests.py examples/compare_runs.py}
-    isort --verbose --check-only --diff {posargs:src/haddock tests setup.py examples/run_tests.py examples/compare_runs.py}
+    isort --quiet --check-only --diff {posargs:src/haddock tests setup.py examples/run_tests.py examples/compare_runs.py}
 
 # asserts package build integrity
 [testenv:build]


### PR DESCRIPTION
`isort` now only outputs errors.