### PR TITLE
Update the `--restart` option to cope with subfolders in steps.

### DIFF
--- a/src/haddock/gear/prepare_run.py
+++ b/src/haddock/gear/prepare_run.py
@@ -870,14 +870,17 @@ def update_step_contents_to_step_names(prev_names, new_names, folder):
     """
     Update step folder names in files after the `--restart` option.
 
+    Runs over the folders defined in `new_names`.
+
     Parameters
     ----------
     prev_names : list
         List of step names to find in file contents.
 
     new_names : list
-        List of new step names to place `prev_names`. Both lists need
-        to be synchronized.
+        List of new step names to replace `prev_names`. Both lists need
+        to be synchronized. That is, the first index of `prev_names` should
+        correspond to the old names of `new_names`.
 
     folder : str or Path
         Folder where the step folders are. Usually run directory or

--- a/src/haddock/gear/prepare_run.py
+++ b/src/haddock/gear/prepare_run.py
@@ -868,7 +868,7 @@ def fuzzy_match(user_input, possibilities):
 
 def update_step_contents_to_step_names(prev_names, new_names, folder):
     """
-    Find-replace run directory and step name in step folders.
+    Update step folder names in files after the `--restart` option.
 
     Parameters
     ----------
@@ -891,7 +891,34 @@ def update_step_contents_to_step_names(prev_names, new_names, folder):
     for new_step in new_names:
         new_step_p = Path(folder, new_step)
         for file_ in new_step_p.iterdir():
-            text = file_.read_text()
-            for s1, s2 in zip(prev_names, new_names):
-                text = text.replace(s1, s2)
-            file_.write_text(text)
+
+            # goes recursive into the next folder
+            if file_.is_dir():
+                update_step_names_in_subfolders(file_, prev_names, new_names)
+
+            else:
+                update_step_names_in_file(file_, prev_names, new_names)
+
+
+def update_step_names_in_subfolders(folder, prev_names, new_names):
+    """
+    Update step names in subfolders.
+
+    Some modules may generate subfolders. This function update
+    its files accordingly to the `--restart` feature.
+    """
+    for file_ in folder.iterdir():
+        if file_.is_dir():
+            update_step_names_in_subfolders(file_, prev_names, new_names)
+        else:
+            update_step_names_in_file(file_, prev_names, new_names)
+    return
+
+
+def update_step_names_in_file(file_, prev_names, new_names):
+    """Update step names in file following the `--restart` option."""
+    text = file_.read_text()
+    for s1, s2 in zip(prev_names, new_names):
+        text = text.replace(s1, s2)
+    file_.write_text(text)
+    return

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -22,5 +22,7 @@ haddock3_yaml_converted_no_header = \
     Path(configs_data, 'yaml2cfg_converted_no_header.cfg')
 clean_steps_folder = Path(tests_path, 'clean_output_data')
 
+steptmp = Path(data_folder, "0_dummystep")
+
 # defines which modules are already working
 working_modules = [t for t in modules_category.items() if t[0] != 'topocg']

--- a/tests/data/0_dummystep/file1.in
+++ b/tests/data/0_dummystep/file1.in
@@ -1,0 +1,1 @@
+0_dummystep

--- a/tests/data/0_dummystep/folder/file2.in
+++ b/tests/data/0_dummystep/folder/file2.in
@@ -1,0 +1,1 @@
+0_dummystep


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and you comply with the following criteria:

- [x] You have stick to Python. Talk with us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [x] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [x] You structured the code into small functions as much as possible. You can use classes if there's a (state) purpose
- [x] code follows our coding style
- [x] You wrote tests for the new code
- [x] `tox` tests pass. *Run `tox` command inside the repository folder*
- [x] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [x] PR does not add any *install dependencies* unless permission granted by the HADDOCK team
- [x] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---

* Update the `--restart` option to cope with subfolders in steps.
* Thanks to @mgiulini for spotting this need for the new coming modules with subfolders.
