### PR TITLE
Uses action to deploy pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -46,5 +46,5 @@ jobs:
         env:
           REPO: self
           BRANCH: gh-pages
-          FOLDER: docs
+          FOLDER: haddock3-docs
           GITHUB_TOKEN: ${{ secrets.PAGES }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -20,19 +20,10 @@ jobs:
         with:
           python-version: '3.9'
 
-      - name: Setup Git
-        run: |
-          git config user.name "amjjbonvin"
-          git config user.email 'amjjbonvin@users.noreply.github.com'
-          git remote set-url origin \https://x-access-token:${{ secrets.PAGES }}@github.com/$GITHUB_REPOSITORY
-          git checkout "${GITHUB_REF:11}"
-          git branch --show-current
-
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip setuptools wheel
           pip install virtualenv tox
-
 
       # needs to install hd3 so the command-line pages are
       # rendered properly
@@ -50,14 +41,10 @@ jobs:
       - name: Generate docs
         run: tox -e docs
 
-      - name: Commit updated pages to gh-pages branch
-        run: |
-          git checkout gh-pages
-          git branch --show-current
-          cp -r haddock3-docs/* .
-          rm -r haddock3-docs
-          rm -r src 2>/dev/null || true
-          git add -A
-          git commit -m "update pages"
-          git push origin gh-pages
-          git branch --show-current
+      - name: deploy
+        uses: s0/git-publish-subdir-action@develop
+        env:
+          REPO: self
+          BRANCH: gh-pages
+          FOLDER: docs
+          GITHUB_TOKEN: ${{ secrets.PAGES }}


### PR DESCRIPTION
Finally, found this to deploy the pages in a clean way: https://github.com/s0/git-publish-subdir-action#when-pushed-to-master-push-publicsite-to-the-gh-pages-branch-on-the-same-repo

Once @amjjbonvin updates the token, it should work. :crossed_fingers: 