### PR TITLE
changed retrieve_models logic

### DIFF
--- a/src/haddock/libs/libontology.py
+++ b/src/haddock/libs/libontology.py
@@ -155,7 +155,7 @@ class ModuleIO:
                 raise Exception(_msg)
 
             # prepare pairwise combinations
-            model_list = [values for values in zip(*input_dic.values())]
+            model_list = [pdb[0] for pdb in input_dic.values()]
         elif input_dic and crossdock and not individualize:
             model_list = [
                 values for values in itertools.product(*input_dic.values())


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and you comply with the following criteria:

- [x] You have stick to Python. Talk with us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [ ] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [ ] You structured the code into small functions as much as possible. You can use classes if there's a (state) purpose
- [x] code follows our coding style
- [ ] You wrote tests for the new code
- [x] `tox` tests pass. *Run `tox` command inside the repository folder*
- [x] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [x] PR does not add any *install dependencies* unless permission granted by the HADDOCK team
- [x] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---

Closes #542. Tests and examples run as usual, but I don't know the reason why the method was developed like that in the first place, please tell me if I missed a point.

PS: a build test failed for no apparent reason. I don't think it's critical.