### PR TITLE
Revert "changed retrieve_models logic"

### DIFF
--- a/src/haddock/libs/libontology.py
+++ b/src/haddock/libs/libontology.py
@@ -155,7 +155,7 @@ class ModuleIO:
                 raise Exception(_msg)
 
             # prepare pairwise combinations
-            model_list = [pdb[0] for pdb in input_dic.values()]
+            model_list = [values for values in zip(*input_dic.values())]
         elif input_dic and crossdock and not individualize:
             model_list = [
                 values for values in itertools.product(*input_dic.values())


### PR DESCRIPTION
Reverts haddocking/haddock3#543

As discussed with @amjjbonvin and @rvhonorato it is better not to change this and stick to the original haddock2.4 logic, namely each input pdb must correspond to a single chain (except for scoring modules). In this way a complex can be refined by providing its chains separately.

#482 must take this into account when rebuilding the topologies of the models generated by openmm. 