### PR TITLE
removed absolute paths in topoaa

### DIFF
--- a/src/haddock/libs/libpdb.py
+++ b/src/haddock/libs/libpdb.py
@@ -226,9 +226,9 @@ def get_new_models(pdb_file_path):
     return new_models
 
 
-def get_pdb_file_suffix_variations(file_name, path=None, sep="_"):
+def get_pdb_file_suffix_variations(file_name, sep="_"):
     """
-    List suffix variations of a PDB file.
+    List suffix variations of a PDB file in the current path.
 
     If `file.pdb` is given, and files `file_1.pdb`, `file_2.pdb`, exist
     in the folder, those will be listed.
@@ -237,9 +237,6 @@ def get_pdb_file_suffix_variations(file_name, path=None, sep="_"):
     ----------
     file_name : str or Path
         The name of the file with extension.
-
-    path : str or pathlib.Path
-        Path pointing to a directory where to perform the search.
 
     sep : str
         The separation between the file base name and the suffix.
@@ -252,8 +249,7 @@ def get_pdb_file_suffix_variations(file_name, path=None, sep="_"):
         If no files are found return an empty list.
     """
     basename = Path(file_name)
-    path = path or Path.cwd()
-    return list(path.glob(f"{basename.stem}{sep}*{basename.suffix}"))
+    return list(Path(".").glob(f"{basename.stem}{sep}*{basename.suffix}"))
 
 
 def read_RECORD_section(lines, section_slice, func=set):


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and you comply with the following criteria:

- [x] You have stick to Python. Talk with us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [x] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [ ] You structured the code into small functions as much as possible. You can use classes if there's a (state) purpose
- [x] code follows our coding style
- [ ] You wrote tests for the new code
- [x] `tox` tests pass. *Run `tox` command inside the repository folder*
- [x] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [x] PR does not add any *install dependencies* unless permission granted by the HADDOCK team
- [x] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---

Closes #561 by reading the list of pdb files here https://github.com/haddocking/haddock3/blob/aa68fd3abf3ebe9e3c7c34812639761c7be9d69c/src/haddock/libs/libpdb.py#L256 always from the current directory, thus eliminating the path dependence and the potentially problematic usage of absolute paths.