### PR TITLE
Fault tolerant caprieval

### DIFF
--- a/src/haddock/modules/analysis/caprieval/capri.py
+++ b/src/haddock/modules/analysis/caprieval/capri.py
@@ -648,14 +648,14 @@ def rearrange_ss_capri_output(
     data = {}
     for ident in range(1, output_count + 1):
         out_file = Path(path, f"{keyword}_{ident}.tsv")
-        data[ident] = {}
-
-        # add this dummy data so we can rank it later
-        #  without messing up the order of the output
+        
+        # raise a warning if file does not exist.
         if not out_file.exists():
-            data[ident]['score'] = 99999.9
+            log.warning((f"Output file {out_file} does not exist. "
+                        "Caprieval will not be exhaustive..."))
             continue
 
+        data[ident] = {}
         header, content = out_file.read_text().split(os.linesep, 1)
 
         header_data = header.split('\t')
@@ -675,30 +675,27 @@ def rearrange_ss_capri_output(
         out_file.unlink()
 
     # Rank according to the score
-    score_rankkey_values = [(i, data[k]['score']) for i, k in enumerate(data)]
+    score_rankkey_values = [(k, data[k]['score']) for k in data.keys()]
     score_rankkey_values.sort(key=lambda x: x[1])
 
     for i, k in enumerate(score_rankkey_values):
-        idx, _ = k
-        data[idx + 1]["caprieval_rank"] = i + 1
-
-        if data[idx + 1]['score'] == 99999.9:
-            del data[idx + 1]
+        data_idx, _ = k
+        data[data_idx]["caprieval_rank"] = i + 1
 
     # Sort according to the sort key
-    rankkey_values = [(i, data[k][sort_key]) for i, k in enumerate(data)]
+    rankkey_values = [(k, data[k][sort_key]) for k in data.keys()]
     rankkey_values.sort(
         key=lambda x: x[1],
         reverse=True if not sort_ascending else False
         )
 
     _data = {}
-    for i, (k, _) in enumerate(rankkey_values):
-        _data[i + 1] = data[k + 1]
+    for i, (data_idx, _) in enumerate(rankkey_values):
+        _data[i + 1] = data[data_idx]
     data = _data
 
     if not data:
-        # This means there were only "dummy" values
+        # This means no files have been collected
         return
     else:
         write_nested_dic_to_file(data, output_name)


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and you comply with the following criteria:

- [x] You have stick to Python. Talk with us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [x] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [ ] You structured the code into small functions as much as possible. You can use classes if there's a (state) purpose
- [x] code follows our coding style
- [ ] You wrote tests for the new code
- [x] `tox` tests pass. *Run `tox` command inside the repository folder*
- [x] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [x] PR does not add any *install dependencies* unless permission granted by the HADDOCK team
- [x] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---

Close #573 by changing the logic with which data is handled in `capri.rearrange_ss_output`. More specifically, when one of the expected capri files is not found in the folder, the workflow raises a warning.
https://github.com/haddocking/haddock3/blob/412e07dc8e41ab9ca6ee1cb09121344a55d054fe/src/haddock/modules/analysis/caprieval/capri.py#L654-L656
The files that have been correctly processed are then written to file.

NB: when the cluster analysis is performed, some models may have cluster information, but if the related capri job failed their capri quantities (fnat, dockq, ...) will be nan. Therefore, in case of failed capri jobs, a capri_clt.tsv file would look like the following

```
cluster_rank    cluster_id      n       under_eval      score   score_std       irmsd   irmsd_std       fnat    fnat_std        lrmsd   lrmsd_std       dockqn  dockq_std
1       2       3       yes     -18.756 11.305  nan     nan     nan     nan     nan     nan     nan     nan
2       1       3       yes     42.560  10.328  5.068   0.109   0.177   0.013   14.757  0.987   0.170   0.010 
```

Here the top-ranked cluster contains some models without capri quantities, which are then set to nan.