### PR TITLE
Add `--ncores` param to clean clients

### DIFF
--- a/src/haddock/clis/cli_clean.py
+++ b/src/haddock/clis/cli_clean.py
@@ -9,7 +9,8 @@ compressed and archived into `.tgz` files. While files with `.pdb` and
 deleted.
 
 The <run_directory> can either be a whole HADDOCK3 run folder or a
-specific folder of the workflow step.
+specific folder of the workflow step. <ncores> defined the number of
+threads to use.
 
 Usage::
 
@@ -17,11 +18,13 @@ Usage::
     haddock3-clean <run_directory>
     haddock3-clean run1
     haddock3-clean run1/1_rigidbody
+    haddock3-clean run1 -n  # uses all cores
+    haddock3-clean run1 -n 2  # uses 2 cores
 """
 import argparse
 import sys
 
-from haddock.libs.libcli import add_rundir_arg, add_version_arg
+from haddock.libs import libcli
 
 
 # Command line interface parser
@@ -30,8 +33,9 @@ ap = argparse.ArgumentParser(
     formatter_class=argparse.RawDescriptionHelpFormatter,
     )
 
-add_rundir_arg(ap)
-add_version_arg(ap)
+libcli.add_rundir_arg(ap)
+libcli.add_ncores_arg(ap)
+libcli.add_version_arg(ap)
 
 
 def _ap():
@@ -54,7 +58,7 @@ def maincli():
     cli(ap, main)
 
 
-def main(run_dir, ncores=None):
+def main(run_dir, ncores=1):
     """
     Clean a HADDOCK3 directory.
 
@@ -68,7 +72,7 @@ def main(run_dir, ncores=None):
 
     ncores : int, or None
         The number of cores to use. If ``None``, use all possible threads.
-        Defaults to ``None``.
+        Defaults to 1.
 
     See Also
     --------

--- a/src/haddock/clis/cli_unpack.py
+++ b/src/haddock/clis/cli_unpack.py
@@ -11,7 +11,8 @@ This CLI performs the opposite operations as the ``haddock3-clean``
 command-line.
 
 The <run_directory> can either be a whole HADDOCK3 run folder or a
-specific folder of the workflow step.
+specific folder of the workflow step. <ncores> defined the number of
+threads to use.
 
 Usage::
 
@@ -19,11 +20,13 @@ Usage::
     haddock3-unpack -r <run_directory>
     haddock3-unpack run1
     haddock3-unpack run1/1_rigidbody
+    haddock3-clean run1 -n  # uses all cores
+    haddock3-clean run1 -n 2  # uses 2 cores
 """
 import argparse
 import sys
 
-from haddock.libs.libcli import add_rundir_arg, add_version_arg
+from haddock.libs import libcli
 
 
 # Command line interface parser
@@ -32,8 +35,9 @@ ap = argparse.ArgumentParser(
     formatter_class=argparse.RawDescriptionHelpFormatter,
     )
 
-add_rundir_arg(ap)
-add_version_arg(ap)
+libcli.add_rundir_arg(ap)
+libcli.add_ncores_arg(ap)
+libcli.add_version_arg(ap)
 
 
 def _ap():
@@ -56,7 +60,7 @@ def maincli():
     cli(ap, main)
 
 
-def main(run_dir, ncores=None):
+def main(run_dir, ncores=1):
     """
     Unpack a HADDOCK3 run directory step folders.
 
@@ -73,7 +77,7 @@ def main(run_dir, ncores=None):
 
     ncores : int, or None
         The number of cores to use. If ``None``, use all possible threads.
-        Defaults to ``None``.
+        Defaults to 1.
 
     See Also
     --------

--- a/src/haddock/libs/libcli.py
+++ b/src/haddock/libs/libcli.py
@@ -40,6 +40,24 @@ def add_rundir_arg(ap):
         )
 
 
+def add_ncores_arg(ap):
+    """Add number of cores option."""
+    ap.add_argument(
+        "-n",
+        "--ncores",
+        dest='ncores',
+        help=(
+            "The number of threads to use. Uses 1 if not specified. "
+            "Uses all available threads if `-n` is given. Else, uses the "
+            "number indicated, for example: `-n 4` will use 4 threads."
+            ),
+        type=int,
+        default=1,
+        const=None,
+        nargs='?',
+        )
+
+
 def add_output_dir_arg(ap):
     """Add output dir argument."""
     ap.add_argument(

--- a/tests/test_libcli.py
+++ b/tests/test_libcli.py
@@ -28,3 +28,21 @@ def test_output_dir_default():
     libcli.add_output_dir_arg(parser)
     v = vars(parser.parse_args([]))
     assert v['output_directory'] == Path.cwd()
+
+
+@pytest.mark.parametrize(
+    'cmd,expected',
+    [
+        ('-n 4', 4),
+        ('--ncores 2', 2),
+        ('', 1),
+        ('-n', None),
+        ('--ncores', None),
+        ],
+    )
+def test_output_dir(cmd, expected):
+    """Test output directory."""
+    parser = argparse.ArgumentParser()
+    libcli.add_ncores_arg(parser)
+    v = vars(parser.parse_args(cmd.split()))
+    assert v['ncores'] == expected

--- a/tests/test_libcli.py
+++ b/tests/test_libcli.py
@@ -40,7 +40,7 @@ def test_output_dir_default():
         ('--ncores', None),
         ],
     )
-def test_output_dir(cmd, expected):
+def test_ncores(cmd, expected):
     """Test output directory."""
     parser = argparse.ArgumentParser()
     libcli.add_ncores_arg(parser)


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and you comply with the following criteria:

- [x] You have stick to Python. Talk with us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [x] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [x] You structured the code into small functions as much as possible. You can use classes if there's a (state) purpose
- [x] code follows our coding style
- [x] You wrote tests for the new code
- [x] `tox` tests pass. *Run `tox` command inside the repository folder*
- [x] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [x] PR does not add any *install dependencies* unless permission granted by the HADDOCK team
- [x] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---

Add the `--ncores` parameter to the `clean` and `unpack` clients.