### PR TITLE
Fix clt order

### DIFF
--- a/src/haddock/modules/analysis/caprieval/capri.py
+++ b/src/haddock/modules/analysis/caprieval/capri.py
@@ -736,9 +736,10 @@ def capri_cluster_analysis(
         path
         ):
     """Consider the cluster results for the CAPRI evaluation."""
+    log.info(f"Rearranging cluster information into {output_fname}")
     # get the cluster data
     clt_data = dict(((m.clt_rank, m.clt_id), []) for m in model_list)
-
+    
     # add models to each cluster
     for capri, model in zip(capri_list, model_list):
         clt_data[(model.clt_rank, model.clt_id)].append((capri, model))
@@ -805,10 +806,30 @@ def capri_cluster_analysis(
         data["fnat_std"] = fnat_stdev
         data["lrmsd"] = lrmsd_mean
         data["lrmsd_std"] = lrmsd_stdev
-        data["dockqn"] = dockq_mean
+        data["dockq"] = dockq_mean
         data["dockq_std"] = dockq_stdev
 
         output_dic[i] = data
+    
+    # Rank according to the score
+    score_rankkey_values = [(key, output_dic[key]['score']) for key in output_dic.keys()]
+    score_rankkey_values.sort(key=lambda x: x[1])
+    for i, k in enumerate(score_rankkey_values):
+        idx, _ = k
+        output_dic[idx]["caprieval_rank"] = i + 1
+
+    # Rank according to the sorting key
+    rankkey_values = [(key, output_dic[key][sort_key]) for key in output_dic.keys()]
+    rankkey_values.sort(
+        key=lambda x: x[1],
+        reverse=True if not sort_ascending else False
+        )
+
+    _output_dic = {}
+    for i, k in enumerate(rankkey_values):
+        idx, _ = k
+        _output_dic[i + 1] = output_dic[idx]
+    output_dic = _output_dic
 
     output_fname = Path(path, output_fname)
 

--- a/src/haddock/modules/analysis/caprieval/capri.py
+++ b/src/haddock/modules/analysis/caprieval/capri.py
@@ -809,14 +809,16 @@ def capri_cluster_analysis(
         output_dic[i] = data
     
     # Rank according to the score
-    score_rankkey_values = [(key, output_dic[key]['score']) for key in output_dic.keys()]
+    score_rankkey_values = [(key, output_dic[key]['score'])
+                            for key in output_dic.keys()]
     score_rankkey_values.sort(key=lambda x: x[1])
     for i, k in enumerate(score_rankkey_values):
         idx, _ = k
         output_dic[idx]["caprieval_rank"] = i + 1
 
     # Rank according to the sorting key
-    rankkey_values = [(key, output_dic[key][sort_key]) for key in output_dic.keys()]
+    rankkey_values = [(key, output_dic[key][sort_key])
+                      for key in output_dic.keys()]
     rankkey_values.sort(
         key=lambda x: x[1],
         reverse=True if not sort_ascending else False

--- a/tests/test_module_caprieval.py
+++ b/tests/test_module_caprieval.py
@@ -32,8 +32,10 @@ def remove_aln_files(class_name):
         if f.exists():
             os.unlink(f)
 
+
 def read_capri_file(fname):
-    file_content = [e.split()[1:] for e in open(fname).readlines() if not e.startswith('#')]
+    file_content = [e.split()[1:] for e in open(fname).readlines()
+                    if not e.startswith('#')]
     return file_content
 
 
@@ -423,10 +425,13 @@ def test_capri_cluster_analysis(protprot_caprimodule, protprot_input_list):
 
     observed_outf_l = read_capri_file("capri_clt.txt")
     expected_outf_l = [
-        ['cluster_id', 'n', 'under_eval', 'score', 'score_std', 'irmsd', 'irmsd_std', 'fnat', 'fnat_std',
-            'lrmsd', 'lrmsd_std', 'dockq', 'dockq_std', 'caprieval_rank'], 
-        ['1', '1', 'yes', '42.000', '0.000', '0.100', '0.000', '1.000', '0.000', '1.200', '0.000', 'nan', 'nan', '1'], 
-        ['2', '1', 'yes', '50.000', '0.000', '0.100', '0.000', '1.000', '0.000', '1.200', '0.000', 'nan', 'nan', '2']]
+        ['cluster_id', 'n', 'under_eval', 'score', 'score_std', 'irmsd',
+         'irmsd_std', 'fnat', 'fnat_std', 'lrmsd', 'lrmsd_std', 'dockq',
+         'dockq_std', 'caprieval_rank'],
+        ['1', '1', 'yes', '42.000', '0.000', '0.100', '0.000', '1.000',
+         '0.000', '1.200', '0.000', 'nan', 'nan', '1'],
+        ['2', '1', 'yes', '50.000', '0.000', '0.100', '0.000', '1.000',
+         '0.000', '1.200', '0.000', 'nan', 'nan', '2']]
     assert observed_outf_l == expected_outf_l
     
     # test sorting
@@ -434,16 +439,20 @@ def test_capri_cluster_analysis(protprot_caprimodule, protprot_input_list):
         capri_list=[protprot_caprimodule, protprot_caprimodule],
         model_list=[model1, model2],
         output_fname="capri_clt.txt",
+        clt_threshold=5,
         sort_key="cluster_rank",
         sort_ascending=False,
         path=Path("."))
     
     observed_outf_l = read_capri_file("capri_clt.txt")
     expected_outf_l = [
-        ['cluster_id', 'n', 'under_eval', 'score', 'score_std', 'irmsd', 'irmsd_std', 'fnat', 'fnat_std',
-            'lrmsd', 'lrmsd_std', 'dockq', 'dockq_std', 'caprieval_rank'],
-        ['2', '1', 'yes', '50.000', '0.000', '0.100', '0.000', '1.000', '0.000', '1.200', '0.000', 'nan', 'nan', '2'],
-        ['1', '1', 'yes', '42.000', '0.000', '0.100', '0.000', '1.000', '0.000', '1.200', '0.000', 'nan', 'nan', '1']]
+        ['cluster_id', 'n', 'under_eval', 'score', 'score_std', 'irmsd',
+         'irmsd_std', 'fnat', 'fnat_std', 'lrmsd', 'lrmsd_std', 'dockq',
+         'dockq_std', 'caprieval_rank'],
+        ['2', '1', 'yes', '50.000', '0.000', '0.100', '0.000', '1.000',
+         '0.000', '1.200', '0.000', 'nan', 'nan', '2'],
+        ['1', '1', 'yes', '42.000', '0.000', '0.100', '0.000', '1.000',
+         '0.000', '1.200', '0.000', 'nan', 'nan', '1']]
 
     Path('capri_clt.txt').unlink()
 


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and you comply with the following criteria:

- [x] You have stick to Python. Talk with us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [x] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [ ] You structured the code into small functions as much as possible. You can use classes if there's a (state) purpose
- [ ] code follows our coding style
- [x] You wrote tests for the new code
- [x] `tox` tests pass. *Run `tox` command inside the repository folder*
- [x] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [x] PR does not add any *install dependencies* unless permission granted by the HADDOCK team
- [x] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [x] Your PR is about writing tests for already existing code :godmode:

---

Closes #580 by implementing the sorting logic in capri_cluster_analysis. 

IMPORTANT: the rank in the caprieval table may differ from the rank coming from the `clustfcc` module, for instance when a different `clt_threshold` is defined. This is why I added a `caprieval_rank` field to the `capri_clt` table, which indicates the ranking according to the standard capri order (average of the score over the first `clt_threshold` models). Of course when a different sorting key (dockq, fnat, ...) is provided, the order changes and `caprieval_rank` remains unaltered (as in the single structure case).

Additionally, the cluster_analysis test has been extended 