### PR TITLE
fixed handling of restr_fname in refinement modules

### DIFF
--- a/src/haddock/modules/refinement/emref/__init__.py
+++ b/src/haddock/modules/refinement/emref/__init__.py
@@ -49,7 +49,12 @@ class HaddockModule(BaseCNSModule):
             self.log("[Warning] sampling_factor is larger than 100")
         
         # checking the ambig_fname:
-        prev_ambig_fnames = [model.restr_fname for model in models_to_refine]
+        try:
+            prev_ambig_fnames = [mod.restr_fname for mod in models_to_refine]
+        except Exception as e:  # noqa:F841
+            # cannot extract restr_fname info from tuples
+            prev_ambig_fnames = [None for model in models_to_refine]
+
         ambig_fnames = self.get_ambig_fnames(prev_ambig_fnames)
 
         model_idx = 0

--- a/src/haddock/modules/refinement/flexref/__init__.py
+++ b/src/haddock/modules/refinement/flexref/__init__.py
@@ -49,7 +49,12 @@ class HaddockModule(BaseCNSModule):
             self.log("[Warning] sampling_factor is larger than 100")
 
         # checking the ambig_fname:
-        prev_ambig_fnames = [model.restr_fname for model in models_to_refine]
+        try:
+            prev_ambig_fnames = [mod.restr_fname for mod in models_to_refine]
+        except Exception as e:  # noqa:F841
+            # cannot extract restr_fname info from tuples
+            prev_ambig_fnames = [None for model in models_to_refine]
+
         ambig_fnames = self.get_ambig_fnames(prev_ambig_fnames)
 
         model_idx = 0

--- a/src/haddock/modules/refinement/mdref/__init__.py
+++ b/src/haddock/modules/refinement/mdref/__init__.py
@@ -49,7 +49,12 @@ class HaddockModule(BaseCNSModule):
             self.log("[Warning] sampling_factor is larger than 100")
         
         # checking the ambig_fname:
-        prev_ambig_fnames = [model.restr_fname for model in models_to_refine]
+        try:
+            prev_ambig_fnames = [mod.restr_fname for mod in models_to_refine]
+        except Exception as e:  # noqa:F841
+            # cannot extract restr_fname info from tuples
+            prev_ambig_fnames = [None for mod in models_to_refine]
+
         ambig_fnames = self.get_ambig_fnames(prev_ambig_fnames)
 
         model_idx = 0


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and you comply with the following criteria:

- [x] You have stick to Python. Talk with us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [x] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [ ] You structured the code into small functions as much as possible. You can use classes if there's a (state) purpose
- [ ] code follows our coding style
- [ ] You wrote tests for the new code
- [x] `tox` tests pass. *Run `tox` command inside the repository folder*
- [x] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [x] PR does not add any *install dependencies* unless permission granted by the HADDOCK team
- [x] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---

Closes #589 by setting the attribute `restr_fname` to None when models to be refined have yet to be merged