### PR TITLE
Compress `.inp`, `.out`, and `.seed` in CNS Jobs on the fly

### DIFF
--- a/docs/clients/cliclean.rst
+++ b/docs/clients/cliclean.rst
@@ -1,4 +1,4 @@
-Clean output Client
+Clean HADDOCK3 runs
 ===================
 
 .. argparse::

--- a/docs/clients/cliunpack.rst
+++ b/docs/clients/cliunpack.rst
@@ -1,5 +1,5 @@
-Unpack output
-=============
+Unpack HADDOCK3 run
+===================
 
 .. argparse::
    :module: haddock.clis.cli_unpack

--- a/src/haddock/clis/cli.py
+++ b/src/haddock/clis/cli.py
@@ -163,6 +163,7 @@ def main(
         restart_step = restart
         WorkflowManager_ = WorkflowManager
 
+    print(params)
     with (
             working_directory(other_params[RUNDIR]),
             log_error_and_exit(),

--- a/src/haddock/clis/cli.py
+++ b/src/haddock/clis/cli.py
@@ -163,7 +163,6 @@ def main(
         restart_step = restart
         WorkflowManager_ = WorkflowManager
 
-    print(params)
     with (
             working_directory(other_params[RUNDIR]),
             log_error_and_exit(),

--- a/src/haddock/clis/cli_clean.py
+++ b/src/haddock/clis/cli_clean.py
@@ -3,14 +3,16 @@
 Clean the output of an HADDOCK3 run directory.
 
 The clean process performs file archiving and file compressing
-operations. File with extension `seed`, `inp`, `out`, and `con` are
-compressed and archived into `.tgz` files. While files with `.pdb` and
-`.psf` extension are compressed to `.gz` files. The original files are
-deleted.
+operations.
+
+All `.inp` and `.out` files are deleted except for the first one, which
+is compressed to `.gz`. On the other hand, all `.seed` and `.con` files
+are compressed and archived to `.tgz` files. Finally, `.pdb` and `.psf`
+files are compressed to `.gz`.
 
 The <run_directory> can either be a whole HADDOCK3 run folder or a
-specific folder of the workflow step. <ncores> defined the number of
-threads to use.
+specific folder of the workflow step. <ncores> defines the number of
+threads to use; by default uses a single core.
 
 Usage::
 

--- a/src/haddock/clis/cli_cp.py
+++ b/src/haddock/clis/cli_cp.py
@@ -121,6 +121,7 @@ def main(run_dir, modules, output):
     """
     from pathlib import Path
 
+    from haddock.gear.clean_steps import unpack_compressed_and_archived_files
     from haddock.gear.extend_run import (
         copy_renum_step_folders,
         update_contents_of_new_steps,
@@ -145,7 +146,7 @@ def main(run_dir, modules, output):
 
     # copy folders over
     zero_fill.set_zerofill_number(len(selected_steps))
-    copy_renum_step_folders(run_dir, outdir, selected_steps)
+    new_step_folder = copy_renum_step_folders(run_dir, outdir, selected_steps)
 
     # copy data folders
     # `data_steps` are selected to avoid FileNotFoundError because some steps
@@ -160,6 +161,11 @@ def main(run_dir, modules, output):
 
     # update step names in files
     # update run dir names in files
+    unpack_compressed_and_archived_files(
+        new_step_folder,
+        ncores=1,
+        dec_all=True,
+        )
     update_contents_of_new_steps(selected_steps, run_dir, outdir)
 
     return

--- a/src/haddock/clis/cli_unpack.py
+++ b/src/haddock/clis/cli_unpack.py
@@ -3,9 +3,10 @@
 Unpack the output of an HADDOCK3 run directory.
 
 The unpack process performs file unpacking and file decompressing
-operations. File with extension `seed`, `inp`, `out`, and `con` are
-unpacked from their `.tgz` files. While files with `.pdb.gz` and
-`.psf.gz` extension are uncompressed.
+operations.  File with extension `seed` and `con` are unpacked from
+their `.tgz` files.  While files with `.pdb.gz` and `.psf.gz` extension
+are uncompressed.  If `--all` is given, unpack also `.inp.gz` and
+`.out.gz` files.
 
 This CLI performs the opposite operations as the ``haddock3-clean``
 command-line.
@@ -20,8 +21,10 @@ Usage::
     haddock3-unpack -r <run_directory>
     haddock3-unpack run1
     haddock3-unpack run1/1_rigidbody
-    haddock3-clean run1 -n  # uses all cores
-    haddock3-clean run1 -n 2  # uses 2 cores
+    haddock3-unpack run1 -n  # uses all cores
+    haddock3-unpack run1 -n 2  # uses 2 cores
+    haddock3-unpack run1 -n 2 -a
+    haddock3-unpack run1 -n 2 --all
 """
 import argparse
 import sys
@@ -36,6 +39,15 @@ ap = argparse.ArgumentParser(
     )
 
 libcli.add_rundir_arg(ap)
+
+ap.add_argument(
+    '--all',
+    '-a',
+    dest='dec_all',
+    help="Unpack all files (includes `.inp` and `.out`).",
+    action='store_true',
+    )
+
 libcli.add_ncores_arg(ap)
 libcli.add_version_arg(ap)
 
@@ -60,7 +72,7 @@ def maincli():
     cli(ap, main)
 
 
-def main(run_dir, ncores=1):
+def main(run_dir, ncores=1, dec_all=False):
     """
     Unpack a HADDOCK3 run directory step folders.
 
@@ -97,7 +109,11 @@ def main(run_dir, ncores=1):
 
     if is_step_folder(run_dir):
         with log_time("unpacking took"):
-            unpack_compressed_and_archived_files([run_dir], ncores)
+            unpack_compressed_and_archived_files(
+                [run_dir],
+                ncores,
+                dec_all=dec_all,
+                )
 
     else:
         step_folders = [
@@ -105,7 +121,11 @@ def main(run_dir, ncores=1):
             for p in get_module_steps_folders(run_dir)
             ]
         with log_time("unpacking took"):
-            unpack_compressed_and_archived_files(step_folders, ncores)
+            unpack_compressed_and_archived_files(
+                step_folders,
+                ncores,
+                dec_all=dec_all,
+                )
 
     return
 

--- a/src/haddock/gear/clean_steps.py
+++ b/src/haddock/gear/clean_steps.py
@@ -106,7 +106,7 @@ def _archive_and_remove_files(fta, path):
 
 
 # eventually this function can be moved to `libs.libio` in case of future need.
-def unpack_compressed_and_archived_files(folders, ncores=1):
+def unpack_compressed_and_archived_files(folders, ncores=1, dec_all=False):
     """
     Unpack compressed and archived files in a folders.
 
@@ -126,8 +126,21 @@ def unpack_compressed_and_archived_files(folders, ncores=1):
     global UNPACK_FOLDERS
     UNPACK_FOLDERS.clear()
 
+    files_to_decompress = [
+        '.pdb.gz',
+        '.psf.gz',
+        '.seed.gz',
+        ]
+
     for folder in folders:
-        gz_files = glob_folder(folder, '.gz')
+        gz_files = []
+        for file_to_dec in files_to_decompress:
+            gz_files.extend(list(glob_folder(folder, file_to_dec)))
+
+        if dec_all:
+            for dec_all_files in ('.inp.gz', '.out.gz'):
+                gz_files.extend(list(glob_folder(folder, dec_all_files)))
+
         tar_files = glob_folder(folder, '.tgz')
 
         if gz_files or tar_files:

--- a/src/haddock/gear/clean_steps.py
+++ b/src/haddock/gear/clean_steps.py
@@ -57,7 +57,7 @@ def clean_output(path, ncores=1):
     # `unpack_compressed_and_archived_files` so that the
     # uncompressing routines when restarting the run work.
 
-    ## Files to delete
+    # Files to delete
     # deletes all except the first one
     files_to_delete = [
         '.inp',
@@ -75,9 +75,6 @@ def clean_output(path, ncores=1):
     files_to_archive = [
         '.seed',
         '.seed.gz',
-        #'.inp.gz',
-        #'.out',
-        #'.out.gz',
         '.con',
         ]
 

--- a/src/haddock/gear/clean_steps.py
+++ b/src/haddock/gear/clean_steps.py
@@ -56,7 +56,30 @@ def clean_output(path, ncores=1):
     # add any formats generated to
     # `unpack_compressed_and_archived_files` so that the
     # uncompressing routines when restarting the run work.
-    files_to_archive = ['seed', 'inp', 'out', 'con']
+
+    ## Files to delete
+    # deletes all except the first one
+    files_to_delete = [
+        '.inp',
+        '.inp.gz',
+        '.out',
+        '.out.gz',
+        ]
+
+    for extension in files_to_delete:
+        flist = glob_folder(path, extension)
+        for file_ in flist[1:]:
+            Path(file_).unlink()
+
+    # files to archive (all files in single .gz)
+    files_to_archive = [
+        '.seed',
+        '.seed.gz',
+        #'.inp.gz',
+        #'.out',
+        #'.out.gz',
+        '.con',
+        ]
 
     archive_ready = partial(_archive_and_remove_files, path=path)
     _ncores = min(ncores, len(files_to_archive))
@@ -65,7 +88,14 @@ def clean_output(path, ncores=1):
         for _ in imap:
             pass
 
-    files_to_compress = ['pdb', 'psf']
+    # files to compress in .gz
+    files_to_compress = [
+        '.inp',
+        '.out',
+        '.pdb',
+        '.psf',
+        ]
+
     for ftc in files_to_compress:
         found = compress_files_ext(path, ftc, ncores=ncores)
         if found:

--- a/src/haddock/gear/extend_run.py
+++ b/src/haddock/gear/extend_run.py
@@ -147,7 +147,13 @@ def copy_renum_step_folders(indir, destdir, steps):
 
     steps : list of (str or Path)
         The list of the folder names in `indir` to copy.
+
+    Returns
+    -------
+    list
+        The new paths created.
     """
+    new_steps = []
     step_names = (Path(step).name for step in steps)
     for i, step in enumerate(step_names):
         ori = Path(indir, step)
@@ -155,6 +161,8 @@ def copy_renum_step_folders(indir, destdir, steps):
         dest = Path(destdir, zero_fill.fill(_modname, i))
         shutil.copytree(ori, dest)
         log.info(f"Copied {str(ori)} -> {str(dest)}")
+        new_steps.append(dest)
+    return new_steps
 
 
 def renum_step_folders(folder):

--- a/src/haddock/gear/prepare_run.py
+++ b/src/haddock/gear/prepare_run.py
@@ -239,6 +239,7 @@ def setup_run(
         unpack_compressed_and_archived_files(
             _step_folders,
             general_params["ncores"],
+            dec_all=True,
             )
 
     if starting_from_copy:

--- a/src/haddock/libs/libio.py
+++ b/src/haddock/libs/libio.py
@@ -259,7 +259,7 @@ def compress_files_ext(path, ext, ncores=1, **kwargs):
     return False
 
 
-def gzip_files(file_, block_size=None, compresslevel=9):
+def gzip_files(file_, block_size=None, compresslevel=9, remove_original=False):
     """
     Gzip a file.
 
@@ -287,6 +287,9 @@ def gzip_files(file_, block_size=None, compresslevel=9):
         while content:
             gout.write(content)
             content = fin.read(block_size)
+
+    if remove_original:
+        Path(file_).unlink()
 
 
 def archive_files_ext(path, ext, compresslevel=9):

--- a/src/haddock/libs/libio.py
+++ b/src/haddock/libs/libio.py
@@ -397,31 +397,6 @@ def glob_folder(folder, ext):
     return sort_numbered_paths(*list(map(Path, files)))
 
 
-#def parse_suffix(ext):
-#    """
-#    Represent a suffix of a file.
-#
-#    Examples
-#    --------
-#    >>> parse_suffix('.pdf')
-#    '.pdf'
-#
-#    >>> parse_suffix('pdf')
-#    '.pdf'
-#
-#    Parameters
-#    ----------
-#    ext : str
-#        String to extract the suffix from.
-#
-#    Returns
-#    -------
-#    str
-#        File extension with leading period.
-#    """
-#    return f'.{ext[ext.find(".") + 1:]}'
-
-
 def remove_files_with_ext(folder, ext):
     """
     Remove files with ``ext`` in folder.

--- a/src/haddock/libs/libio.py
+++ b/src/haddock/libs/libio.py
@@ -15,6 +15,46 @@ from haddock.libs.libontology import PDBFile
 from haddock.libs.libutil import sort_numbered_paths
 
 
+def clean_suffix(ext):
+    """
+    Remove the preffix dot of an extension if exists.
+
+    Parameters
+    ----------
+    ext : str
+        The extension string.
+
+    Examples
+    --------
+    >>> clean_suffix('.pdb')
+    'pdb'
+
+    >>> clean_suffix('pdb')
+    'pdb'
+    """
+    return ext.lstrip(r'.')
+
+
+def dot_suffix(ext):
+    """
+    Add the dot preffix to an extension if missing.
+
+    Parameters
+    ----------
+    ext : str
+        The extension string.
+
+    Examples
+    --------
+    >>> clean_suffix('.pdb')
+    '.pdb'
+
+    >>> clean_suffix('pdb')
+    '.pdb'
+    """
+    return '.' + clean_suffix(ext)
+
+
 def read_lines(func):
     """
     Open the file and read lines for the decorated function.
@@ -314,7 +354,10 @@ def archive_files_ext(path, ext, compresslevel=9):
         ``False`` if no files with ``ext`` were found and, hence, the
         Zip files was not created.
     """
-    files = glob_folder(path, ext)
+    files = glob_folder(path, clean_suffix(ext))
+
+    ext = clean_suffix(ext)
+
     if files:
         with tarfile.open(
                 Path(path, f'{ext}.tgz'),
@@ -349,34 +392,34 @@ def glob_folder(folder, ext):
     list of Path objects
         SORTED list of matching results.
     """
-    ext = f'*{parse_suffix(ext)}'
+    ext = f'*{dot_suffix(ext)}'
     files = glob.glob(str(Path(folder, ext)))
     return sort_numbered_paths(*list(map(Path, files)))
 
 
-def parse_suffix(ext):
-    """
-    Represent a suffix of a file.
-
-    Examples
-    --------
-    >>> parse_suffix('.pdf')
-    '.pdf'
-
-    >>> parse_suffix('pdf')
-    '.pdf'
-
-    Parameters
-    ----------
-    ext : str
-        String to extract the suffix from.
-
-    Returns
-    -------
-    str
-        File extension with leading period.
-    """
-    return f'.{ext[ext.find(".") + 1:]}'
+#def parse_suffix(ext):
+#    """
+#    Represent a suffix of a file.
+#
+#    Examples
+#    --------
+#    >>> parse_suffix('.pdf')
+#    '.pdf'
+#
+#    >>> parse_suffix('pdf')
+#    '.pdf'
+#
+#    Parameters
+#    ----------
+#    ext : str
+#        String to extract the suffix from.
+#
+#    Returns
+#    -------
+#    str
+#        File extension with leading period.
+#    """
+#    return f'.{ext[ext.find(".") + 1:]}'
 
 
 def remove_files_with_ext(folder, ext):

--- a/src/haddock/libs/libsubprocess.py
+++ b/src/haddock/libs/libsubprocess.py
@@ -153,8 +153,29 @@ class CNSJob:
 
         self._cns_exec = cns_exec_path
 
-    def run(self):
-        """Run this CNS job script."""
+    def run(
+            self,
+            compress_inp=False,
+            compress_out=True,
+            compress_seed=False,
+            ):
+        """
+        Run this CNS job script.
+
+        Parameters
+        ----------
+        compress_inp : bool
+            Compress the *.inp file to '.gz' after the run. Defaults to
+            ``False``.
+
+        compress_out : bool
+            Compress the *.out file to '.gz' after the run. Defaults to
+            ``True``.
+
+        compress_seed : bool
+            Compress the *.seed file to '.gz' after the run. Defaults to
+            ``False``.
+        """
         with open(self.input_file) as inp, \
                 open(self.output_file, 'w+') as outf:
 
@@ -170,12 +191,17 @@ class CNSJob:
             out, error = p.communicate()
             p.kill()
 
-        gzip_files(self.input_file, remove_original=True)
-        gzip_files(self.output_file, remove_original=True)
-        with suppress(FileNotFoundError):
-            gzip_files(
-                Path(Path(self.output_file).stem).with_suffix('.seed'),
-                remove_original=True)
+        if compress_inp:
+            gzip_files(self.input_file, remove_original=True)
+
+        if compress_out:
+            gzip_files(self.output_file, remove_original=True)
+
+        if compress_seed:
+            with suppress(FileNotFoundError):
+                gzip_files(
+                    Path(Path(self.output_file).stem).with_suffix('.seed'),
+                    remove_original=True)
 
         if error:
             raise CNSRunningError(error)

--- a/src/haddock/libs/libsubprocess.py
+++ b/src/haddock/libs/libsubprocess.py
@@ -2,10 +2,12 @@
 import os
 import shlex
 import subprocess
+from contextlib import suppress
 from pathlib import Path
 
 from haddock.core.defaults import cns_exec as global_cns_exec
 from haddock.core.exceptions import CNSRunningError, JobRunningError
+from haddock.libs.libio import gzip_files
 
 
 class BaseJob:
@@ -167,6 +169,13 @@ class CNSJob:
 
             out, error = p.communicate()
             p.kill()
+
+        gzip_files(self.input_file, remove_original=True)
+        gzip_files(self.output_file, remove_original=True)
+        with suppress(FileNotFoundError):
+            gzip_files(
+                Path(Path(self.output_file).stem).with_suffix('.seed'),
+                remove_original=True)
 
         if error:
             raise CNSRunningError(error)

--- a/src/haddock/libs/libworkflow.py
+++ b/src/haddock/libs/libworkflow.py
@@ -26,7 +26,7 @@ class WorkflowManager:
         # terminate is used to synchronize the `clean` option with the
         # `exit` module. If the `exit` module is removed in the future,
         # you can also remove and clean the `terminate` part here.
-        self._terminated = 0
+        self._terminated = None
 
     def run(self):
         """High level workflow composer."""

--- a/tests/test_gear_clean_steps.py
+++ b/tests/test_gear_clean_steps.py
@@ -32,15 +32,15 @@ def test_clean_output():
     # these are the files that SHOULD exist after packing
     files_that_should_exist = [
         Path("0_topoaa", "params.cfg"),
-        Path("0_topoaa", "inp.tgz"),
-        Path("0_topoaa", "out.tgz"),
+        Path("0_topoaa", "structure_1.inp.gz"),
+        Path("0_topoaa", "structure_1.out.gz"),
         Path("0_topoaa", "structure_1.pdb.gz"),
         Path("0_topoaa", "structure_1.psf.gz"),
 
         Path("1_rigidbody", "params.cfg"),
         Path("1_rigidbody", "io.json"),
-        Path("1_rigidbody", "inp.tgz"),
-        Path("1_rigidbody", "out.tgz"),
+        Path("1_rigidbody", "structure_1.inp.gz"),
+        Path("1_rigidbody", "structure_1.out.gz"),
         Path("1_rigidbody", "seed.tgz"),
         Path("1_rigidbody", "structure_1.pdb.gz"),
         Path("1_rigidbody", "structure_2.pdb.gz"),
@@ -98,24 +98,22 @@ def test_clean_output():
         Path("1_rigidbody", "structure_1.out"),
         Path("1_rigidbody", "structure_1.pdb"),
         Path("1_rigidbody", "structure_1.seed"),
-        Path("1_rigidbody", "structure_2.inp"),
-        Path("1_rigidbody", "structure_2.out"),
         Path("1_rigidbody", "structure_2.pdb"),
         Path("1_rigidbody", "structure_2.seed"),
 
-        Path("2_clustfcc", "structure_2.con"),
+        Path("2_clustfcc", "structure_1.con"),
         Path("2_clustfcc", "structure_2.con"),
         ]
 
     # these are the files that should NOT exist after unpacking
     files_that_should_not_exist = [
-        Path("0_topoaa", "inp.tgz"),
-        Path("0_topoaa", "out.tgz"),
+        Path("0_topoaa", "structure_1.inp.gz"),
+        Path("0_topoaa", "structure_1.out.gz"),
         Path("0_topoaa", "structure_1.pdb.gz"),
         Path("0_topoaa", "structure_1.psf.gz"),
 
-        Path("1_rigidbody", "inp.tgz"),
-        Path("1_rigidbody", "out.tgz"),
+        Path("1_rigidbody", "structure_1.inp.gz"),
+        Path("1_rigidbody", "structure_1.out.gz"),
         Path("1_rigidbody", "seed.tgz"),
         Path("1_rigidbody", "structure_1.pdb.gz"),
         Path("1_rigidbody", "structure_2.pdb.gz"),

--- a/tests/test_gear_clean_steps.py
+++ b/tests/test_gear_clean_steps.py
@@ -87,6 +87,131 @@ def test_clean_output():
     # these are the files that SHOULD exist after unpacking
     files_that_should_exist = [
         Path("0_topoaa", "params.cfg"),
+        # Path("0_topoaa", "structure_1.inp"),
+        # Path("0_topoaa", "structure_1.out"),
+        Path("0_topoaa", "structure_1.pdb"),
+        Path("0_topoaa", "structure_1.psf"),
+        Path("0_topoaa", "structure_1.inp.gz"),
+        Path("0_topoaa", "structure_1.out.gz"),
+
+        Path("1_rigidbody", "params.cfg"),
+        Path("1_rigidbody", "io.json"),
+        # Path("1_rigidbody", "structure_1.inp"),
+        # Path("1_rigidbody", "structure_1.out"),
+        Path("1_rigidbody", "structure_1.pdb"),
+        Path("1_rigidbody", "structure_1.seed"),
+        Path("1_rigidbody", "structure_2.pdb"),
+        Path("1_rigidbody", "structure_2.seed"),
+
+        Path("2_clustfcc", "structure_1.con"),
+        Path("2_clustfcc", "structure_2.con"),
+        ]
+
+    # these are the files that should NOT exist after unpacking
+    files_that_should_not_exist = [
+        Path("0_topoaa", "structure_1.inp"),
+        Path("0_topoaa", "structure_1.out"),
+        Path("0_topoaa", "structure_1.pdb.gz"),
+        Path("0_topoaa", "structure_1.psf.gz"),
+
+        Path("1_rigidbody", "structure_1.inp"),
+        Path("1_rigidbody", "structure_1.out"),
+        Path("1_rigidbody", "seed.tgz"),
+        Path("1_rigidbody", "structure_1.pdb.gz"),
+        Path("1_rigidbody", "structure_2.pdb.gz"),
+
+        Path("2_clustfcc", "con.tgz"),
+        ]
+
+    # assert files actually exist
+    for file_ in files_that_should_exist:
+        assert Path(outdir, file_).exists()
+
+    # assert files do not exist
+    for file_ in files_that_should_not_exist:
+        assert not Path(outdir, file_).exists()
+
+    # removes the dir as it is no longer needed
+    shutil.rmtree(outdir)
+
+
+def test_clean_output_dec_all():
+    """Test correct clean and unpack functions."""
+    # defines the dir to compress
+    outdir = Path(clean_steps_folder, 'run1c')
+    # remove it just in case it remained in the testing environment
+    shutil.rmtree(outdir, ignore_errors=True)
+
+    # copies the directory to avoid messing with git stack
+    shutil.copytree(
+        Path(clean_steps_folder, 'run1'),
+        outdir,
+        )
+
+    # packs each folder separately
+    clean_output(Path(outdir, "0_topoaa"))
+    clean_output(Path(outdir, "1_rigidbody"))
+    clean_output(Path(outdir, "2_clustfcc"))
+
+    # these are the files that SHOULD exist after packing
+    files_that_should_exist = [
+        Path("0_topoaa", "params.cfg"),
+        Path("0_topoaa", "structure_1.inp.gz"),
+        Path("0_topoaa", "structure_1.out.gz"),
+        Path("0_topoaa", "structure_1.pdb.gz"),
+        Path("0_topoaa", "structure_1.psf.gz"),
+
+        Path("1_rigidbody", "params.cfg"),
+        Path("1_rigidbody", "io.json"),
+        Path("1_rigidbody", "structure_1.inp.gz"),
+        Path("1_rigidbody", "structure_1.out.gz"),
+        Path("1_rigidbody", "seed.tgz"),
+        Path("1_rigidbody", "structure_1.pdb.gz"),
+        Path("1_rigidbody", "structure_2.pdb.gz"),
+
+        Path("2_clustfcc", "con.tgz"),
+        ]
+
+    # assert if the files actually exist in the `outdir` folder
+    for file_ in files_that_should_exist:
+        assert Path(outdir, file_).exists()
+
+    # these are the files that should NOT exist after packing
+    files_that_should_not_exist = [
+        Path("0_topoaa", "structure_1.inp"),
+        Path("0_topoaa", "structure_1.out"),
+        Path("0_topoaa", "structure_1.pdb"),
+        Path("0_topoaa", "structure_1.psf"),
+
+        Path("1_rigidbody", "structure_1.inp"),
+        Path("1_rigidbody", "structure_1.out"),
+        Path("1_rigidbody", "structure_1.pdb"),
+        Path("1_rigidbody", "structure_1.seed"),
+        Path("1_rigidbody", "structure_2.inp"),
+        Path("1_rigidbody", "structure_2.out"),
+        Path("1_rigidbody", "structure_2.pdb"),
+        Path("1_rigidbody", "structure_2.seed"),
+
+        Path("2_clustfcc", "structure_2.con"),
+        Path("2_clustfcc", "structure_2.con"),
+        ]
+
+    # asserts the files do NOT exist in the `outdir` folder
+    for file_ in files_that_should_not_exist:
+        assert not Path(outdir, file_).exists()
+
+    # now, unpacks the `outdir`. In other words, reverts the previous
+    # clean_output operation
+    unpack_compressed_and_archived_files([
+        Path(outdir, "0_topoaa"),
+        Path(outdir, "1_rigidbody"),
+        Path(outdir, "2_clustfcc"),
+        ],
+        dec_all=True)
+
+    # these are the files that SHOULD exist after FULL unpacking
+    files_that_should_exist = [
+        Path("0_topoaa", "params.cfg"),
         Path("0_topoaa", "structure_1.inp"),
         Path("0_topoaa", "structure_1.out"),
         Path("0_topoaa", "structure_1.pdb"),

--- a/tests/test_libio.py
+++ b/tests/test_libio.py
@@ -5,9 +5,10 @@ from pathlib import Path
 import pytest
 
 from haddock.libs.libio import (
+    clean_suffix,
+    dot_suffix,
     file_exists,
     folder_exists,
-    parse_suffix,
     read_from_yaml,
     write_dic_to_file,
     write_nested_dic_to_file,
@@ -60,10 +61,26 @@ def test_write_dic_to_file():
     [
         (".ext", ".ext"),
         ("ext", ".ext"),
+        (".out.gz", ".out.gz"),
+        ("out.gz", ".out.gz"),
         ]
     )
-def test_parse_suffix(in_, expected):
-    result = parse_suffix(in_)
+def test_dot_suffix(in_, expected):
+    result = dot_suffix(in_)
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "in_,expected",
+    [
+        (".ext", "ext"),
+        ("ext", "ext"),
+        (".out.gz", "out.gz"),
+        ("out.gz", "out.gz"),
+        ]
+    )
+def test_clean_suffix(in_, expected):
+    result = clean_suffix(in_)
     assert result == expected
 
 


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and you comply with the following criteria:

- [x] You have stick to Python. Talk with us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [x] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [x] You structured the code into small functions as much as possible. You can use classes if there's a (state) purpose
- [x] code follows our coding style
- [x] You wrote tests for the new code
- [x] `tox` tests pass. *Run `tox` command inside the repository folder*
- [x] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [x] PR does not add any *install dependencies* unless permission granted by the HADDOCK team
- [x] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---

Closes #587
Closes #593

@amjjbonvin can you test this? In case you don't yet have my fork on your clone:

```
git remote add joaot https://github.com/joaomcteixeira/haddock3
git fetch joaot
git checkout unpackmore
```

And test some example.  Let me know if you with more to be done regarding **on the fly packing of output files**.

Cheers!