### PR TITLE
Implement option to use MAX CPUs and bypass the `N-1` rule for `local` mode.

### DIFF
--- a/src/haddock/libs/libparallel.py
+++ b/src/haddock/libs/libparallel.py
@@ -32,7 +32,7 @@ class Worker(Process):
 class Scheduler:
     """Schedules tasks to run in multiprocessing."""
 
-    def __init__(self, tasks, ncores=None):
+    def __init__(self, tasks, ncores=None, max_cpus=False):
         """
         Schedule tasks to a defined number of processes.
 
@@ -47,11 +47,9 @@ class Scheduler:
             maximum number of CPUs allowed by
             `libs.libututil.parse_ncores` function.
         """
+        self.max_cpus = max_cpus
         self.num_tasks = len(tasks)
         self.num_processes = ncores  # first parses num_cores
-
-        # Do not waste resources
-        self.num_processes = min(self.num_processes, self.num_tasks)
 
         # Sort the tasks by input_file name and its length,
         #  so we know that 2 comes before 10
@@ -82,7 +80,11 @@ class Scheduler:
 
     @num_processes.setter
     def num_processes(self, n):
-        self._ncores = parse_ncores(n)
+        self._ncores = parse_ncores(
+            n,
+            njobs=self.num_tasks,
+            max_cpus=self.max_cpus,
+            )
         log.debug(f"Scheduler configured for {self._ncores} cpu cores.")
 
     def run(self):

--- a/src/haddock/libs/libutil.py
+++ b/src/haddock/libs/libutil.py
@@ -139,7 +139,12 @@ def parse_ncores(n=None, njobs=None, max_cpus=None):
     int
         A correct number of cores according to specifications.
     """
-    max_cpus = max_cpus or max(cpu_count() - 1, 1)
+    if max_cpus is None or max_cpus is False:
+        max_cpus = max(cpu_count() - 1, 1)
+    if max_cpus is True:
+        max_cpus = cpu_count()
+    elif not isinstance(max_cpus, int):
+        raise TypeError(f'`max_cpus` not of valid type: {type(max_cpus)}')
 
     if n is None:
         return max_cpus

--- a/src/haddock/modules/__init__.py
+++ b/src/haddock/modules/__init__.py
@@ -359,6 +359,7 @@ def get_engine(mode, params):
         return partial(
             Scheduler,
             ncores=params['ncores'],
+            max_ncores=params['max_cpus'],
             )
     elif mode == "mpi":
         return partial(MPIScheduler, ncores=params["ncores"])

--- a/src/haddock/modules/__init__.py
+++ b/src/haddock/modules/__init__.py
@@ -359,7 +359,7 @@ def get_engine(mode, params):
         return partial(
             Scheduler,
             ncores=params['ncores'],
-            max_ncores=params['max_cpus'],
+            max_cpus=params['max_cpus'],
             )
     elif mode == "mpi":
         return partial(MPIScheduler, ncores=params["ncores"])

--- a/src/haddock/modules/defaults.yaml
+++ b/src/haddock/modules/defaults.yaml
@@ -23,6 +23,18 @@ ncores:
     Note that is truncated to the total number of available CPUs minus 1.
   group: 'execution'
   explevel: easy
+max_cpus:
+  default: False
+  type: boolean
+  title: The max number of CPUs allowed.
+  short: By default the max number of CPUs allows is the max available minus 1.
+  long: In order to spare a minimum amount of resources for daily tasks, the
+    maximum number of CPUs allowed is the total available in the machine minus
+    1. This calculation is done automatically. However, in some occasions it
+    might be relevant to use ALL CPUs available. For this, define the number of
+    CPUs in the `ncores` parameter and set `max_cpu` parameter to True.
+  group: 'execution'
+  explevel: expert
 mode:
   default: local
   type: string


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and you comply with the following criteria:

- [x] You have stick to Python. Talk with us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [x] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [x] You structured the code into small functions as much as possible. You can use classes if there's a (state) purpose
- [x] code follows our coding style
- [x] You wrote tests for the new code
- [x] `tox` tests pass. *Run `tox` command inside the repository folder*
- [x] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [ ] PR does not add any *install dependencies* unless permission granted by the HADDOCK team
- [ ] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [x] Your PR is about writing tests for already existing code :godmode:

---

The new `max_cpus` parameter is introduced.
