### PR TITLE
add `w+` to data dir

### DIFF
--- a/src/haddock/gear/prepare_run.py
+++ b/src/haddock/gear/prepare_run.py
@@ -50,6 +50,7 @@ from haddock.gear.validations import v_rundir
 from haddock.gear.yaml2cfg import read_from_yaml_config
 from haddock.gear.zerofill import zero_fill
 from haddock.libs.libfunc import not_none
+from haddock.libs.libio import make_writeable_recursive
 from haddock.libs.libutil import (
     extract_keys_recursive,
     recursive_dict_update,
@@ -306,6 +307,9 @@ def setup_run(
     else:
         # copies everything
         copy_input_files_to_data_dir(data_dir, modules_params)
+
+    # grant write permissions to data/ dir
+    make_writeable_recursive(data_dir)
 
     # return the modules' parameters and general parameters separately
     return modules_params, general_params

--- a/src/haddock/libs/libio.py
+++ b/src/haddock/libs/libio.py
@@ -3,6 +3,7 @@ import contextlib
 import glob
 import gzip
 import os
+import stat
 import tarfile
 from functools import partial
 from multiprocessing import Pool
@@ -501,3 +502,28 @@ def file_exists(
 
     # don't change to f-strings, .format has a purpose
     raise exception(emsg.format(str(path)))
+
+
+def get_perm(fname):
+    """Get permissions of file."""
+    # https://stackoverflow.com/questions/6874970
+    return stat.S_IMODE(os.lstat(fname)[stat.ST_MODE])
+
+
+def make_writeable_recursive(path):
+    """
+    Add writing to a folder, its subfolders and files.
+
+    Parameters
+    ----------
+    path : str or Path
+        The path to add writing permissions.
+    """
+    # https://stackoverflow.com/questions/6874970
+    for root, dirs, files in os.walk(path, topdown=False):
+
+        for dir_ in [os.path.join(root, d) for d in dirs]:
+            os.chmod(dir_, get_perm(dir_) | os.ST_WRITE)
+
+        for file_ in [os.path.join(root, f) for f in files]:
+            os.chmod(file_, get_perm(file_) | os.ST_WRITE)


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and you comply with the following criteria:

- [x] You have stick to Python. Talk with us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [x] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [x] You structured the code into small functions as much as possible. You can use classes if there's a (state) purpose
- [x] code follows our coding style
- [x] You wrote tests for the new code
- [x] `tox` tests pass. *Run `tox` command inside the repository folder*
- [x] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [ ] PR does not add any *install dependencies* unless permission granted by the HADDOCK team
- [ ] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---

After preparing the run directory, and before starting the calculations, add writing permissions to all files in the `run_dir/data` directory.

@amjjbonvin can you test it to see wether it works on your side?

Closes #598 