### PR TITLE
Related to issue #598 - now compatible with OSX as well

### DIFF
--- a/src/haddock/libs/libio.py
+++ b/src/haddock/libs/libio.py
@@ -523,7 +523,7 @@ def make_writeable_recursive(path):
     for root, dirs, files in os.walk(path, topdown=False):
 
         for dir_ in [os.path.join(root, d) for d in dirs]:
-            os.chmod(dir_, get_perm(dir_) | os.ST_WRITE)
+            os.chmod(dir_, get_perm(dir_) | stat.S_IWUSR)
 
         for file_ in [os.path.join(root, f) for f in files]:
-            os.chmod(file_, get_perm(file_) | os.ST_WRITE)
+            os.chmod(file_, get_perm(file_) | stat.S_IWUSR)


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and you comply with the following criteria:

- [x] You have stick to Python. Talk with us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [ ] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [ ] You structured the code into small functions as much as possible. You can use classes if there's a (state) purpose
- [x] code follows our coding style
- [ ] You wrote tests for the new code
- [x] `tox` tests pass. *Run `tox` command inside the repository folder*
- [x] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [x] PR does not add any *install dependencies* unless permission granted by the HADDOCK team
- [x] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---

The last commit #599 broke the execution on OSX. This fix makes it work (tested both on OSX and Linux). The solution proposed by @mgiulini was to change `os.ST_WRITE` with `stat.S_IWUSR` in `src/haddock/libs/libio.py`
