### PR TITLE
Correct rmsds

### DIFF
--- a/src/haddock/modules/analysis/caprieval/capri.py
+++ b/src/haddock/modules/analysis/caprieval/capri.py
@@ -865,7 +865,7 @@ class CAPRIError(Exception):
 #             fh.write(dummy_line)
 
 
-# debug only
+# # debug only
 # def write_coords(output_name, coor_list):
 #     """Add a dummy atom to a PDB file according to a list of coordinates."""
 #     with open(output_name, "w") as fh:

--- a/src/haddock/modules/analysis/caprieval/capri.py
+++ b/src/haddock/modules/analysis/caprieval/capri.py
@@ -172,12 +172,12 @@ class CAPRI:
             # get receptor and ligand coordinates
             Q_r_first = Q[r_start: r_end + 1]
             P_r_first = P[r_start: r_end + 1]
-            # write_coords("ref_r_first.pdb", Q_r_first)
-            # write_coords("model_r_first.pdb", P_r_first)
-            # Q_l_first = Q[l_start: l_end + 1]
-            # P_l_first = P[l_start: l_end + 1]
-            # write_coords("ref_l_first.pdb", Q_l_first)
-            # write_coords("model_l_first.pdb", P_l_first)
+            #write_coords("ref_r_first.pdb", Q_r_first)
+            #write_coords("model_r_first.pdb", P_r_first)
+            Q_l_first = Q[l_start: l_end + 1]
+            P_l_first = P[l_start: l_end + 1]
+            #write_coords("ref_l_first.pdb", Q_l_first)
+            #write_coords("model_l_first.pdb", P_l_first)
 
             # move to the origin of the receptor
             
@@ -190,28 +190,29 @@ class CAPRI:
             # Center receptors and get rotation matrix
             # Q_r = Q_r - centroid(Q_r)
             # P_r = P_r - centroid(P_r)
+            #write_coords("ref_r_centr.pdb", Q_r)
+            #write_coords("model_r_centr.pdb", P_r)
 
             U_r = kabsch(P_r, Q_r)
+            print(U_r)
+            print(calc_rmsd(Q_r, np.dot(P_r, U_r)))
 
             # Apply rotation to complex
             #  - complex are now aligned by the receptor
             P = np.dot(P, U_r)
 
-            write_coords("ref.pdb", Q)
-            write_coords("model.pdb", P)
+            #write_coords("ref.pdb", Q)
+            #write_coords("model.pdb", P)
 
             # Identify the ligand coordinates
             Q_l = Q[l_start: l_end + 1]
             P_l = P[l_start: l_end + 1]
 
-            write_coords("ref_l.pdb", Q_l)
-            write_coords("model_l.pdb", P_l)
+            #write_coords("ref_l.pdb", Q_l)
+            #write_coords("model_l.pdb", P_l)
 
             # Calculate the RMSD of the ligands
             self.lrmsd = calc_rmsd(P_l, Q_l)
-
-            # write_coords("ref.pdb", Q)
-            # write_coords("model.pdb", P)
 
     def calc_ilrmsd(self, cutoff=10.0):
         """
@@ -224,19 +225,12 @@ class CAPRI:
         """
         # Identify interface
         ref_interface_resdic = self.identify_interface(self.reference, cutoff)
-        print(ref_interface_resdic)
         # Load interface coordinates
         # ref_coord_dic, _ = load_coords(self.reference, self.atoms)
 
         ref_int_coord_dic, _ = load_coords(
             self.reference, self.atoms, ref_interface_resdic
             )
-
-        #mod_coord_dic, _ = load_coords(
-        #    self.model,
-        #    self.atoms,
-        #    numbering_dic=self.model2ref_numbering
-        #    )
 
         mod_int_coord_dic, _ = load_coords(
             self.model,
@@ -273,7 +267,6 @@ class CAPRI:
              chain_ranges[chain].append(i)
 
         chain_ranges = make_range(chain_ranges)
-        print(f"chain_ranges {chain_ranges}")
         obs_chains = list(chain_ranges.keys())  # observed chains
         if len(obs_chains) < 2:
             log.warning("Not enough chains for calculating ilrmsd")
@@ -290,26 +283,27 @@ class CAPRI:
             Q_r_int = Q_int[r_start: r_end + 1]
             P_r_int = P_int[r_start: r_end + 1]
 
-            write_coords("ref_r_int.pdb", Q_r_int)
-            write_coords("mod_r_int.pdb", P_r_int)
-
             Q_int = Q_int - centroid(Q_r_int)
             P_int = P_int - centroid(P_r_int)
             # put interfaces at the origin
 
             # find the rotation that minimizes the receptor interface rmsd
-            U_int = kabsch(P_r_int, Q_r_int)
+            Q_r_int = Q_int[r_start: r_end + 1]
+            P_r_int = P_int[r_start: r_end + 1]
             
+            U_int = kabsch(P_r_int, Q_r_int)
             P_int = np.dot(P_int, U_int)
             # just for checks.
             # the interface rmsd for the receptor interface should be zero
-            # Q_r_int = Q_int[r_start: r_end + 1]
-            # P_r_int = P_int[r_start: r_end + 1]
-            # r_rmsd = calc_rmsd(Q_r_int[r_start: r_end + 1], P_int[r_start: r_end + 1])
-            # print(r_rmsd)
+            #Q_r_int = Q_int[r_start: r_end + 1]
+            #P_r_int = P_int[r_start: r_end + 1]
+            #r_rmsd = calc_rmsd(Q_r_int[r_start: r_end + 1], P_int[r_start: r_end + 1])
+            #print(r_rmsd)
 
             Q_l_int = Q_int[l_start: l_end + 1]
             P_l_int = P_int[l_start: l_end + 1]
+            #write_coords("ref_l_int_fin.pdb", Q_l_int)
+            #write_coords("mod_l_int_fin.pdb", P_l_int)
 
             # # this will be the interface-ligand-rmsd
             self.ilrmsd = calc_rmsd(P_l_int, Q_l_int)

--- a/src/haddock/modules/analysis/caprieval/capri.py
+++ b/src/haddock/modules/analysis/caprieval/capri.py
@@ -81,7 +81,6 @@ class CAPRI:
         """
         # Identify reference interface
         ref_interface_resdic = self.identify_interface(self.reference, cutoff)
-        print(f"ref_interface_resdic {ref_interface_resdic}")
         if len(ref_interface_resdic) == 0:
             log.warning("No reference interface found")
         else:
@@ -169,15 +168,15 @@ class CAPRI:
             # write_coords("ref_first.pdb", Q)
             # write_coords("model_first.pdb", P)
 
-            # get receptor and ligand coordinates
+            # get receptor and ligand coordinates
             Q_r_first = Q[r_start: r_end + 1]
             P_r_first = P[r_start: r_end + 1]
-            #write_coords("ref_r_first.pdb", Q_r_first)
-            #write_coords("model_r_first.pdb", P_r_first)
-            Q_l_first = Q[l_start: l_end + 1]
-            P_l_first = P[l_start: l_end + 1]
-            #write_coords("ref_l_first.pdb", Q_l_first)
-            #write_coords("model_l_first.pdb", P_l_first)
+            # write_coords("ref_r_first.pdb", Q_r_first)
+            # write_coords("model_r_first.pdb", P_r_first)
+            # Q_l_first = Q[l_start: l_end + 1]
+            # P_l_first = P[l_start: l_end + 1]
+            # write_coords("ref_l_first.pdb", Q_l_first)
+            # write_coords("model_l_first.pdb", P_l_first)
 
             # move to the origin of the receptor
             
@@ -190,26 +189,24 @@ class CAPRI:
             # Center receptors and get rotation matrix
             # Q_r = Q_r - centroid(Q_r)
             # P_r = P_r - centroid(P_r)
-            #write_coords("ref_r_centr.pdb", Q_r)
-            #write_coords("model_r_centr.pdb", P_r)
+            # write_coords("ref_r_centr.pdb", Q_r)
+            # write_coords("model_r_centr.pdb", P_r)
 
             U_r = kabsch(P_r, Q_r)
-            print(U_r)
-            print(calc_rmsd(Q_r, np.dot(P_r, U_r)))
 
             # Apply rotation to complex
             #  - complex are now aligned by the receptor
             P = np.dot(P, U_r)
 
-            #write_coords("ref.pdb", Q)
-            #write_coords("model.pdb", P)
+            # write_coords("ref.pdb", Q)
+            # write_coords("model.pdb", P)
 
             # Identify the ligand coordinates
             Q_l = Q[l_start: l_end + 1]
             P_l = P[l_start: l_end + 1]
 
-            #write_coords("ref_l.pdb", Q_l)
-            #write_coords("model_l.pdb", P_l)
+            # write_coords("ref_l.pdb", Q_l)
+            # write_coords("model_l.pdb", P_l)
 
             # Calculate the RMSD of the ligands
             self.lrmsd = calc_rmsd(P_l, Q_l)
@@ -261,10 +258,10 @@ class CAPRI:
         
         chain_ranges = {}
         for i, segment in enumerate(sorted(common_keys)):
-             chain, _, _ = segment
-             if chain not in chain_ranges:
-                 chain_ranges[chain] = []
-             chain_ranges[chain].append(i)
+            chain, _, _ = segment
+            if chain not in chain_ranges:
+                chain_ranges[chain] = []
+            chain_ranges[chain].append(i)
 
         chain_ranges = make_range(chain_ranges)
         obs_chains = list(chain_ranges.keys())  # observed chains
@@ -294,16 +291,16 @@ class CAPRI:
             U_int = kabsch(P_r_int, Q_r_int)
             P_int = np.dot(P_int, U_int)
             # just for checks.
-            # the interface rmsd for the receptor interface should be zero
-            #Q_r_int = Q_int[r_start: r_end + 1]
-            #P_r_int = P_int[r_start: r_end + 1]
-            #r_rmsd = calc_rmsd(Q_r_int[r_start: r_end + 1], P_int[r_start: r_end + 1])
-            #print(r_rmsd)
+            # the interface rmsd for the rec interface should be almost zero
+            # Q_r_int = Q_int[r_start: r_end + 1]
+            # P_r_int = P_int[r_start: r_end + 1]
+            # r_rmsd = calc_rmsd(Q_r_int, P_int[r_start: r_end + 1])
+            # print(r_rmsd)
 
             Q_l_int = Q_int[l_start: l_end + 1]
             P_l_int = P_int[l_start: l_end + 1]
-            #write_coords("ref_l_int_fin.pdb", Q_l_int)
-            #write_coords("mod_l_int_fin.pdb", P_l_int)
+            # write_coords("ref_l_int_fin.pdb", Q_l_int)
+            # write_coords("mod_l_int_fin.pdb", P_l_int)
 
             # # this will be the interface-ligand-rmsd
             self.ilrmsd = calc_rmsd(P_l_int, Q_l_int)

--- a/src/haddock/modules/analysis/caprieval/capri.py
+++ b/src/haddock/modules/analysis/caprieval/capri.py
@@ -81,6 +81,7 @@ class CAPRI:
         """
         # Identify reference interface
         ref_interface_resdic = self.identify_interface(self.reference, cutoff)
+
         if len(ref_interface_resdic) == 0:
             log.warning("No reference interface found")
         else:
@@ -223,7 +224,6 @@ class CAPRI:
         # Identify interface
         ref_interface_resdic = self.identify_interface(self.reference, cutoff)
         # Load interface coordinates
-        # ref_coord_dic, _ = load_coords(self.reference, self.atoms)
 
         ref_int_coord_dic, _ = load_coords(
             self.reference, self.atoms, ref_interface_resdic
@@ -866,21 +866,21 @@ class CAPRIError(Exception):
 
 
 # debug only
-def write_coords(output_name, coor_list):
-    """Add a dummy atom to a PDB file according to a list of coordinates."""
-    with open(output_name, "w") as fh:
-        for i, dummy_coord in enumerate(coor_list):
-            atom_num = f"{i}".rjust(4, " ")
-            resnum = f"{i}".rjust(3, " ")
-            dum_x = f"{dummy_coord[0]:.3f}".rjust(7, " ")
-            dum_y = f"{dummy_coord[1]:.3f}".rjust(7, " ")
-            dum_z = f"{dummy_coord[2]:.3f}".rjust(7, " ")
-            dummy_line = (
-                f"ATOM   {atom_num}  H   DUM X {resnum}   "
-                f"  {dum_x} {dum_y} {dum_z}  1.00  1.00   "
-                "        H  " + os.linesep
-                )
-            fh.write(dummy_line)
+# def write_coords(output_name, coor_list):
+#     """Add a dummy atom to a PDB file according to a list of coordinates."""
+#     with open(output_name, "w") as fh:
+#         for i, dummy_coord in enumerate(coor_list):
+#             atom_num = f"{i}".rjust(4, " ")
+#             resnum = f"{i}".rjust(3, " ")
+#             dum_x = f"{dummy_coord[0]:.3f}".rjust(7, " ")
+#             dum_y = f"{dummy_coord[1]:.3f}".rjust(7, " ")
+#             dum_z = f"{dummy_coord[2]:.3f}".rjust(7, " ")
+#             dummy_line = (
+#                 f"ATOM   {atom_num}  H   DUM X {resnum}   "
+#                 f"  {dum_x} {dum_y} {dum_z}  1.00  1.00   "
+#                 "        H  " + os.linesep
+#                 )
+#             fh.write(dummy_line)
 
 
 # # debug only

--- a/src/haddock/modules/analysis/caprieval/capri.py
+++ b/src/haddock/modules/analysis/caprieval/capri.py
@@ -81,7 +81,7 @@ class CAPRI:
         """
         # Identify reference interface
         ref_interface_resdic = self.identify_interface(self.reference, cutoff)
-
+        print(f"ref_interface_resdic {ref_interface_resdic}")
         if len(ref_interface_resdic) == 0:
             log.warning("No reference interface found")
         else:
@@ -133,7 +133,6 @@ class CAPRI:
             self.atoms,
             numbering_dic=self.model2ref_numbering
             )
-        print(f"len ref_coord_dic.keys() {len(ref_coord_dic.keys())}")
 
         Q = []
         P = []
@@ -147,8 +146,8 @@ class CAPRI:
             if chain not in chain_ranges:
                 chain_ranges[chain] = []
             chain_ranges[chain].append(i)
+        
         chain_ranges = make_range(chain_ranges)
-        print(f"chain ranges {chain_ranges}")
         obs_chains = list(chain_ranges.keys())  # observed chains
         if len(obs_chains) < 2:
             log.warning("Not enough chains for calculating lrmsd")
@@ -167,42 +166,32 @@ class CAPRI:
             Q = np.asarray(Q)
             P = np.asarray(P)
 
-            # write_coord_dic("ref.pdb", ref_coord_dic)
-            # write_coord_dic("model.pdb", mod_coord_dic)
+            # write_coords("ref_first.pdb", Q)
+            # write_coords("model_first.pdb", P)
 
-            write_coords("ref_first.pdb", Q)
-            write_coords("model_first.pdb", P)
             # get receptor and ligand coordinates
             Q_r_first = Q[r_start: r_end + 1]
             P_r_first = P[r_start: r_end + 1]
-            write_coords("ref_r_first.pdb", Q_r_first)
-            write_coords("model_r_first.pdb", P_r_first)
-            Q_l_first = Q[l_start: l_end + 1]
-            P_l_first = P[l_start: l_end + 1]
-            write_coords("ref_l_first.pdb", Q_l_first)
-            write_coords("model_l_first.pdb", P_l_first)
+            # write_coords("ref_r_first.pdb", Q_r_first)
+            # write_coords("model_r_first.pdb", P_r_first)
+            # Q_l_first = Q[l_start: l_end + 1]
+            # P_l_first = P[l_start: l_end + 1]
+            # write_coords("ref_l_first.pdb", Q_l_first)
+            # write_coords("model_l_first.pdb", P_l_first)
 
             # move to the origin of the receptor
-            print(f"centr P vs centroid Q {centroid(P)} vs {centroid(Q)}")
+            
             Q = Q - centroid(Q_r_first)
             P = P - centroid(P_r_first)
-            
 
             # get receptor coordinates
             Q_r = Q[r_start: r_end + 1]
             P_r = P[r_start: r_end + 1]
-            write_coords("ref_r_centr.pdb", Q_r)
-            write_coords("model_r_centr.pdb", P_r)
             # Center receptors and get rotation matrix
             # Q_r = Q_r - centroid(Q_r)
             # P_r = P_r - centroid(P_r)
 
             U_r = kabsch(P_r, Q_r)
-            print(f"U_r {U_r}")
-
-            # Center complexes at receptor centroids
-            #Q = Q - centroid(Q_r)
-            #P = P - centroid(P_r)
 
             # Apply rotation to complex
             #  - complex are now aligned by the receptor
@@ -455,7 +444,7 @@ class CAPRI:
         if self.params["irmsd"]:
             log.debug(f"id {self.identificator}, calculating I-RMSD")
             irmsd_cutoff = self.params["irmsd_cutoff"]
-            log.debug(f" cutoff: {irmsd_cutoff}A")
+            log.info(f" cutoff: {irmsd_cutoff}A")
             self.calc_irmsd(cutoff=irmsd_cutoff)
 
         if self.params["lrmsd"]:

--- a/tests/test_module_caprieval.py
+++ b/tests/test_module_caprieval.py
@@ -175,7 +175,7 @@ def test_protprot_lrmsd(protprot_caprimodule):
 def test_protprot_ilrmsd(protprot_caprimodule):
     """Test protein-protein i-l-rmsd calculation."""
     protprot_caprimodule.calc_ilrmsd()
-    assert round_two_dec(protprot_caprimodule.ilrmsd) == 9.67
+    assert round_two_dec(protprot_caprimodule.ilrmsd) == 18.25
 
 
 def test_protprot_fnat(protprot_caprimodule):
@@ -202,13 +202,13 @@ def test_protlig_irmsd(protlig_caprimodule):
 def test_protlig_lrmsd(protlig_caprimodule):
     """Test protein-ligand l-rmsd calculation."""
     protlig_caprimodule.calc_lrmsd()
-    assert round_two_dec(protlig_caprimodule.lrmsd) == 0.51
+    assert round_two_dec(protlig_caprimodule.lrmsd) == 0.49
 
 
 def test_protlig_ilrmsd(protlig_caprimodule):
     """Test protein-ligand i-l-rmsd calculation."""
     protlig_caprimodule.calc_ilrmsd()
-    assert round_two_dec(protlig_caprimodule.ilrmsd) == 0.5
+    assert round_two_dec(protlig_caprimodule.ilrmsd) == 0.49
 
 
 def test_protlig_fnat(protlig_caprimodule):
@@ -226,13 +226,13 @@ def test_protdna_irmsd(protdna_caprimodule):
 def test_protdna_lrmsd(protdna_caprimodule):
     """Test protein-dna l-rmsd calculation."""
     protdna_caprimodule.calc_lrmsd()
-    assert round_two_dec(protdna_caprimodule.lrmsd) == 4.19
+    assert round_two_dec(protdna_caprimodule.lrmsd) == 6.13
 
 
 def test_protdna_ilrmsd(protdna_caprimodule):
     """Test protein-dna i-l-rmsd calculation."""
     protdna_caprimodule.calc_ilrmsd()
-    assert round_two_dec(protdna_caprimodule.ilrmsd) == 1.89
+    assert round_two_dec(protdna_caprimodule.ilrmsd) == 5.97
 
 
 def test_protdna_fnat(protdna_caprimodule, protdna_input_list):

--- a/tests/test_module_caprieval.py
+++ b/tests/test_module_caprieval.py
@@ -159,7 +159,7 @@ def protprot_caprimodule_parallel(protprot_input_list):
 def test_protprot_irmsd(protprot_caprimodule):
     """Test protein-protein i-rmsd calculation."""
     # using standard cutoff
-    protprot_caprimodule.calc_irmsd(cutoff = 10.0)
+    protprot_caprimodule.calc_irmsd(cutoff=10.0)
     assert round_two_dec(protprot_caprimodule.irmsd) == 8.33
     # using default cutoff = 5.0
     protprot_caprimodule.calc_irmsd()

--- a/tests/test_module_caprieval.py
+++ b/tests/test_module_caprieval.py
@@ -158,6 +158,10 @@ def protprot_caprimodule_parallel(protprot_input_list):
 
 def test_protprot_irmsd(protprot_caprimodule):
     """Test protein-protein i-rmsd calculation."""
+    # using standard cutoff
+    protprot_caprimodule.calc_irmsd(cutoff = 10.0)
+    assert round_two_dec(protprot_caprimodule.irmsd) == 8.33
+    # using default cutoff = 5.0
     protprot_caprimodule.calc_irmsd()
     assert round_two_dec(protprot_caprimodule.irmsd) == 7.38
 
@@ -165,7 +169,7 @@ def test_protprot_irmsd(protprot_caprimodule):
 def test_protprot_lrmsd(protprot_caprimodule):
     """Test protein-protein l-rmsd calculation."""
     protprot_caprimodule.calc_lrmsd()
-    assert round_two_dec(protprot_caprimodule.lrmsd) == 15.9
+    assert round_two_dec(protprot_caprimodule.lrmsd) == 20.94
 
 
 def test_protprot_ilrmsd(protprot_caprimodule):


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and you comply with the following criteria:

- [x] You have stick to Python. Talk with us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [x] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [x] You structured the code into small functions as much as possible. You can use classes if there's a (state) purpose
- [x] code follows our coding style
- [x] You wrote tests for the new code
- [x] `tox` tests pass. *Run `tox` command inside the repository folder*
- [ ] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [x] PR does not add any *install dependencies* unless permission granted by the HADDOCK team
- [ ] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---

Closes #603 by

1. fixing the indexing error in the retrieval of receptor https://github.com/haddocking/haddock3/blob/f0ebd692277f5e58a34c22ce304d6b22c2824dfc/src/haddock/modules/analysis/caprieval/capri.py#L181-L182 and ligand https://github.com/haddocking/haddock3/blob/f0ebd692277f5e58a34c22ce304d6b22c2824dfc/src/haddock/modules/analysis/caprieval/capri.py#L202-L203 coordinates
2. correct the removal of the center of geometry of the receptor rather than that of the full complex https://github.com/haddocking/haddock3/blob/f0ebd692277f5e58a34c22ce304d6b22c2824dfc/src/haddock/modules/analysis/caprieval/capri.py#L177-L178
3. rewriting the ilrmsd function