### PR TITLE
added png option

### DIFF
--- a/src/haddock/clis/cli_analyse.py
+++ b/src/haddock/clis/cli_analyse.py
@@ -30,7 +30,12 @@ from haddock import log
 from haddock.gear.yaml2cfg import read_from_yaml_config
 from haddock.libs.libcli import _ParamsToDict
 from haddock.libs.libontology import ModuleIO
-from haddock.libs.libplots import box_plots, read_capri_table, scatter_plots
+from haddock.libs.libplots import (
+    box_plots,
+    read_capri_table,
+    scatter_plots,
+    scatter_plots_png,
+    )
 from haddock.modules import get_module_steps_folders
 from haddock.modules.analysis.caprieval import \
     DEFAULT_CONFIG as caprieval_params
@@ -93,6 +98,14 @@ ap.add_argument(
     required=False,
     type=int,
     default=10
+    )
+
+ap.add_argument(
+    "--png",
+    help="produce png images",
+    required=False,
+    type=bool,
+    default=False
     )
 
 ap.add_argument(
@@ -189,7 +202,7 @@ def update_capri_dict(capri_dict, target_path):
     return new_capri_dict
 
 
-def analyse_step(step, run_dir, capri_dict, target_path, top_cluster):
+def analyse_step(step, run_dir, capri_dict, target_path, top_cluster, png):
     """
     Analyse a step.
 
@@ -238,10 +251,12 @@ def analyse_step(step, run_dir, capri_dict, target_path, top_cluster):
     if ss_file.exists():
         log.info("Plotting results..")
         scatter_plots(ss_file, cluster_ranking)
-        box_plots(ss_file, cluster_ranking)
+        box_plots(ss_file, cluster_ranking, png)
+        if png:
+            scatter_plots_png(ss_file, cluster_ranking)
 
 
-def main(run_dir, modules, top_cluster, **kwargs):
+def main(run_dir, modules, top_cluster, png, **kwargs):
     """
     Analyse CLI.
 
@@ -309,7 +324,12 @@ def main(run_dir, modules, top_cluster, **kwargs):
         # run the analysis
         error = False
         try:
-            analyse_step(step, Path("./"), capri_dict, target_path, top_cluster)
+            analyse_step(step,
+                         Path("./"),
+                         capri_dict,
+                         target_path,
+                         top_cluster,
+                         png)
         except Exception as e:
             error = True
             log.warning(

--- a/src/haddock/clis/cli_analyse.py
+++ b/src/haddock/clis/cli_analyse.py
@@ -31,10 +31,9 @@ from haddock.gear.yaml2cfg import read_from_yaml_config
 from haddock.libs.libcli import _ParamsToDict
 from haddock.libs.libontology import ModuleIO
 from haddock.libs.libplots import (
-    box_plots,
+    box_plot_handler,
     read_capri_table,
-    scatter_plots,
-    scatter_plots_png,
+    scatter_plot_handler,
     )
 from haddock.modules import get_module_steps_folders
 from haddock.modules.analysis.caprieval import \
@@ -262,10 +261,8 @@ def analyse_step(step, run_dir, capri_dict, target_path, top_cluster, png, dpi):
         raise Exception(f"clustering file {clt_file} does not exist")
     if ss_file.exists():
         log.info("Plotting results..")
-        scatter_plots(ss_file, cluster_ranking)
-        box_plots(ss_file, cluster_ranking, png, dpi)
-        if png:
-            scatter_plots_png(ss_file, cluster_ranking, dpi)
+        scatter_plot_handler(ss_file, cluster_ranking, png, dpi)
+        box_plot_handler(ss_file, cluster_ranking, png, dpi)
 
 
 def main(run_dir, modules, top_cluster, png, dpi, **kwargs):

--- a/src/haddock/clis/cli_analyse.py
+++ b/src/haddock/clis/cli_analyse.py
@@ -109,6 +109,14 @@ ap.add_argument(
     )
 
 ap.add_argument(
+    "--dpi",
+    help="dpi for png images",
+    required=False,
+    type=int,
+    default=200
+    )
+
+ap.add_argument(
     "-p",
     "--other-params",
     dest="other_params",
@@ -202,7 +210,7 @@ def update_capri_dict(capri_dict, target_path):
     return new_capri_dict
 
 
-def analyse_step(step, run_dir, capri_dict, target_path, top_cluster, png):
+def analyse_step(step, run_dir, capri_dict, target_path, top_cluster, png, dpi):
     """
     Analyse a step.
 
@@ -221,6 +229,10 @@ def analyse_step(step, run_dir, capri_dict, target_path, top_cluster, png):
         path to the output folder
     top_cluster : int
         Number of clusters to be considered
+    png : bool
+        Produce png images.
+    dpi : int
+        DPI for png images.
     """
     log.info(f"Analysing step {step}")
     
@@ -251,12 +263,12 @@ def analyse_step(step, run_dir, capri_dict, target_path, top_cluster, png):
     if ss_file.exists():
         log.info("Plotting results..")
         scatter_plots(ss_file, cluster_ranking)
-        box_plots(ss_file, cluster_ranking, png)
+        box_plots(ss_file, cluster_ranking, png, dpi)
         if png:
-            scatter_plots_png(ss_file, cluster_ranking)
+            scatter_plots_png(ss_file, cluster_ranking, dpi)
 
 
-def main(run_dir, modules, top_cluster, png, **kwargs):
+def main(run_dir, modules, top_cluster, png, dpi, **kwargs):
     """
     Analyse CLI.
 
@@ -269,11 +281,17 @@ def main(run_dir, modules, top_cluster, png, **kwargs):
         List of the integer prefix of the modules to copy.
 
     top_cluster : int
-        Number of clusters to be considered
+        Number of clusters to be considered.
+
+    png : bool
+        Produce png images.
+    
+    dpi : int
+        DPI for png images.
     """
     log.info(f"Running haddock3-analyse on {run_dir}, modules {modules}, "
              f"with top_cluster = {top_cluster}")
-
+    
     # modifying the parameters
     default_capri = read_from_yaml_config(caprieval_params)
     capri_dict = default_capri.copy()
@@ -329,7 +347,8 @@ def main(run_dir, modules, top_cluster, png, **kwargs):
                          capri_dict,
                          target_path,
                          top_cluster,
-                         png)
+                         png,
+                         dpi)
         except Exception as e:
             error = True
             log.warning(

--- a/src/haddock/libs/libplots.py
+++ b/src/haddock/libs/libplots.py
@@ -162,6 +162,8 @@ def box_plots(capri_filename, cl_ranking, png):
             colors = plt.cm.tab20.colors
             for patch, color in zip(bplot['boxes'], colors):
                 patch.set_facecolor(color)
+            for median, color in zip(bplot['medians'], colors):
+                median.set_color(color)
             # plot details
             ax.legend(bplot["boxes"], legend_labels, bbox_to_anchor=(1.0, 1.0))
             plt.ylabel(AXIS_NAMES[x_ax])
@@ -364,7 +366,7 @@ def scatter_plots_png(capri_filename, cl_ranking):
         plt_fname = f"{x_ax}_{y_ax}.png"
         plt.tight_layout()
         plt.savefig(plt_fname, dpi=200)
-        plt.close()
+
         # creating full picture
         if not gb_other.empty:
             plt.scatter(
@@ -381,4 +383,5 @@ def scatter_plots_png(capri_filename, cl_ranking):
             plt_fname = f"{x_ax}_{y_ax}_full.png"
             plt.tight_layout()
             plt.savefig(plt_fname, dpi=200)
-            plt.close()
+        plt.close()
+        

--- a/src/haddock/libs/libplots.py
+++ b/src/haddock/libs/libplots.py
@@ -83,7 +83,188 @@ def read_capri_table(capri_filename, comment="#"):
     return capri_df
 
 
-def box_plots(capri_filename, cl_ranking, png, dpi):
+def in_capri(column, df_columns):
+    """
+    Check if the selected column is in the set of available columns.
+
+    Parameters
+    ----------
+    column : str
+        column name
+    df_columns : pandas.DataFrame.columns
+        columns of a pandas.DataFrame
+    Returns
+    -------
+    resp : bool
+        if True, the column is present
+    """
+    resp = True
+    if column not in df_columns:
+        log.warning(f"quantity {column} not present in capri table")
+        resp = False
+    return resp
+
+
+def update_layout_plotly(fig, x_label, y_label, title=None):
+    """
+    Update layout of plotly plot.
+
+    Parameters
+    ----------
+    fig : plotly Figure
+        figure
+    x_label : str
+        x axis name
+    y_label : str
+        y axis name
+    title : str or None
+        plot title
+    """
+    px_dict = {
+        "title": title,
+        "xaxis": dict(
+            title=x_label,
+            tickfont_size=14,
+            titlefont_size=40,
+            ),
+        "yaxis": dict(
+            title=y_label,
+            tickfont_size=14,
+            titlefont_size=40,
+            ),
+        "legend": dict(x=1.01, y=1.0, font_family="Helvetica", font_size=16),
+        "hoverlabel": dict(font_size=16, font_family="Helvetica")
+        }
+    fig.update_layout(px_dict)
+    return
+
+
+def update_layout_matplotlib(x_label, y_label):
+    """
+    Update layout of matplotlib plot.
+
+    Parameters
+    ----------
+    x_label : str
+        x axis name
+    y_label : str
+        y axis name
+    """
+    plt.title(f"{x_label} vs {y_label}", fontsize=40)
+    plt.xlabel(x_label, fontsize=40)
+    plt.ylabel(y_label, fontsize=40)
+    plt.xticks(fontsize=20)
+    plt.yticks(fontsize=20)
+    legend = plt.legend(bbox_to_anchor=(1.0, 1.0), fontsize=30)
+    for handle in legend.legendHandles:
+        handle.set_sizes([150])
+    plt.tight_layout()
+    return
+
+
+def box_plot_plotly(gb_full, y_ax):
+    """
+    Create a scatter plot in plotly.
+    
+    Parameters
+    ----------
+    gb_full : pandas DataFrame
+        data to box plot
+    y_ax : str
+        variable to plot
+    """
+    fig = px.box(gb_full,
+                 x="capri_rank",
+                 y=f"{y_ax}",
+                 color="cluster-id",
+                 boxmode="overlay",
+                 points="outliers"
+                 )
+    # layout
+    update_layout_plotly(fig, "Cluster rank", AXIS_NAMES[y_ax])
+    # save figure
+    px_fname = f"{y_ax}_clt.html"
+    fig.write_html(px_fname, full_html=False, include_plotlyjs='cdn')
+    return
+
+
+def box_plot_matplotlib(gbcl, y_ax, legend_labels, dpi):
+    """
+    Create a scatter plot in plotly.
+    
+    Parameters
+    ----------
+    gbcl : pandas DataFrameGroupBy
+        capri data grouped by cluster-id
+    y_ax : str
+        variable to plot
+    legend_labels : list
+        list of legend labels
+    dpi : int
+        DPI for png images.
+    
+    """
+    plt.figure(figsize=(20, 16))
+    fig, ax = plt.subplots()
+    # box plot must take element 1 of groupby instance
+    bplot = ax.boxplot([el[1][y_ax] for el in gbcl],
+                       patch_artist=True,
+                       showmeans=False,
+                       )
+    # assigning colors to boxes and medians
+    colors = plt.cm.tab20.colors
+    for patch, color in zip(bplot['boxes'], colors):
+        patch.set_facecolor(color)
+    for median, color in zip(bplot['medians'], colors):
+        median.set_color(color)
+    
+    # plot details
+    ax.legend(bplot["boxes"], legend_labels, bbox_to_anchor=(1.0, 1.0))
+    plt.ylabel(AXIS_NAMES[y_ax])
+    plt.xlabel("Cluster rank")
+    plt.tight_layout()
+    # save figure
+    plt_fname = f"{y_ax}_clt.png"
+    plt.savefig(fname=plt_fname, dpi=dpi)
+    plt.close()
+    return
+
+
+def box_plot_data(capri_df, cl_rank):
+    """
+    Retrieve box plot data.
+
+    Parameters
+    ----------
+    capri_df : pandas DataFrame
+        capri table dataframe
+    cl_rank : dict
+        {cluster_id : cluster_rank} dictionary
+    
+    Returns
+    -------
+    gb_full : pandas DataFrame
+        DataFrame of all the clusters to be plotted
+    gb_other : pandas DataFrame
+        DataFrame of clusters not in the top cluster ranking
+    """
+    gb_cluster = capri_df.groupby("cluster-id")
+    gb_other = pd.DataFrame([])
+    gb_good = pd.DataFrame([])
+    for cl_id, cl_df in gb_cluster:
+        if cl_id not in cl_rank.keys():
+            gb_other = pd.concat([gb_other, cl_df])
+        else:
+            cl_df["capri_rank"] = cl_rank[cl_id]
+            gb_good = pd.concat([gb_good, cl_df])
+            
+    gb_other["cluster-id"] = "Other"
+    gb_other["capri_rank"] = len(cl_rank.keys()) + 1
+    gb_full = pd.concat([gb_good, gb_other])
+    return gb_full, gb_other
+
+
+def box_plot_handler(capri_filename, cl_rank, png, dpi):
     """
     Create box plots.
 
@@ -94,7 +275,7 @@ def box_plots(capri_filename, cl_ranking, png, dpi):
     ----------
     capri_filename : str or Path
         capri single structure filename
-    cl_ranking : dict
+    cl_rank : dict
         {cluster_id : cluster_rank} dictionary
     png : bool
         Produce png images.
@@ -103,81 +284,228 @@ def box_plots(capri_filename, cl_ranking, png, dpi):
     """
     # generating the correct dataframe
     capri_df = read_capri_table(capri_filename, comment="#")
-    gb_cluster = capri_df.groupby("cluster-id")
-    gb_other = pd.DataFrame([])
-    gb_good = pd.DataFrame([])
-    for cl_id, cl_df in gb_cluster:
-        if cl_id not in cl_ranking.keys():
-            gb_other = pd.concat([gb_other, cl_df])
-        else:
-            cl_df["capri_rank"] = cl_ranking[cl_id]
-            gb_good = pd.concat([gb_good, cl_df])
-            
-    gb_other["cluster-id"] = "Other"
-    gb_other["capri_rank"] = len(cl_ranking.keys()) + 1
-    gb_cluster = pd.concat([gb_good, gb_other])
-    # when png is true we already order everything according to capri_rank
+    gb_full, gb_other = box_plot_data(capri_df, cl_rank)
+    
     if png:
-        gb_sorted = gb_cluster.sort_values("capri_rank")
+        # when png is true we have to manually sort according to capri_rank
+        gb_sorted = gb_full.sort_values("capri_rank")
         gbcl = gb_sorted.groupby("cluster-id", sort=False)
         legend_labels = [f"Cluster {el[0]}" for el in gbcl]
         if not gb_other.empty:
             legend_labels[-1] = "Other"
     
     # iterate over the variables
-    for x_ax in AXIS_NAMES.keys():
-        if x_ax not in capri_df.columns:
-            log.info(f"x axis quantity {x_ax} not present in capri table")
+    for y_ax in AXIS_NAMES.keys():
+        if not in_capri(y_ax, capri_df.columns):
             continue
-        fig = px.box(gb_cluster,
-                     x="capri_rank",
-                     y=f"{x_ax}",
-                     color="cluster-id",
-                     boxmode="overlay",
-                     points="outliers"
-                     )
-        # layout
-        px_fname = f"{x_ax}_clt.html"
-        fig.update_layout(
-            xaxis=dict(
-                title="Cluster rank",
-                tickfont_size=14,
-                titlefont_size=40,
-                ),
-            yaxis=dict(
-                title=AXIS_NAMES[x_ax],
-                tickfont_size=14,
-                titlefont_size=40,
-                ),
-            legend=dict(x=1.01, y=1.0, font_family="Helvetica", font_size=16),
-            hoverlabel=dict(font_size=16, font_family="Helvetica"),
-            )
-        fig.write_html(px_fname, full_html=False, include_plotlyjs='cdn')
+        box_plot_plotly(gb_full, y_ax)
         # create png boxplot if necessary
         if png:
-            plt.figure(figsize=(20, 16))
-            plt_fname = f"{x_ax}_clt.png"
-            fig, ax = plt.subplots()
-            # box plot must take element 1 of groupby instance
-            bplot = ax.boxplot([el[1][x_ax] for el in gbcl],
-                               patch_artist=True,
-                               showmeans=False,
-                               )
-            colors = plt.cm.tab20.colors
-            for patch, color in zip(bplot['boxes'], colors):
-                patch.set_facecolor(color)
-            for median, color in zip(bplot['medians'], colors):
-                median.set_color(color)
-            # plot details
-            ax.legend(bplot["boxes"], legend_labels, bbox_to_anchor=(1.0, 1.0))
-            plt.ylabel(AXIS_NAMES[x_ax])
-            plt.xlabel("Cluster rank")
-            plt.tight_layout()
-            plt.savefig(fname=plt_fname, dpi=dpi)
-            plt.close()
-        
+            box_plot_matplotlib(gbcl, y_ax, legend_labels, dpi)
+    return
 
-def scatter_plots(capri_filename, cl_ranking):
+
+def scatter_plot_plotly(gb_cluster, gb_other, cl_rank, x_ax, y_ax, colors):
+    """
+    Create a scatter plot in plotly.
+    
+    Parameters
+    ----------
+    gb_cluster : pandas DataFrameGroupBy
+        capri DataFrame grouped by cluster-id
+    gb_other : pandas DataFrame
+        DataFrame of clusters not in the top cluster ranking
+    cl_rank : dict
+        {cluster_id : cluster_rank} dictionary
+    x_ax : str
+        name of the x column
+    y_ax : str
+        name of the y column
+    colors : list
+        list of colors to be used
+    """
+    fig = go.Figure(layout={"width": 1000, "height": 800})
+    traces = []
+    n_colors = len(colors)
+    for cl_id, cl_df in gb_cluster:
+        if cl_id in cl_rank.keys():
+            if cl_id == "-":
+                cl_name = "Unclustered"
+            else:
+                cl_name = f"Cluster {cl_id}"
+            color_idx = (cl_rank[cl_id] - 1) % n_colors  # color index
+            x_mean = np.mean(cl_df[x_ax])
+            y_mean = np.mean(cl_df[y_ax])
+            text_list = [f"Model: {cl_df['model'].iloc[n].split('/')[-1]}<br>Score: {cl_df['score'].iloc[n]}" for n in range(cl_df.shape[0])]  # noqa:E501
+            traces.append(
+                go.Scatter(
+                    x=cl_df[x_ax],
+                    y=cl_df[y_ax],
+                    name=cl_name,
+                    mode="markers",
+                    text=text_list,
+                    legendgroup=cl_name,
+                    marker_color=colors[color_idx],
+                    hoverlabel=dict(
+                        bgcolor=colors[color_idx],
+                        font_size=16,
+                        font_family="Helvetica"
+                        )
+                    )
+                )
+            clt_text = f"{cl_name}<br>"
+            if 'score' not in [x_ax, y_ax]:
+                clt_text += f"Score: {np.mean(cl_df['score']):.3f}<br>"
+            clt_text += f"{x_ax}: {x_mean:.3f}<br>{y_ax}: {y_mean:.3f}"
+            clt_text_list = [clt_text]
+            traces.append(
+                go.Scatter(
+                    x=[x_mean],
+                    y=[y_mean],
+                    # error bars
+                    error_x=dict(
+                        type='data',
+                        array=[np.std(cl_df[x_ax])],
+                        visible=True),
+                    error_y=dict(
+                        type='data',
+                        array=[np.std(cl_df[y_ax])],
+                        visible=True),
+                    # color and text
+                    marker_color=colors[color_idx],
+                    text=clt_text_list,
+                    legendgroup=cl_name,
+                    showlegend=False,
+                    mode="markers",
+                    marker=dict(
+                        size=10,
+                        symbol="square-dot"),
+                    hovertemplate=f'<b>{clt_text}</b><extra></extra>',
+                    hoverlabel=dict(
+                        bgcolor=colors[color_idx],
+                        font_size=16,
+                        font_family="Helvetica"
+                        )
+                    )
+                )
+    # append trace other
+    if not gb_other.empty:
+        text_list_other = [f"Model: {gb_other['model'].iloc[n].split('/')[-1]}<br>Score: {gb_other['score'].iloc[n]}" for n in range(gb_other.shape[0])]  # noqa:E501
+        traces.append(
+            go.Scatter(
+                x=gb_other[x_ax],
+                y=gb_other[y_ax],
+                name="Other",
+                mode="markers",
+                text=text_list_other,
+                legendgroup="Other",
+                marker=dict(
+                    color="white",
+                    line=dict(
+                        width=2,
+                        color='DarkSlateGrey')
+                    ),
+                hoverlabel=dict(
+                    bgcolor="white",
+                    font_size=16,
+                    font_family="Helvetica"
+                    )
+                )
+            )
+    for trace in traces:
+        fig.add_trace(trace)
+    px_fname = f"{x_ax}_{y_ax}.html"
+    update_layout_plotly(fig,
+                         TITLE_NAMES[x_ax],
+                         TITLE_NAMES[y_ax],
+                         title=f"{TITLE_NAMES[x_ax]} vs {TITLE_NAMES[y_ax]}")
+    fig.write_html(px_fname, full_html=False, include_plotlyjs='cdn')
+    return
+
+
+def scatter_plot_matplotlib(gbcl, gb_other, cl_rank, x_ax, y_ax, colors, dpi):
+    """
+    Create a scatter plot in matplotlib.
+    
+    Parameters
+    ----------
+    gbcl : pandas DataFrameGroupBy
+        capri DataFrame grouped by cluster-id.
+    gb_other : pandas DataFrame
+        DataFrame of clusters not in the top cluster ranking.
+    cl_rank : dict
+        {cluster_id : cluster_rank} dictionary.
+    x_ax : str
+        name of the x column.
+    y_ax : str
+        name of the y column.
+    colors : list
+        list of colors to be used.
+    dpi : int
+        DPI for png images.
+    """
+    plt.figure(figsize=(20, 16))
+    for cl_id, cl_df in gbcl:
+        if cl_id not in cl_rank.keys():
+            gb_other = pd.concat([gb_other, cl_df])
+        else:
+            if cl_id == "-":
+                cl_name = "Unclustered"
+            else:
+                cl_name = f"Cluster {cl_id}"
+            color_idx = (cl_rank[cl_id] - 1) % len(colors)  # color index
+            plt.scatter(x=cl_df[x_ax],
+                        y=cl_df[y_ax],
+                        color=colors[color_idx],
+                        label=cl_name,
+                        s=40)
+    update_layout_matplotlib(TITLE_NAMES[x_ax], TITLE_NAMES[y_ax])
+    plt_fname = f"{x_ax}_{y_ax}.png"
+    plt.savefig(plt_fname, dpi=dpi)
+    # creating full picture
+    if not gb_other.empty:
+        plt.scatter(
+            x=gb_other[x_ax],
+            y=gb_other[y_ax],
+            color="gray",
+            label="Other",
+            s=10,
+            )
+        # details
+        update_layout_matplotlib(TITLE_NAMES[x_ax], TITLE_NAMES[y_ax])
+        plt_fname = f"{x_ax}_{y_ax}_full.png"
+        plt.savefig(plt_fname, dpi=dpi)
+    plt.close()
+    return
+
+
+def scatter_plot_data(capri_df, cl_rank):
+    """
+    Retrieve scatter plot data.
+
+    Parameters
+    ----------
+    capri_df : pandas DataFrame
+        capri table dataframe
+    cl_rank : dict
+        {cluster_id : cluster_rank} dictionary
+    
+    Returns
+    -------
+    gb_cluster : pandas DataFrameGroupBy
+        capri DataFrame grouped by cluster-id
+    gb_other : pandas DataFrame
+        DataFrame of clusters not in the top cluster ranking
+    """
+    gb_cluster = capri_df.groupby("cluster-id")
+    gb_other = pd.DataFrame([])
+    for cl_id, cl_df in gb_cluster:
+        if cl_id not in cl_rank.keys():
+            gb_other = pd.concat([gb_other, cl_df])
+    return gb_cluster, gb_other
+
+
+def scatter_plot_handler(capri_filename, cl_rank, png, dpi):
     """
     Create scatter plots.
 
@@ -189,205 +517,35 @@ def scatter_plots(capri_filename, cl_ranking):
     ----------
     capri_filename : str or Path
         capri single structure filename
-    cl_ranking : dict
+    cl_rank : dict
         {cluster_id : cluster_rank} dictionary
-    """
-    capri_df = read_capri_table(capri_filename, comment="#")
-    for x_ax, y_ax in SCATTER_PAIRS[:1]:
-        if x_ax not in capri_df.columns:
-            log.warning(f"x axis quantity {x_ax} not present in capri table")
-            continue
-        if y_ax not in capri_df.columns:
-            log.warning(f"y axis quantity {y_ax} not present in capri table")
-            continue
-        
-        gb_cluster = capri_df.groupby("cluster-id")
-        gb_other = pd.DataFrame([])
-        fig = go.Figure(layout={"width": 1000, "height": 800})
-        traces = []
-        # defining colors
-        colors = px_colors.qualitative.Alphabet
-        n_colors = len(colors)
-        for cl_id, cl_df in gb_cluster:
-            if cl_id not in cl_ranking.keys():
-                gb_other = pd.concat([gb_other, cl_df])
-            else:
-                if cl_id == "-":
-                    cl_name = "Unclustered"
-                else:
-                    cl_name = f"Cluster {cl_id}"
-                color_idx = (cl_ranking[cl_id] - 1) % n_colors  # color index
-                x_mean = np.mean(cl_df[x_ax])
-                y_mean = np.mean(cl_df[y_ax])
-                text_list = [f"Model: {cl_df['model'].iloc[n].split('/')[-1]}<br>Score: {cl_df['score'].iloc[n]}" for n in range(cl_df.shape[0])]  # noqa:E501
-                traces.append(
-                    go.Scatter(
-                        x=cl_df[x_ax],
-                        y=cl_df[y_ax],
-                        name=cl_name,
-                        mode="markers",
-                        text=text_list,
-                        legendgroup=cl_name,
-                        marker_color=colors[color_idx],
-                        hoverlabel=dict(
-                            bgcolor=colors[color_idx],
-                            font_size=16,
-                            font_family="Helvetica"
-                            )
-                        )
-                    )
-                clt_text = f"{cl_name}<br>"
-                if 'score' not in [x_ax, y_ax]:
-                    clt_text += f"Score: {np.mean(cl_df['score']):.3f}<br>"
-                clt_text += f"{x_ax}: {x_mean:.3f}<br>{y_ax}: {y_mean:.3f}"
-                clt_text_list = [clt_text]
-                traces.append(
-                    go.Scatter(
-                        x=[x_mean],
-                        y=[y_mean],
-                        # error bars
-                        error_x=dict(
-                            type='data',
-                            array=[np.std(cl_df[x_ax])],
-                            visible=True),
-                        error_y=dict(
-                            type='data',
-                            array=[np.std(cl_df[y_ax])],
-                            visible=True),
-                        # color and text
-                        marker_color=colors[color_idx],
-                        text=clt_text_list,
-                        legendgroup=cl_name,
-                        showlegend=False,
-                        mode="markers",
-                        marker=dict(
-                            size=10,
-                            symbol="square-dot"),
-                        hovertemplate=f'<b>{clt_text}</b><extra></extra>',
-                        hoverlabel=dict(
-                            bgcolor=colors[color_idx],
-                            font_size=16,
-                            font_family="Helvetica"
-                            )
-                        )
-                    )
-        # append trace other
-        if not gb_other.empty:
-            text_list_other = [f"Model: {gb_other['model'].iloc[n].split('/')[-1]}<br>Score: {gb_other['score'].iloc[n]}" for n in range(gb_other.shape[0])]  # noqa:E501
-            traces.append(
-                go.Scatter(
-                    x=gb_other[x_ax],
-                    y=gb_other[y_ax],
-                    name="Other",
-                    mode="markers",
-                    text=text_list_other,
-                    legendgroup="Other",
-                    marker=dict(
-                        color="white",
-                        line=dict(
-                            width=2,
-                            color='DarkSlateGrey')
-                        ),
-                    hoverlabel=dict(
-                        bgcolor="white",
-                        font_size=16,
-                        font_family="Helvetica"
-                        )
-                    )
-                )
-        for trace in traces:
-            fig.add_trace(trace)
-        px_fname = f"{x_ax}_{y_ax}.html"
-
-        fig.update_layout(
-            title=f"{TITLE_NAMES[x_ax]} vs {TITLE_NAMES[y_ax]}",
-            xaxis=dict(
-                title=AXIS_NAMES[x_ax],
-                tickfont_size=14,
-                titlefont_size=40,
-                ),
-            yaxis=dict(
-                title=AXIS_NAMES[y_ax],
-                tickfont_size=14,
-                titlefont_size=40,
-                ),
-            legend=dict(x=1.01, y=1.0, font_family="Helvetica", font_size=16),
-            hoverlabel=dict(font_size=16, font_family="Helvetica"),
-            )
-
-        fig.write_html(px_fname, full_html=False, include_plotlyjs='cdn')
-        
-
-def scatter_plots_png(capri_filename, cl_ranking, dpi):
-    """
-    Create scatter plots in png format.
-
-    analogous to scatter_plots, but here the plots are saved in png format.
-
-    Parameters
-    ----------
-    capri_filename : str or Path
-        capri single structure filename
-    cl_ranking : dict
-        {cluster_id : cluster_rank} dictionary
+    png : bool
+        Produce png images.
     dpi : int
         DPI for png images.
     """
     capri_df = read_capri_table(capri_filename, comment="#")
+    gb_cluster, gb_other = scatter_plot_data(capri_df, cl_rank)
+    
+    # defining colors
+    colors = px_colors.qualitative.Alphabet
     for x_ax, y_ax in SCATTER_PAIRS:
-        if x_ax not in capri_df.columns:
-            log.warning(f"x axis quantity {x_ax} not present in capri table")
+        if not in_capri(x_ax, capri_df.columns):
             continue
-        if y_ax not in capri_df.columns:
-            log.warning(f"y axis quantity {y_ax} not present in capri table")
+        if not in_capri(y_ax, capri_df.columns):
             continue
-        gb_cluster = capri_df.groupby("cluster-id")
-        gb_other = pd.DataFrame([])
-        # defining colors
-        colors = px_colors.qualitative.Alphabet
-        n_colors = len(colors)
-        plt.figure(figsize=(20, 16))
-        for cl_id, cl_df in gb_cluster:
-            if cl_id not in cl_ranking.keys():
-                gb_other = pd.concat([gb_other, cl_df])
-            else:
-                if cl_id == "-":
-                    cl_name = "Unclustered"
-                else:
-                    cl_name = f"Cluster {cl_id}"
-                color_idx = (cl_ranking[cl_id] - 1) % n_colors  # color index
-                plt.scatter(x=cl_df[x_ax],
-                            y=cl_df[y_ax],
-                            color=colors[color_idx],
-                            label=cl_name,
-                            s=40)
-        plt.title(f"{TITLE_NAMES[x_ax]} vs {TITLE_NAMES[y_ax]}", fontsize=40)
-        plt.xlabel(AXIS_NAMES[x_ax], fontsize=40)
-        plt.ylabel(AXIS_NAMES[y_ax], fontsize=40)
-        plt.xticks(fontsize=20)
-        plt.yticks(fontsize=20)
-        legend = plt.legend(bbox_to_anchor=(1.0, 1.0), fontsize=30)
-        for handle in legend.legendHandles:
-            handle.set_sizes([150])
-        plt_fname = f"{x_ax}_{y_ax}.png"
-        plt.tight_layout()
-        plt.savefig(plt_fname, dpi=dpi)
-
-        # creating full picture
-        if not gb_other.empty:
-            plt.scatter(
-                x=gb_other[x_ax],
-                y=gb_other[y_ax],
-                color="gray",
-                label="Other",
-                s=10,
-                )
-            # details
-            legend = plt.legend(bbox_to_anchor=(1.0, 1.0), fontsize=30)
-            for handle in legend.legendHandles:
-                handle.set_sizes([150])
-            plt_fname = f"{x_ax}_{y_ax}_full.png"
-            plt.tight_layout()
-            plt.savefig(plt_fname, dpi=dpi)
-        plt.close()
-        
+        scatter_plot_plotly(gb_cluster,
+                            gb_other,
+                            cl_rank,
+                            x_ax,
+                            y_ax,
+                            colors)
+        if png:
+            scatter_plot_matplotlib(gb_cluster,
+                                    gb_other,
+                                    cl_rank,
+                                    x_ax,
+                                    y_ax,
+                                    colors,
+                                    dpi)
+    return

--- a/src/haddock/libs/libplots.py
+++ b/src/haddock/libs/libplots.py
@@ -83,7 +83,7 @@ def read_capri_table(capri_filename, comment="#"):
     return capri_df
 
 
-def box_plots(capri_filename, cl_ranking, png):
+def box_plots(capri_filename, cl_ranking, png, dpi):
     """
     Create box plots.
 
@@ -96,6 +96,10 @@ def box_plots(capri_filename, cl_ranking, png):
         capri single structure filename
     cl_ranking : dict
         {cluster_id : cluster_rank} dictionary
+    png : bool
+        Produce png images.
+    dpi : int
+        DPI for png images.
     """
     # generating the correct dataframe
     capri_df = read_capri_table(capri_filename, comment="#")
@@ -169,7 +173,7 @@ def box_plots(capri_filename, cl_ranking, png):
             plt.ylabel(AXIS_NAMES[x_ax])
             plt.xlabel("Cluster rank")
             plt.tight_layout()
-            plt.savefig(fname=plt_fname, dpi=200)
+            plt.savefig(fname=plt_fname, dpi=dpi)
             plt.close()
         
 
@@ -314,7 +318,7 @@ def scatter_plots(capri_filename, cl_ranking):
         fig.write_html(px_fname, full_html=False, include_plotlyjs='cdn')
         
 
-def scatter_plots_png(capri_filename, cl_ranking):
+def scatter_plots_png(capri_filename, cl_ranking, dpi):
     """
     Create scatter plots in png format.
 
@@ -326,6 +330,8 @@ def scatter_plots_png(capri_filename, cl_ranking):
         capri single structure filename
     cl_ranking : dict
         {cluster_id : cluster_rank} dictionary
+    dpi : int
+        DPI for png images.
     """
     capri_df = read_capri_table(capri_filename, comment="#")
     for x_ax, y_ax in SCATTER_PAIRS:
@@ -365,7 +371,7 @@ def scatter_plots_png(capri_filename, cl_ranking):
             handle.set_sizes([150])
         plt_fname = f"{x_ax}_{y_ax}.png"
         plt.tight_layout()
-        plt.savefig(plt_fname, dpi=200)
+        plt.savefig(plt_fname, dpi=dpi)
 
         # creating full picture
         if not gb_other.empty:
@@ -382,6 +388,6 @@ def scatter_plots_png(capri_filename, cl_ranking):
                 handle.set_sizes([150])
             plt_fname = f"{x_ax}_{y_ax}_full.png"
             plt.tight_layout()
-            plt.savefig(plt_fname, dpi=200)
+            plt.savefig(plt_fname, dpi=dpi)
         plt.close()
         


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and you comply with the following criteria:

- [x] You have stick to Python. Talk with us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [x] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [ ] You structured the code into small functions as much as possible. You can use classes if there's a (state) purpose
- [x] code follows our coding style
- [ ] You wrote tests for the new code
- [x] `tox` tests pass. *Run `tox` command inside the repository folder*
- [ ] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [x] PR does not add any *install dependencies* unless permission granted by the HADDOCK team
- [x] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---

Closes #601 

Now the user can get static png scatter plots and box plots by adding the `--png` flag while running `haddock3-analyse`

Example:
`haddock3-analyse -r examples/docking-antibody-antigen/run1-ranairCDR-cltsel-test/ -m 5 --png=True
`