### PR TITLE
solve unicode problem in restarting and copying runs

### DIFF
--- a/src/haddock/gear/extend_run.py
+++ b/src/haddock/gear/extend_run.py
@@ -256,7 +256,11 @@ def update_contents_of_new_steps(selected_steps, olddir, newdir):
     for ns in new_steps:
         new_step = Path(newdir, ns)
         for file_ in new_step.iterdir():
-            text = file_.read_text()
+            try:
+                text = file_.read_text()
+            except UnicodeDecodeError as err:
+                log.warning(f"Failed to read file {file_}. Error is {err}")
+                continue
             for s1, s2 in zip(selected_steps, new_steps):
                 text = text.replace(s1, s2)
             text = text.replace(olddir.name, newdir.name)

--- a/src/haddock/gear/prepare_run.py
+++ b/src/haddock/gear/prepare_run.py
@@ -934,7 +934,11 @@ def update_step_names_in_subfolders(folder, prev_names, new_names):
 
 def update_step_names_in_file(file_, prev_names, new_names):
     """Update step names in file following the `--restart` option."""
-    text = file_.read_text()
+    try:
+        text = file_.read_text()
+    except UnicodeDecodeError as err:
+        log.warning(f"Failed to read file {file_}. Error is {err}")
+        return
     for s1, s2 in zip(prev_names, new_names):
         text = text.replace(s1, s2)
     file_.write_text(text)


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and you comply with the following criteria:

- [ ] You have stick to Python. Talk with us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [ ] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [ ] You structured the code into small functions as much as possible. You can use classes if there's a (state) purpose
- [ ] code follows our coding style
- [ ] You wrote tests for the new code
- [ ] `tox` tests pass. *Run `tox` command inside the repository folder*
- [ ] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [ ] PR does not add any *install dependencies* unless permission granted by the HADDOCK team
- [ ] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---

Closes #558 by adding a try except on UnicodeDecodeError. I still find the whole procedure of restarting quite complex and resource and time-consuming..