### PR TITLE
Adjust clustrmsd

### DIFF
--- a/examples/analysis/topoaa-rmsdmatrix-clustrmsd-test.cfg
+++ b/examples/analysis/topoaa-rmsdmatrix-clustrmsd-test.cfg
@@ -22,3 +22,4 @@ dielec="jogn"
 [clustrmsd]
 criterion="distance"
 tolerance=7.5
+threshold=2

--- a/src/haddock/libs/libclust.py
+++ b/src/haddock/libs/libclust.py
@@ -42,6 +42,6 @@ def write_structure_list(input_models, clustered_models, out_fname):
             f'{os.linesep}'
             )
     output_str += os.linesep
-    log.info('Saving structure list to clustfcc.tsv')
+    log.info(f'Saving structure list to {out_fname}')
     with open(output_fname, 'w') as out_fh:
         out_fh.write(output_str)

--- a/src/haddock/modules/analysis/clustrmsd/__init__.py
+++ b/src/haddock/modules/analysis/clustrmsd/__init__.py
@@ -139,7 +139,7 @@ class HaddockModule(BaseHaddockModule):
             # rank the models
             for model_ranking, pdb in enumerate(clt_dic[cluster_id],
                                                 start=1):
-                pdb.clt_id = cluster_id
+                pdb.clt_id = int(cluster_id)
                 pdb.clt_rank = cluster_rank
                 pdb.clt_model_rank = model_ranking
                 self.output_models.append(pdb)

--- a/src/haddock/modules/analysis/clustrmsd/__init__.py
+++ b/src/haddock/modules/analysis/clustrmsd/__init__.py
@@ -43,7 +43,7 @@ from haddock.libs.libclust import write_structure_list
 from haddock.libs.libontology import ModuleIO
 from haddock.modules import BaseHaddockModule
 from haddock.modules.analysis.clustrmsd.clustrmsd import (
-    apply_threshold,
+    iterate_threshold,
     get_clusters,
     get_cluster_center,
     get_dendrogram,
@@ -102,8 +102,12 @@ class HaddockModule(BaseHaddockModule):
                 raise Exception(f"unknown criterion {crit}")
         log.info(f"tolerance {tol}")
         cluster_arr = get_clusters(dendrogram, tol, crit)
+
+        # when crit == distance, apply clustering threshold
         if crit == "distance":
-            cluster_arr = apply_threshold(cluster_arr, threshold)
+            cluster_arr = iterate_threshold(cluster_arr, threshold)
+
+        # print clusters
         unq_clusters = np.unique(cluster_arr)  # contains -1 (unclustered)
         clusters = [c for c in unq_clusters if c != -1]
         log.info(f"clusters = {clusters}")

--- a/src/haddock/modules/analysis/clustrmsd/clustrmsd.py
+++ b/src/haddock/modules/analysis/clustrmsd/clustrmsd.py
@@ -9,10 +9,22 @@ from haddock.libs.libontology import RMSDFile
 
 
 def read_matrix(rmsd_matrix):
-    """Read the RMSD matrix."""
+    """
+    Read the RMSD matrix.
+    
+    Parameters
+    ----------
+    rmsd_matrix : :obj:`RMSDFile`
+        RMSDFile object with the path to the RMSD matrix.
+    
+    Returns
+    -------
+    matrix : :obj:`numpy.ndarray`
+        Numpy array with the RMSD matrix.
+    """
     if not isinstance(rmsd_matrix, RMSDFile):
         err = f"{type(rmsd_matrix)} is not a RMSDFile object."
-        raise Exception(err)
+        raise TypeError(err)
     filename = Path(rmsd_matrix.path, rmsd_matrix.file_name)
     # count lines
     nlines = sum(1 for line in open(filename))
@@ -32,7 +44,7 @@ def read_matrix(rmsd_matrix):
         for line in mf:
             data = line.split()
             if len(data) != 3:
-                raise Exception(f"line {line} malformed")
+                raise ValueError(f"line {line} malformed")
             else:
                 matrix[[c]] = float(data[2])
                 c += 1
@@ -50,3 +62,50 @@ def get_clusters(dendrogram, tolerance, criterion):
     log.info('Clustering dendrogram...')
     cluster_list = fcluster(dendrogram, t=tolerance, criterion=criterion)
     return cluster_list
+
+
+def cond_index(i, j, n):
+    """
+    Get the condensed index from two matrix indexes.
+
+    Parameters
+    ----------
+    i : int
+        Index of the first element.
+    j : int
+        Index of the second element.
+    n : int
+        Number of observations.
+    """
+    return n * (n - 1) / 2 - (n - i) * (n - i - 1) / 2 + j - i - 1
+
+
+def get_cluster_center(npw, n_obs, rmsd_matrix):
+    """
+    Get the cluster centers.
+
+    Parameters
+    ----------
+    clusters : list
+        List of clusters.
+    cluster_list : list
+        List of clustered observations.
+    rmsd_matrix : array
+        List of RMSD values.
+
+    Returns
+    -------
+    cluster_center : int
+        Index of cluster center
+    """
+    intra_cl_distances = {el: 0.0 for el in npw}
+    
+    # iterating over the elements of the cluster
+    for m_idx in range(len(npw)):
+        npws = npw[m_idx + 1:]
+        pairs = [int(cond_index(npw[m_idx], npw_el, n_obs)) for npw_el in npws]
+        for pair_idx in range(len(pairs)):
+            intra_cl_distances[npw[m_idx]] += rmsd_matrix[pairs[pair_idx]]
+            intra_cl_distances[npws[pair_idx]] += rmsd_matrix[pairs[pair_idx]]
+    cluster_center = min(intra_cl_distances, key=intra_cl_distances.get)
+    return cluster_center

--- a/src/haddock/modules/analysis/clustrmsd/clustrmsd.py
+++ b/src/haddock/modules/analysis/clustrmsd/clustrmsd.py
@@ -96,6 +96,33 @@ def apply_threshold(cluster_arr, threshold):
     return new_cluster_arr
 
 
+def iterate_threshold(cluster_arr, threshold):
+    """
+    Iterate over the threshold values until we find at least one valid cluster.
+
+    Parameters
+    ----------
+    cluster_arr : np.ndarray
+        Array of clusters.
+    threshold : int
+        Threshold value on cluster population.
+
+    Returns
+    -------
+    new_cluster_arr : np.ndarray
+        Array of clusters (unclustered structures are labelled with -1)
+    """
+    for curr_thr in range(threshold, 0, -1):
+        log.info(f'Clustering with threshold={curr_thr}')
+        new_cluster_arr = apply_threshold(cluster_arr, curr_thr)
+        ncl = len(np.unique(new_cluster_arr))
+        if ncl <= 1:  # contains -1 (unclustered)
+            log.warning(f'No clusters found with threshold={curr_thr}')
+        else:
+            break
+    return new_cluster_arr
+
+
 def cond_index(i, j, n):
     """
     Get the condensed index from two matrix indexes.

--- a/src/haddock/modules/analysis/clustrmsd/defaults.yaml
+++ b/src/haddock/modules/analysis/clustrmsd/defaults.yaml
@@ -46,7 +46,7 @@ tolerance:
   max: 9999
   precision: 3
   title: Numeric value for clustering
-  short: if criterion is maxclust, the number of desired clusters. if criterion is distance, the value of cophenetic distance
-  long: No long description yet
+  short: if criterion is maxclust, the number of desired clusters. if criterion is distance, the value of cutoff cophenetic distance
+  long: if criterion is maxclust, the number of desired clusters. if criterion is distance, the value of cutoff cophenetic distance
   group: ''
   explevel: easy

--- a/src/haddock/modules/analysis/clustrmsd/defaults.yaml
+++ b/src/haddock/modules/analysis/clustrmsd/defaults.yaml
@@ -12,7 +12,7 @@ criterion:
   - distance
   - maxclust
 linkage:
-  default: "single"
+  default: "average"
   type: "string"
   minchars: 0
   maxchars: 100

--- a/src/haddock/modules/analysis/clustrmsd/defaults.yaml
+++ b/src/haddock/modules/analysis/clustrmsd/defaults.yaml
@@ -35,8 +35,8 @@ threshold:
   min: 1
   max: 9999
   title: Clustering population threshold
-  short: No short description yet
-  long: No long description yet
+  short: Threshold employed to exclude clusters with less than this number of members
+  long: Threshold employed to exclude clusters with less than this number of members. When criterion is maxclust, this value is ignored.
   group: ''
   explevel: easy
 tolerance:

--- a/src/haddock/modules/analysis/rmsdmatrix/rmsd.py
+++ b/src/haddock/modules/analysis/rmsdmatrix/rmsd.py
@@ -174,7 +174,7 @@ def get_pair(nmodels, idx):
     if (nmodels < 0 or idx < 0):
         err = "get_pair cannot accept negative numbers"
         err += f"Input is {nmodels} , {idx}"
-        raise Exception(err)
+        raise ValueError(err)
     # solve the second degree equation
     b = 1 - (2 * nmodels)
     i = (-b - np.sqrt(b ** 2 - 8 * idx)) // 2

--- a/tests/test_module_clustrmsd.py
+++ b/tests/test_module_clustrmsd.py
@@ -9,7 +9,9 @@ from haddock.libs.libontology import ModuleIO, PDBFile, RMSDFile
 from haddock.modules.analysis.clustrmsd import DEFAULT_CONFIG as clustrmsd_pars
 from haddock.modules.analysis.clustrmsd import HaddockModule
 from haddock.modules.analysis.clustrmsd.clustrmsd import (
+    cond_index,
     get_clusters,
+    get_cluster_center,
     get_dendrogram,
     read_matrix,
     )
@@ -24,7 +26,7 @@ def output_list():
     """Clustfcc output list."""
     return [
         "rmsd.matrix",
-        "rmsd_matrix.json"
+        "rmsd_matrix.json",
         "cluster.out",
         "clustrmsd.txt",
         "clustrmsd.tsv",
@@ -160,10 +162,10 @@ def test_read_matrix_input(correct_rmsd_vec):
     write_rmsd_matrix(output_name, rmsd_vec)
 
     # testing input : has to be RMSDFile
-    with pytest.raises(Exception):
+    with pytest.raises(TypeError):
         read_matrix(output_name)
     
-    with pytest.raises(Exception):
+    with pytest.raises(TypeError):
         read_matrix(Path(output_name))
 
     os.unlink(output_name)
@@ -182,8 +184,8 @@ def test_read_matrix_binomial(short_rmsd_vec):
 
     matrix_json = read_rmsd_json(json_name)
 
-    with pytest.raises(Exception):
-        read_matrix(matrix_json)
+    with pytest.raises(ValueError):
+        read_matrix(matrix_json.input[0])
     
     os.unlink(json_name)
     os.unlink(output_name)
@@ -202,8 +204,8 @@ def test_read_matrix_npairs(correct_rmsd_vec):
 
     matrix_json = read_rmsd_json(json_name)
 
-    with pytest.raises(Exception):
-        read_matrix(matrix_json)
+    with pytest.raises(ValueError):
+        read_matrix(matrix_json.input[0])
     
     os.unlink(json_name)
     os.unlink(output_name)
@@ -221,9 +223,9 @@ def test_read_matrix_malformed(malformed_rmsd_vec):
     save_rmsd_json(output_name, json_name, 3)
 
     matrix_json = read_rmsd_json(json_name)
-
-    with pytest.raises(Exception):
-        read_matrix(matrix_json)
+    
+    with pytest.raises(ValueError):
+        read_matrix(matrix_json.input[0])
     
     os.unlink(json_name)
     os.unlink(output_name)
@@ -285,13 +287,41 @@ def test_correct_output(input_protdna_models, output_list):
 
     assert expected_txt_filename in ls
 
-    expected_out_content = "Cluster 1 -> 1 2"
+    expected_out_content = f"Cluster 1 -> 1{os.linesep}Cluster 2 -> 2"
     expected_out_content += os.linesep
 
     observed_out_content = open(expected_out_filename).read()
 
     assert observed_out_content == expected_out_content
 
-    # TODO: check the content of clustrmsd.txt
-
     remove_clustrmsd_files(output_list)
+
+
+def test_get_cluster_center(correct_rmsd_array):
+    """Test get_cluster_center function."""
+    obs_clt_center = get_cluster_center(
+        npw=[0, 1, 2, 3],
+        n_obs=4,
+        rmsd_matrix=correct_rmsd_array
+        )
+    exp_clt_center = 2
+    assert obs_clt_center == exp_clt_center
+    # [1,2,3] cluster. 2 is still the center
+    obs_clt_center = get_cluster_center(
+        npw=[1, 2, 3],
+        n_obs=4,
+        rmsd_matrix=correct_rmsd_array
+        )
+    exp_clt_center = 2
+    assert obs_clt_center == exp_clt_center
+
+
+def test_cond_index():
+    """Test cond_index function."""
+    n_obs = 10
+    idxs = [0, 0, 2, 8]
+    jdxs = [1, 2, 3, 9]
+    len_idxs = len(idxs)
+    obs_c_idxs = [cond_index(idxs[n], jdxs[n], n_obs) for n in range(len_idxs)]
+    exp_c_idxs = [0, 1, 17, 44]
+    assert obs_c_idxs == exp_c_idxs

--- a/tests/test_module_clustrmsd.py
+++ b/tests/test_module_clustrmsd.py
@@ -9,6 +9,7 @@ from haddock.libs.libontology import ModuleIO, PDBFile, RMSDFile
 from haddock.modules.analysis.clustrmsd import DEFAULT_CONFIG as clustrmsd_pars
 from haddock.modules.analysis.clustrmsd import HaddockModule
 from haddock.modules.analysis.clustrmsd.clustrmsd import (
+    apply_threshold,
     cond_index,
     get_clusters,
     get_cluster_center,
@@ -325,3 +326,17 @@ def test_cond_index():
     obs_c_idxs = [cond_index(idxs[n], jdxs[n], n_obs) for n in range(len_idxs)]
     exp_c_idxs = [0, 1, 17, 44]
     assert obs_c_idxs == exp_c_idxs
+
+
+def test_apply_threshold():
+    """Test apply_threshold function."""
+    # defining cluster_arr
+    cluster_arr = np.array([1, 1, 4, 1, 1, 2, 1, 1, 3, 1])
+    # using a threshold of 2
+    obs_cluster_arr = apply_threshold(cluster_arr, 2)
+    exp_cluster_arr = np.array([1, 1, -1, 1, 1, -1, 1, 1, -1, 1])
+    assert (obs_cluster_arr == exp_cluster_arr).all()
+    # using a threshold of 1
+    obs_cluster_arr = apply_threshold(cluster_arr, threshold=1)
+    exp_cluster_arr = np.array([1, 1, 4, 1, 1, 2, 1, 1, 3, 1])
+    assert (obs_cluster_arr == exp_cluster_arr).all()

--- a/tests/test_module_clustrmsd.py
+++ b/tests/test_module_clustrmsd.py
@@ -14,6 +14,7 @@ from haddock.modules.analysis.clustrmsd.clustrmsd import (
     get_clusters,
     get_cluster_center,
     get_dendrogram,
+    iterate_threshold,
     read_matrix,
     )
 from haddock.modules.analysis.rmsdmatrix import DEFAULT_CONFIG as rmsd_pars
@@ -339,4 +340,12 @@ def test_apply_threshold():
     # using a threshold of 1
     obs_cluster_arr = apply_threshold(cluster_arr, threshold=1)
     exp_cluster_arr = np.array([1, 1, 4, 1, 1, 2, 1, 1, 3, 1])
+    assert (obs_cluster_arr == exp_cluster_arr).all()
+
+
+def test_iterate_threshold():
+    """Test iterate_threshold function."""
+    cluster_arr = np.array([1, 1, 2, 3, 4])
+    obs_cluster_arr = iterate_threshold(cluster_arr, threshold=4)
+    exp_cluster_arr = np.array([1, 1, -1, -1, -1])
     assert (obs_cluster_arr == exp_cluster_arr).all()

--- a/tests/test_module_rmsdmatrix.py
+++ b/tests/test_module_rmsdmatrix.py
@@ -51,9 +51,9 @@ def test_get_pair_error():
     """Test negative arguments to the get_pair() function."""
     neg_nmodels = -1
     neg_idx = -1
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         get_pair(neg_nmodels, 1)
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         get_pair(1, neg_idx)
 
 


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and that you comply with the following criteria:

- [ ] You have sticked to Python. Please talk to us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [ ] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [ ] You structured the code into small functions as much as possible. You can use classes if there is a (state) purpose
- [ ] Your code follows our coding style
- [ ] You wrote tests for the new code
- [ ] `tox` tests pass. *Run `tox` command inside the repository folder*
- [ ] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [ ] PR does not add any dependencies, unless permission granted by the HADDOCK team
- [ ] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---

Closes #555 by

- adding a function that finds rmsd clustering centers
- adding this cluster center info to the output `clustrmsd.txt` file
- modifying the default linkage criterion to `average`
- improves testing
- implements effectively the clustering threshold for the `distance` (cutoff) criterion, excluding clusters with population < 4 (default threshold). If no cluster is found such that this threshold is respected, the threshold is lowered by 1, as in `clustfcc`