### PR TITLE
make `Path()` accept `Persistent` and it's subclass.

### DIFF
--- a/src/haddock/libs/libalign.py
+++ b/src/haddock/libs/libalign.py
@@ -232,8 +232,7 @@ def load_coords(pdb_f, atoms, filter_resdic=None, numbering_dic=None):
     coord_dic = {}
     chain_dic = {}
     idx = 0
-    if isinstance(pdb_f, PDBFile):
-        pdb_f = pdb_f.rel_path
+    pdb_f = Path(pdb_f)
     with open(pdb_f, "r") as fh:
         for line in fh.readlines():
             if line.startswith("ATOM"):
@@ -314,8 +313,7 @@ def get_atoms(pdb, full=False):
         atom_dic.update(DNA_FULL_DICT)
         atom_dic.update(RNA_FULL_DICT)
 
-    if isinstance(pdb, PDBFile):
-        pdb = pdb.rel_path
+    pdb = Path(pdb)
     
     exists, msg = pdb_path_exists(pdb)
     if not exists:
@@ -392,8 +390,7 @@ def pdb2fastadic(pdb_f):
         )
     seq_dic = {}
 
-    if isinstance(pdb_f, PDBFile):
-        pdb_f = pdb_f.rel_path
+    pdb_f = Path(pdb_f)
 
     with open(pdb_f) as fh:
         for line in fh.readlines():

--- a/src/haddock/libs/libio.py
+++ b/src/haddock/libs/libio.py
@@ -188,10 +188,8 @@ def write_dic_to_file(
         row_l = []
         for element in data_dict:
             value = data_dict[element]
-            if isinstance(value, Path):
-                row_l.append(str(value))
-            elif isinstance(value, PDBFile):
-                row_l.append(str(value.rel_path))
+            if isinstance(value, (Path, PDBFile)):
+                row_l.append(os.fspath(value))
             elif isinstance(value, int):
                 row_l.append(f"{value}")
             elif isinstance(value, str):
@@ -236,10 +234,8 @@ def write_nested_dic_to_file(
             row_l = []
             for element in data_dict[row]:
                 value = data_dict[row][element]
-                if isinstance(value, Path):
-                    row_l.append(str(value))
-                elif isinstance(value, PDBFile):
-                    row_l.append(str(value.rel_path))
+                if isinstance(value, (Path, PDBFile)):
+                    row_l.append(os.fspath(value))
                 elif isinstance(value, int):
                     row_l.append(f"{value}")
                 elif isinstance(value, str):

--- a/src/haddock/libs/libontology.py
+++ b/src/haddock/libs/libontology.py
@@ -55,6 +55,9 @@ class Persistent:
         """Check if the persisent file exists on disk."""
         return self.rel_path.resolve().exists()
 
+    def __fspath__(self) -> str:
+        return str(self.rel_path)
+
 
 class PDBFile(Persistent):
     """Represent a PDB file."""

--- a/src/haddock/modules/analysis/caprieval/capri.py
+++ b/src/haddock/modules/analysis/caprieval/capri.py
@@ -41,8 +41,7 @@ def load_contacts(pdb_f, cutoff=5.0):
         set of unique contacts
     """
     con_list = []
-    if isinstance(pdb_f, PDBFile):
-        pdb_f = pdb_f.rel_path
+    pdb_f = Path(pdb_f)
     # get also side chains atoms
     atoms = get_atoms(pdb_f, full=True)
     ref_coord_dic, _ = load_coords(pdb_f, atoms)
@@ -540,8 +539,7 @@ class CAPRI:
         cutoff : float, optional
             Cutoff distance for the interface identification.
         """
-        if isinstance(pdb_f, PDBFile):
-            pdb_f = pdb_f.rel_path
+        pdb_f = Path(pdb_f)
 
         interface_resdic = {}
         contacts = load_contacts(pdb_f, cutoff)

--- a/src/haddock/modules/analysis/clustfcc/__init__.py
+++ b/src/haddock/modules/analysis/clustfcc/__init__.py
@@ -51,7 +51,7 @@ class HaddockModule(BaseHaddockModule):
         log.info('Calculating contacts')
         contact_jobs = []
         for model in models_to_cluster:
-            pdb_f = Path(model.rel_path)
+            pdb_f = Path(model)
             contact_f = Path(model.file_name.replace('.pdb', '.con'))
             job = JobInputFirst(
                 pdb_f,


### PR DESCRIPTION
Add a `__fspath__` protocal in `Persistent` defination to make `Path()` accept `Persisent` and it' subclass.Type-checking statements related with `Persisent` are simplified.

Functions accepting `Path` or `Persistent` now don't have to use `isinstance()` to check variable types.Use `Path(path)` is enough.

In order to get `Path` or `Persistent`'s string representation, I recommend to use `os.fspath(path)` instead of `str(Path(path))`.

If some variable is `Persistent` only,use `Persistent.rel_path` is better because `Path(pdbfile)` converts `Persistent` to str first then converts to Path,while `Persistent.rel_path` is Path already.
