### PR TITLE
Adding libstdcxx-ng in env

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -158,7 +158,7 @@ information.
 
 1. Install the latest version of openmm and pdbfixer
 ```
-conda install -c conda-forge openmm pdbfixer
+conda install -c conda-forge libstdcxx-ng openmm pdbfixer
 ```
 
 Openmm should automatically detect the fastest platform among those available


### PR DESCRIPTION
Issue with the libstdc++.so.6 library searching for GLIBCXX_3.4.30.
Multiple people run into this issue (https://github.com/openmm/openmm/issues/3943)
Solved by adding the libstdcxx-ng in the conda env

