### PR TITLE
Issuefixes

### DIFF
--- a/src/haddock/gear/config.py
+++ b/src/haddock/gear/config.py
@@ -163,10 +163,14 @@ def loads(cfg_str):
 
     Returns
     -------
-    dict
-        The config in the form of a dictionary.
-        The order of the keys matters as it defines the order of the
-        steps in the workflow.
+    all_configs : dict
+        A dictionary holding all the configuration file steps:
+        - 'raw_input': Original input file as provided by user.
+        - 'cleaned_input': Regex cleaned input file.
+        - 'loaded_cleaned_input': Dict of toml loaded cleaned input.
+        - 'final_cfg': The config in the form of a dictionary. In which
+          the order of the keys matters as it defines the order of the
+          steps in the workflow.
     """
     new_lines = []
     cfg_lines = cfg_str.split(os.linesep)
@@ -209,10 +213,11 @@ def loads(cfg_str):
 
         new_lines.append(new_line)
 
+    # Re-build workflow configuration file
     cfg = os.linesep.join(new_lines)
 
     try:
-        cfg_dict = toml.loads(cfg)
+        cfg_dict = toml.loads(cfg)  # Try to load it with the toml library
     except Exception as err:
         raise ConfigurationError(
             "Some thing is wrong with the config file: "
@@ -221,7 +226,15 @@ def loads(cfg_str):
 
     final_cfg = convert_variables_to_paths(cfg_dict)
 
-    return final_cfg
+    all_configs = {
+        'raw_input': cfg_str,
+        'cleaned_input': cfg,
+        'loaded_cleaned_input': cfg_dict,
+        'final_cfg': final_cfg,
+        }
+
+    # Return all configuration steps
+    return all_configs
 
 
 def convert_variables_to_paths(cfg):

--- a/src/haddock/gear/config.py
+++ b/src/haddock/gear/config.py
@@ -202,7 +202,7 @@ def loads(cfg_str):
         elif group := _uppercase_bool_re.match(line):
             param = group[1]  # Catches 'param = '
             uppercase_bool = group[4]
-            new_line = f"{param}{uppercase_bool.lower()}" # Lower boolean value
+            new_line = f"{param}{uppercase_bool.lower()}"  # Lowercase bool
 
         else:
             new_line = line

--- a/src/haddock/gear/config.py
+++ b/src/haddock/gear/config.py
@@ -90,6 +90,12 @@ _sub_quoted_header_re = re.compile(
     re.ASCII,
     )
 
+# Captures parameter uppercase boolean
+_uppercase_bool_re = re.compile(
+    r'(_?\w+((_?\w+?)+)?\s*=\s*)(True|False)',
+    re.ASCII
+    )
+
 # Some parameters are paths. The configuration reader reads those as
 # pathlib.Path so that they are injected properly in the rest of the
 # workflow. In general, any parameter ending with `_fname` is a path,
@@ -192,6 +198,11 @@ def loads(cfg_str):
             name = group[1]
             count = counter[name]  # name should be already defined here
             new_line = f"['{name}.{count}'{group[2]}]"
+
+        elif group := _uppercase_bool_re.match(line):
+            param = group[1]  # Catches 'param = '
+            uppercase_bool = group[4]
+            new_line = f"{param}{uppercase_bool.lower()}" # Lower boolean value
 
         else:
             new_line = line

--- a/src/haddock/gear/prepare_run.py
+++ b/src/haddock/gear/prepare_run.py
@@ -325,7 +325,7 @@ def setup_run(
     enhanced_haddock_params = deepcopy(general_params)
     enhanced_haddock_params.update(modules_params)
     config_files['enhanced_haddock_params'] = enhanced_haddock_params
-    config_saves = save_configuration_files(config_files, data_dir)
+    config_saves = save_configuration_files(config_files, data_dir)  # noqa : F841
 
     if scratch_rest0:
         copy_molecules_to_data_dir(

--- a/src/haddock/gear/prepare_run.py
+++ b/src/haddock/gear/prepare_run.py
@@ -525,7 +525,7 @@ def validate_modules_params(modules_params, max_mols):
                 )
             raise ConfigurationError(_msg)
 
-        # Now that existance of the parameter was checked,
+        # Now that existence of the parameter was checked,
         # it is time to validate the type and value taken by this param
         validate_module_params_values(module_name, args)
 

--- a/src/haddock/gear/yaml2cfg.py
+++ b/src/haddock/gear/yaml2cfg.py
@@ -119,13 +119,32 @@ def _yaml2cfg_text(ycfg, module, explevel):
     return os.linesep.join(params)
 
 
-def read_from_yaml_config(cfg_file):
-    """Read config from yaml by collapsing the expert levels."""
+def read_from_yaml_config(cfg_file, default_only=True) -> dict:
+    """Read config from yaml by collapsing the expert levels.
+    
+    Parameters
+    ----------
+    cfg_file :
+        Path to a .yaml configuration file
+    default_only : bool
+        Set the return value of this function; if True (default value), only
+        returns default values, else return the fully loaded configuration file
+
+    Return
+    ------
+    ycfg : dict
+        The full default configuration file as a dict
+    OR
+    cfg : dict
+        A dictionnary containing only the default parameters values
+    """
     ycfg = read_from_yaml(cfg_file)
-    # there's no need to make a deep copy here, a shallow copy suffices.
-    cfg = {}
-    cfg.update(flat_yaml_cfg(ycfg))
-    return cfg
+    if default_only:
+        # there's no need to make a deep copy here, a shallow copy suffices.
+        cfg = {}
+        cfg.update(flat_yaml_cfg(ycfg))
+        return cfg
+    return ycfg
 
 
 def flat_yaml_cfg(cfg):

--- a/src/haddock/gear/yaml2cfg.py
+++ b/src/haddock/gear/yaml2cfg.py
@@ -136,7 +136,7 @@ def read_from_yaml_config(cfg_file, default_only=True) -> dict:
         The full default configuration file as a dict
     OR
     cfg : dict
-        A dictionnary containing only the default parameters values
+        A dictionary containing only the default parameters values
     """
     ycfg = read_from_yaml(cfg_file)
     if default_only:

--- a/src/haddock/modules/refinement/emref/defaults.yaml
+++ b/src/haddock/modules/refinement/emref/defaults.yaml
@@ -1178,7 +1178,7 @@ w_elec:
 w_lcc:
   default: -10000.0
   type: float
-  min: -9999
+  min: -10000.0
   max: 0
   precision: 3
   title: Weight of the EM local correlation coefficient

--- a/src/haddock/modules/refinement/flexref/defaults.yaml
+++ b/src/haddock/modules/refinement/flexref/defaults.yaml
@@ -1515,7 +1515,7 @@ w_elec:
 w_lcc:
   default: -10000.0
   type: float
-  min: -9999
+  min: -10000.0
   max: 0
   precision: 3
   title: Weight of the EM local correlation coefficient
@@ -1524,7 +1524,7 @@ w_lcc:
   group: 'scoring'
   explevel: hidden
 w_rg:
-  default: 1.0
+  default: 1.000
   type: float
   min: 0
   max: 9999

--- a/src/haddock/modules/refinement/mdref/defaults.yaml
+++ b/src/haddock/modules/refinement/mdref/defaults.yaml
@@ -1217,7 +1217,7 @@ w_elec:
 w_lcc:
   default: -10000.0
   type: float
-  min: -9999
+  min: -10000.0
   max: 0
   precision: 3
   title: Weight of the EM local correlation coefficient

--- a/src/haddock/modules/scoring/emscoring/defaults.yaml
+++ b/src/haddock/modules/scoring/emscoring/defaults.yaml
@@ -86,7 +86,7 @@ w_elec:
 w_lcc:
   default: -10000.0
   type: float
-  min: -9999
+  min: -10000.0
   max: 0
   precision: 3
   title: Weight of the EM local correlation coefficient

--- a/src/haddock/modules/scoring/mdscoring/defaults.yaml
+++ b/src/haddock/modules/scoring/mdscoring/defaults.yaml
@@ -86,7 +86,7 @@ w_elec:
 w_lcc:
   default: -10000.0
   type: float
-  min: -9999
+  min: -10000.0
   max: 0
   precision: 3
   title: Weight of the EM local correlation coefficient

--- a/tests/test_modules_general.py
+++ b/tests/test_modules_general.py
@@ -11,6 +11,7 @@ import pytest
 
 from haddock import modules_defaults_path
 from haddock.core.exceptions import ConfigurationError
+from haddock.gear.prepare_run import validate_param_range
 from haddock.gear.yaml2cfg import read_from_yaml_config
 from haddock.libs.libio import read_from_yaml
 from haddock.modules import (
@@ -91,8 +92,8 @@ def keys_inspect(keys, d, param, module):
 
 # global dictionaries helping functions below
 yaml_params_types = {
-    "integer": (int, float),
-    "float": (float,),
+    "integer": (int, float,),
+    "float": (float, int,),
     "boolean": (bool,),
     "string": (str,),
     "list": (list,),
@@ -144,6 +145,13 @@ def test_general_config():
     assert read_from_yaml_config(modules_defaults_path)
 
 
+def inspect_default_value(defaultval, param, paramname, module):
+    """Test if default value is acceptable."""
+    error_msg = validate_param_range(param, defaultval)
+    assert error_msg is None, \
+        f"In module {module} parameter {paramname}, the default {error_msg}"
+
+
 def test_yaml_keys(module_yaml_pure):
     """
     Test keys in each parameter.
@@ -169,6 +177,8 @@ def inspect_types(d, module):
                 module,
                 )
             yaml_types_to_keys[_type](value, param, module)
+            # Validate default value
+            inspect_default_value(value["default"], value, param, module)
 
         elif isinstance(value, dict):
             inspect_commons(value, param, module)


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and that you comply with the following criteria:

- [X] You have sticked to Python. Please talk to us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [X] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [X] You structured the code into small functions as much as possible. You can use classes if there is a (state) purpose
- [X] Your code follows our coding style
- [x] You wrote tests for the new code
- [x] `tox` tests pass. *Run `tox` command inside the repository folder*
- [x] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [X] PR does not add any dependencies, unless permission granted by the HADDOCK team
- [X] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [x] Your PR is about writing tests for already existing code :godmode:

---
This PR aims at closing three issues:
- With the addition of a regular expression that checks the presence of upper case True and False in the .toml input file and lowering them on-the-fly, this closes #575 
- Also by checking values types and ranges/choices, by comparing values present in the defaults.yaml and parameter =  value present in the user provided .cfg file, this closes #487 
- Finally, a bunch of copies of the workflow haddock3 input files are now written in the `data` directory of the run. This includes the `original inputed file`, the `regular expression cleaned file` and the `enhanced full parameter file`, which includes all default parameters in addition to the ones provided by the user. This closes #578 

Accordingly, additionnal tests were added, while some other test were modified to fit the new implementation.

Finally, `run_tests.py` ran without errors and the comparisons by `compare-runs.py` returned only `No errors found - OKAY!`.
