### PR TITLE
Fixes b16 glycan linkage issue #659

### DIFF
--- a/src/haddock/modules/topology/topoaa/cns/bondglycans.cns
+++ b/src/haddock/modules/topology/topoaa/cns/bondglycans.cns
@@ -308,7 +308,7 @@ ident (store3) ( ( &alpha or &beta ) and name O3 and known )
 {- for B14: beta(1,4)  link from beta-anomer to any -}
 ident (store4) ( ( &alpha or &beta ) and name O4 and known ) 
 {- for B16: beta(1,6)  link from beta-anomer to any -}
-ident (store6) ( ( &alpha or &beta ) and name O4 and known ) 
+ident (store6) ( ( &alpha or &beta ) and name O6 and known ) 
 
 for $id1 in id ( &beta and name C1 and known ) loop B1
 
@@ -438,46 +438,6 @@ for $id1 in id ( &beta and name C1 and known ) loop B1
     end if
 
   end loop B14
-
-  for $id2 in id ( recall6 ) loop B16
-
-    show (segid) (id $id2)
-    evaluate ($segid2=$result)
-    show (resid) (id $id2)
-    evaluate ($resid2=$result)
-    
-    evaluate ($identical=false)
-    if ($resid1 = $resid2) then
-        if ($segid1 = $segid2) then
-           evaluate ($identical=true)
-        end if
-    end if
-
-    if ($identical=false) then
-
-      show (x) ( id $id1 ) evaluate ($x1=$result)
-      show (y) ( id $id1 ) evaluate ($y1=$result)
-      show (z) ( id $id1 ) evaluate ($z1=$result)
-      show (x) ( id $id2 ) evaluate ($x2=$result)
-      show (y) ( id $id2 ) evaluate ($y2=$result)
-      show (z) ( id $id2 ) evaluate ($z2=$result)
-      evaluate ($distance=sqrt( ($x1-$x2)^2 + ($y1-$y2)^2 + ($z1-$z2)^2 ))
-
-      if ( $distance <= &carbo_dist ) then
-          evaluate ($npatch=$npatch+1)
-          evaluate ($seg1.$npatch=$segid1)
-          evaluate ($seg2.$npatch=$segid2)
-          evaluate ($res1.$npatch=$resid1)
-          evaluate ($res2.$npatch=$resid2)
-          if ($resname1="FUL") then
-             evaluate ($pres.$npatch="B16L")
-          else
-             evaluate ($pres.$npatch="B16")
-          end if
-      end if
-    end if
-
-  end loop B16
 
 end loop B1
 


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and that you comply with the following criteria:

- [ ] You have sticked to Python. Please talk to us before adding other programming languages to HADDOCK3
- [X] Your PR is about CNS
- [ ] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [ ] You structured the code into small functions as much as possible. You can use classes if there is a (state) purpose
- [ ] Your code follows our coding style
- [ ] You wrote tests for the new code
- [ ] `tox` tests pass. *Run `tox` command inside the repository folder*
- [X] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [X] PR does not add any dependencies, unless permission granted by the HADDOCK team
- [X] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---

Corrected an atom naming typo that was causing wrong glycosidic linkages