### PR TITLE
Hide install deprecation warnings

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -58,11 +58,11 @@ pip install -r requirements.txt
 
 ## 3. Install the HADDOCK3 package and command line clients
 
-[Of note](## "Here we are still using the Depreacted `setup.py` command due to HPC, GRID and LOCAL compabilities with CNS.")
-
 ```bash
 python setup.py develop --no-deps
 ```
+
+Of note, here we are still using the depreacted `setup.py` command due to HPC, GRID and LOCAL compabilities with CNS.
 
 ## 4. Make a CNS binary shortcut to the expected path:
 
@@ -112,7 +112,7 @@ pip install -r requirements.txt  --upgrade
 python setup.py develop --no-deps
 ```
 
-[Of note](## "Here we are still using the Depreacted `setup.py` command due to HPC, GRID and LOCAL compabilities with CNS.")
+Of note, here we are still using the depreacted `setup.py` command due to HPC, GRID and LOCAL compabilities with CNS.
 
 
 ## 6. (Optional) Install MPI libraries if you intend to run HADDOCK3 with MPI

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -58,6 +58,8 @@ pip install -r requirements.txt
 
 ## 3. Install the HADDOCK3 package and command line clients
 
+[Of note](## "Here we are still using the Depreacted `setup.py` command due to HPC, GRID and LOCAL compabilities with CNS.")
+
 ```bash
 python setup.py develop --no-deps
 ```
@@ -109,6 +111,8 @@ pip install -r requirements.txt  --upgrade
 # ensure all command-lines clients are installed
 python setup.py develop --no-deps
 ```
+
+[Of note](## "Here we are still using the Depreacted `setup.py` command due to HPC, GRID and LOCAL compabilities with CNS.")
 
 
 ## 6. (Optional) Install MPI libraries if you intend to run HADDOCK3 with MPI

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,18 @@
 #!/usr/bin/env python
 # -*- encoding: utf-8 -*-
 """Setup dot py."""
+import warnings
 from os.path import dirname, join
 
 from setuptools import find_packages, setup
+# Import warnings object for later filtering out
+from setuptools.command.easy_install import EasyInstallDeprecationWarning
+from setuptools.warnings import SetuptoolsDeprecationWarning
+
+
+# Add warnings filtering to the Setup Deprecation Warnings
+warnings.filterwarnings("ignore", category=SetuptoolsDeprecationWarning)
+warnings.filterwarnings("ignore", category=EasyInstallDeprecationWarning)
 
 
 def read(*names, **kwargs):


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and that you comply with the following criteria:

- [x] You have sticked to Python. Please talk to us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [x] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [ ] You structured the code into small functions as much as possible. You can use classes if there is a (state) purpose
- [x] Your code follows our coding style
- [ ] You wrote tests for the new code
- [x] `tox` tests pass. *Run `tox` command inside the repository folder*
- [ ] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [x] PR does not add any dependencies, unless permission granted by the HADDOCK team
- [x] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---

In this PR, deprecation warning that are printed to user while running the command `python3 setup.py develop --no-deps` during the installation are silenced.
This is performed by the importation of the `warning` library and the two `EasyInstallDeprecationWarning` and `SetuptoolsDeprecationWarning` warning class from the `setuptools` library.

To compensate (and somehow remember) that these warnings exists, one line is added in the `docs/INSTALL.md` to justify the use of `python setup.py`.

(also related to #617)
