### PR TITLE
Increased dihedral restraints array size - in line with haddock2.4/5

### DIFF
--- a/src/haddock/modules/refinement/emref/cns/protein-ss-restraints-all.cns
+++ b/src/haddock/modules/refinement/emref/cns/protein-ss-restraints-all.cns
@@ -20,7 +20,7 @@
 
 {- Dihedral restraints for the protein backbone -}
 restraint dihedral
-    nass = 10000
+    nass = 50000
 end
 do (store1 = 1) (all)
 evaluate ($group=1)

--- a/src/haddock/modules/refinement/emref/cns/protein-ss-restraints-alpha-beta.cns
+++ b/src/haddock/modules/refinement/emref/cns/protein-ss-restraints-alpha-beta.cns
@@ -24,7 +24,7 @@
 
 do (store1 = 1) (all)
 restraint dihedral
-    nass = 10000
+    nass = 50000
 end
 evaluate ($group=1)
 evaluate ($done=false)

--- a/src/haddock/modules/refinement/emref/cns/protein-ss-restraints-alpha.cns
+++ b/src/haddock/modules/refinement/emref/cns/protein-ss-restraints-alpha.cns
@@ -22,7 +22,7 @@
 
 {- Dihedral restraints for the protein backbone in alpha-helical regions -}
 restraint dihedral
-    nass = 10000
+    nass = 50000
 end
 do (store1 = 1) (all)
 evaluate ($group=1)

--- a/src/haddock/modules/refinement/emref/cns/read_data.cns
+++ b/src/haddock/modules/refinement/emref/cns/read_data.cns
@@ -61,7 +61,7 @@ end
 !dihedral restraints:
 restraints dihedral 
     reset
-    nassign 20000 
+    nassign 50000 
 end
 fileexist $dihe_fname end
 if ($result eq true) then

--- a/src/haddock/modules/refinement/flexref/cns/protein-ss-restraints-all.cns
+++ b/src/haddock/modules/refinement/flexref/cns/protein-ss-restraints-all.cns
@@ -20,7 +20,7 @@
 
 {- Dihedral restraints for the protein backbone -}
 restraint dihedral
-    nass = 10000
+    nass = 50000
 end
 do (store1 = 1) (all)
 evaluate ($group=1)

--- a/src/haddock/modules/refinement/flexref/cns/protein-ss-restraints-alpha-beta.cns
+++ b/src/haddock/modules/refinement/flexref/cns/protein-ss-restraints-alpha-beta.cns
@@ -24,7 +24,7 @@
 
 do (store1 = 1) (all)
 restraint dihedral
-    nass = 10000
+    nass = 50000
 end
 evaluate ($group=1)
 evaluate ($done=false)

--- a/src/haddock/modules/refinement/flexref/cns/protein-ss-restraints-alpha.cns
+++ b/src/haddock/modules/refinement/flexref/cns/protein-ss-restraints-alpha.cns
@@ -22,7 +22,7 @@
 
 {- Dihedral restraints for the protein backbone in alpha-helical regions -}
 restraint dihedral
-    nass = 10000
+    nass = 50000
 end
 do (store1 = 1) (all)
 evaluate ($group=1)

--- a/src/haddock/modules/refinement/flexref/cns/read_data.cns
+++ b/src/haddock/modules/refinement/flexref/cns/read_data.cns
@@ -61,7 +61,7 @@ end
 !dihedral restraints:
 restraints dihedral 
     reset
-    nassign 20000 
+    nassign 50000 
 end
 fileexist $dihe_fname end
 if ($result eq true) then

--- a/src/haddock/modules/refinement/mdref/cns/protein-ss-restraints-all.cns
+++ b/src/haddock/modules/refinement/mdref/cns/protein-ss-restraints-all.cns
@@ -20,7 +20,7 @@
 
 {- Dihedral restraints for the protein backbone -}
 restraint dihedral
-    nass = 10000
+    nass = 50000
 end
 do (store1 = 1) (all)
 evaluate ($group=1)

--- a/src/haddock/modules/refinement/mdref/cns/protein-ss-restraints-alpha-beta.cns
+++ b/src/haddock/modules/refinement/mdref/cns/protein-ss-restraints-alpha-beta.cns
@@ -24,7 +24,7 @@
 
 do (store1 = 1) (all)
 restraint dihedral
-    nass = 10000
+    nass = 50000
 end
 evaluate ($group=1)
 evaluate ($done=false)

--- a/src/haddock/modules/refinement/mdref/cns/protein-ss-restraints-alpha.cns
+++ b/src/haddock/modules/refinement/mdref/cns/protein-ss-restraints-alpha.cns
@@ -22,7 +22,7 @@
 
 {- Dihedral restraints for the protein backbone in alpha-helical regions -}
 restraint dihedral
-    nass = 10000
+    nass = 50000
 end
 do (store1 = 1) (all)
 evaluate ($group=1)

--- a/src/haddock/modules/refinement/mdref/cns/read_data.cns
+++ b/src/haddock/modules/refinement/mdref/cns/read_data.cns
@@ -61,7 +61,7 @@ end
 !dihedral restraints:
 restraints dihedral 
     reset
-    nassign 20000 
+    nassign 50000 
 end
 fileexist $dihe_fname end
 if ($result eq true) then

--- a/src/haddock/modules/scoring/mdscoring/cns/protein-ss-restraints-all.cns
+++ b/src/haddock/modules/scoring/mdscoring/cns/protein-ss-restraints-all.cns
@@ -20,7 +20,7 @@
 
 {- Dihedral restraints for the protein backbone -}
 restraint dihedral
-    nass = 10000
+    nass = 50000
 end
 do (store1 = 1) (all)
 evaluate ($group=1)

--- a/src/haddock/modules/scoring/mdscoring/cns/protein-ss-restraints-alpha-beta.cns
+++ b/src/haddock/modules/scoring/mdscoring/cns/protein-ss-restraints-alpha-beta.cns
@@ -24,7 +24,7 @@
 
 do (store1 = 1) (all)
 restraint dihedral
-    nass = 10000
+    nass = 50000
 end
 evaluate ($group=1)
 evaluate ($done=false)

--- a/src/haddock/modules/scoring/mdscoring/cns/protein-ss-restraints-alpha.cns
+++ b/src/haddock/modules/scoring/mdscoring/cns/protein-ss-restraints-alpha.cns
@@ -22,7 +22,7 @@
 
 {- Dihedral restraints for the protein backbone in alpha-helical regions -}
 restraint dihedral
-    nass = 10000
+    nass = 50000
 end
 do (store1 = 1) (all)
 evaluate ($group=1)


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and that you comply with the following criteria:

- [ ] You have sticked to Python. Please talk to us before adding other programming languages to HADDOCK3
- [X] Your PR is about CNS
- [ ] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [ ] You structured the code into small functions as much as possible. You can use classes if there is a (state) purpose
- [X] Your code follows our coding style
- [ ] You wrote tests for the new code
- [ ] `tox` tests pass. *Run `tox` command inside the repository folder*
- [X] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [X] PR does not add any dependencies, unless permission granted by the HADDOCK team
- [X] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---

Fixes #663