### PR TITLE
modify location of SetuptoolsDeprecationWarning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,9 @@
 import warnings
 from os.path import dirname, join
 
-from setuptools import find_packages, setup
+from setuptools import SetuptoolsDeprecationWarning, find_packages, setup
 # Import warnings object for later filtering out
 from setuptools.command.easy_install import EasyInstallDeprecationWarning
-from setuptools import SetuptoolsDeprecationWarning
 
 
 # Add warnings filtering to the Setup Deprecation Warnings

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from os.path import dirname, join
 from setuptools import find_packages, setup
 # Import warnings object for later filtering out
 from setuptools.command.easy_install import EasyInstallDeprecationWarning
-from setuptools.warnings import SetuptoolsDeprecationWarning
+from setuptools import SetuptoolsDeprecationWarning
 
 
 # Add warnings filtering to the Setup Deprecation Warnings


### PR DESCRIPTION
Solving issue with SetuptoolsDeprecationWarning exception class that has change location in the `setuptools` lib.
Should now be directly imported from `setuptools`.
