### PR TITLE
fix max_molecules_allowed formatting

### DIFF
--- a/src/haddock/gear/prepare_run.py
+++ b/src/haddock/gear/prepare_run.py
@@ -259,7 +259,7 @@ def setup_run(
             )
 
         if len(modules_params["topoaa.1"]["molecules"]) > max_molecules_allowed:
-            raise ConfigurationError("Too many molecules defined, max is {max_molecules_allowed}.")  # noqa: E501
+            raise ConfigurationError(f"Too many molecules defined, max is {max_molecules_allowed}.")  # noqa: E501
 
         zero_fill.read(modules_params)
 


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and that you comply with the following criteria:

- [x] You have sticked to Python. Please talk to us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [ ] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [ ] You structured the code into small functions as much as possible. You can use classes if there is a (state) purpose
- [ ] Your code follows our coding style
- [ ] You wrote tests for the new code
- [ ] `tox` tests pass. *Run `tox` command inside the repository folder*
- [ ] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [ ] PR does not add any dependencies, unless permission granted by the HADDOCK team
- [ ] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---

This very small PR closes #677, simply by formating the string
