### PR TITLE
handled max sampling_factor

### DIFF
--- a/src/haddock/modules/refinement/emref/__init__.py
+++ b/src/haddock/modules/refinement/emref/__init__.py
@@ -47,8 +47,9 @@ class HaddockModule(BaseCNSModule):
             sampling_factor = 1
         if sampling_factor > 100:
             self.log("[Warning] sampling_factor is larger than 100")
-
-        if len(models_to_refine) * sampling_factor > 50000:
+        
+        max_nmodels = self.params["max_nmodels"]
+        if len(models_to_refine) * sampling_factor > max_nmodels:
             self.finish_with_error(
                 "Too many models to refine. Please reduce the number of "
                 "models or decrease the sampling_factor."

--- a/src/haddock/modules/refinement/emref/__init__.py
+++ b/src/haddock/modules/refinement/emref/__init__.py
@@ -47,6 +47,12 @@ class HaddockModule(BaseCNSModule):
             sampling_factor = 1
         if sampling_factor > 100:
             self.log("[Warning] sampling_factor is larger than 100")
+
+        if len(models_to_refine) * sampling_factor > 50000:
+            self.finish_with_error(
+                "Too many models to refine. Please reduce the number of "
+                "models or decrease the sampling_factor."
+                )
         
         # checking the ambig_fname:
         try:

--- a/src/haddock/modules/refinement/emref/__init__.py
+++ b/src/haddock/modules/refinement/emref/__init__.py
@@ -49,10 +49,12 @@ class HaddockModule(BaseCNSModule):
             self.log("[Warning] sampling_factor is larger than 100")
         
         max_nmodels = self.params["max_nmodels"]
-        if len(models_to_refine) * sampling_factor > max_nmodels:
+        nmodels = len(models_to_refine) * sampling_factor
+        if nmodels > max_nmodels:
             self.finish_with_error(
-                "Too many models to refine. Please reduce the number of "
-                "models or decrease the sampling_factor."
+                f"Too many models ({nmodels}) to refine, max_nmodels ="
+                f" {max_nmodels}. Please reduce the number of models or"
+                " decrease the sampling_factor."
                 )
         
         # checking the ambig_fname:

--- a/src/haddock/modules/refinement/emref/defaults.yaml
+++ b/src/haddock/modules/refinement/emref/defaults.yaml
@@ -1346,7 +1346,7 @@ sampling_factor:
   default: 1
   type: integer
   min: 1
-  max: 1
+  max: 100
   title: Sampling factor for each starting model
   short: This paramater control how many times a model will be refined.
   long: This paramater control how many times a model will be refined. For EM refinement only it does not make sense to increase it unless random removal of restraints is turned on. If not then the energy minimisation will lead to the same final conformation. 

--- a/src/haddock/modules/refinement/emref/defaults.yaml
+++ b/src/haddock/modules/refinement/emref/defaults.yaml
@@ -1346,7 +1346,7 @@ sampling_factor:
   default: 1
   type: integer
   min: 1
-  max: 100
+  max: 200
   title: Sampling factor for each starting model
   short: This paramater control how many times a model will be refined.
   long: This paramater control how many times a model will be refined. For EM refinement only it does not make sense to increase it unless random removal of restraints is turned on. If not then the energy minimisation will lead to the same final conformation. 

--- a/src/haddock/modules/refinement/emref/defaults.yaml
+++ b/src/haddock/modules/refinement/emref/defaults.yaml
@@ -1352,6 +1352,16 @@ sampling_factor:
   long: This paramater control how many times a model will be refined. For EM refinement only it does not make sense to increase it unless random removal of restraints is turned on. If not then the energy minimisation will lead to the same final conformation. 
   group: 'sampling'
   explevel: expert
+max_nmodels:
+  default: 50000
+  type: integer
+  min: 1
+  max: 100000
+  title: Maximum number of models to refine
+  short: This paramater controls the maximum number of models to refine.
+  long: This paramater controls the maximum number of models to refine.
+  group: 'sampling'
+  explevel: expert
 nemsteps:
   default: 200
   type: integer

--- a/src/haddock/modules/refinement/flexref/__init__.py
+++ b/src/haddock/modules/refinement/flexref/__init__.py
@@ -48,6 +48,12 @@ class HaddockModule(BaseCNSModule):
         if sampling_factor > 100:
             self.log("[Warning] sampling_factor is larger than 100")
 
+        if len(models_to_refine) * sampling_factor > 50000:
+            self.finish_with_error(
+                "Too many models to refine. Please reduce the number of "
+                "models or decrease the sampling_factor."
+                )
+
         # checking the ambig_fname:
         try:
             prev_ambig_fnames = [mod.restr_fname for mod in models_to_refine]

--- a/src/haddock/modules/refinement/flexref/__init__.py
+++ b/src/haddock/modules/refinement/flexref/__init__.py
@@ -49,10 +49,12 @@ class HaddockModule(BaseCNSModule):
             self.log("[Warning] sampling_factor is larger than 100")
 
         max_nmodels = self.params["max_nmodels"]
-        if len(models_to_refine) * sampling_factor > max_nmodels:
+        nmodels = len(models_to_refine) * sampling_factor
+        if nmodels > max_nmodels:
             self.finish_with_error(
-                "Too many models to refine. Please reduce the number of "
-                "models or decrease the sampling_factor."
+                f"Too many models ({nmodels}) to refine, max_nmodels ="
+                f" {max_nmodels}. Please reduce the number of models or"
+                " decrease the sampling_factor."
                 )
 
         # checking the ambig_fname:

--- a/src/haddock/modules/refinement/flexref/__init__.py
+++ b/src/haddock/modules/refinement/flexref/__init__.py
@@ -48,7 +48,8 @@ class HaddockModule(BaseCNSModule):
         if sampling_factor > 100:
             self.log("[Warning] sampling_factor is larger than 100")
 
-        if len(models_to_refine) * sampling_factor > 50000:
+        max_nmodels = self.params["max_nmodels"]
+        if len(models_to_refine) * sampling_factor > max_nmodels:
             self.finish_with_error(
                 "Too many models to refine. Please reduce the number of "
                 "models or decrease the sampling_factor."

--- a/src/haddock/modules/refinement/flexref/defaults.yaml
+++ b/src/haddock/modules/refinement/flexref/defaults.yaml
@@ -1683,7 +1683,7 @@ sampling_factor:
   default: 1
   type: integer
   min: 1
-  max: 100
+  max: 200
   title: Sampling factor for each starting model
   short: This paramater controls how many times a model will be refined.
   long: This paramater controls how many times a model will be refined. 

--- a/src/haddock/modules/refinement/flexref/defaults.yaml
+++ b/src/haddock/modules/refinement/flexref/defaults.yaml
@@ -1683,7 +1683,7 @@ sampling_factor:
   default: 1
   type: integer
   min: 1
-  max: 1
+  max: 100
   title: Sampling factor for each starting model
   short: This paramater control how many times a model will be refined.
   long: This paramater control how many times a model will be refined. 

--- a/src/haddock/modules/refinement/flexref/defaults.yaml
+++ b/src/haddock/modules/refinement/flexref/defaults.yaml
@@ -1685,8 +1685,18 @@ sampling_factor:
   min: 1
   max: 100
   title: Sampling factor for each starting model
-  short: This paramater control how many times a model will be refined.
-  long: This paramater control how many times a model will be refined. 
+  short: This paramater controls how many times a model will be refined.
+  long: This paramater controls how many times a model will be refined. 
+  group: 'sampling'
+  explevel: expert
+max_nmodels:
+  default: 10000
+  type: integer
+  min: 1
+  max: 50000
+  title: Maximum number of models to refine
+  short: This paramater controls the maximum number of models to refine.
+  long: This paramater controls the maximum number of models to refine.
   group: 'sampling'
   explevel: expert
 nemsteps:

--- a/src/haddock/modules/refinement/mdref/__init__.py
+++ b/src/haddock/modules/refinement/mdref/__init__.py
@@ -49,10 +49,12 @@ class HaddockModule(BaseCNSModule):
             self.log("[Warning] sampling_factor is larger than 100")
 
         max_nmodels = self.params["max_nmodels"]
-        if len(models_to_refine) * sampling_factor > max_nmodels:
+        nmodels = len(models_to_refine) * sampling_factor
+        if nmodels > max_nmodels:
             self.finish_with_error(
-                "Too many models to refine. Please reduce the number of "
-                "models or decrease the sampling_factor."
+                f"Too many models ({nmodels}) to refine, max_nmodels ="
+                f" {max_nmodels}. Please reduce the number of models or"
+                " decrease the sampling_factor."
                 )
         
         # checking the ambig_fname:

--- a/src/haddock/modules/refinement/mdref/__init__.py
+++ b/src/haddock/modules/refinement/mdref/__init__.py
@@ -47,8 +47,9 @@ class HaddockModule(BaseCNSModule):
             sampling_factor = 1
         if sampling_factor > 100:
             self.log("[Warning] sampling_factor is larger than 100")
-        
-        if len(models_to_refine) * sampling_factor > 50000:
+
+        max_nmodels = self.params["max_nmodels"]
+        if len(models_to_refine) * sampling_factor > max_nmodels:
             self.finish_with_error(
                 "Too many models to refine. Please reduce the number of "
                 "models or decrease the sampling_factor."

--- a/src/haddock/modules/refinement/mdref/__init__.py
+++ b/src/haddock/modules/refinement/mdref/__init__.py
@@ -48,6 +48,12 @@ class HaddockModule(BaseCNSModule):
         if sampling_factor > 100:
             self.log("[Warning] sampling_factor is larger than 100")
         
+        if len(models_to_refine) * sampling_factor > 50000:
+            self.finish_with_error(
+                "Too many models to refine. Please reduce the number of "
+                "models or decrease the sampling_factor."
+                )
+        
         # checking the ambig_fname:
         try:
             prev_ambig_fnames = [mod.restr_fname for mod in models_to_refine]

--- a/src/haddock/modules/refinement/mdref/defaults.yaml
+++ b/src/haddock/modules/refinement/mdref/defaults.yaml
@@ -1385,7 +1385,7 @@ sampling_factor:
   default: 1
   type: integer
   min: 1
-  max: 100
+  max: 200
   title: Sampling factor for each starting model
   short: This paramater control how many times a model will be refined.
   long: This paramater control how many times a model will be refined. 

--- a/src/haddock/modules/refinement/mdref/defaults.yaml
+++ b/src/haddock/modules/refinement/mdref/defaults.yaml
@@ -1391,6 +1391,16 @@ sampling_factor:
   long: This paramater control how many times a model will be refined. 
   group: 'sampling'
   explevel: expert
+max_nmodels:
+  default: 10000
+  type: integer
+  min: 1
+  max: 50000
+  title: Maximum number of models to refine
+  short: This paramater controls the maximum number of models to refine.
+  long: This paramater controls the maximum number of models to refine.
+  group: 'sampling'
+  explevel: expert
 solvent:
   default: water
   type: string

--- a/src/haddock/modules/refinement/mdref/defaults.yaml
+++ b/src/haddock/modules/refinement/mdref/defaults.yaml
@@ -1385,7 +1385,7 @@ sampling_factor:
   default: 1
   type: integer
   min: 1
-  max: 1
+  max: 100
   title: Sampling factor for each starting model
   short: This paramater control how many times a model will be refined.
   long: This paramater control how many times a model will be refined. 


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and that you comply with the following criteria:

- [ ] You have sticked to Python. Please talk to us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [ ] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [ ] You structured the code into small functions as much as possible. You can use classes if there is a (state) purpose
- [ ] Your code follows our coding style
- [ ] You wrote tests for the new code
- [ ] `tox` tests pass. *Run `tox` command inside the repository folder*
- [ ] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [ ] PR does not add any dependencies, unless permission granted by the HADDOCK team
- [ ] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---

Closes #689 by changing the max value of `sampling_factor` to 100 and adding a check at the python level such that if the product between the number of models and the `sampling_factor` is > 50 000 the code exits with an error.

I have absolutely no idea about why tests are failing..