### PR TITLE
Access long description of module parameters

### DIFF
--- a/src/haddock/clis/cli_cfg.py
+++ b/src/haddock/clis/cli_cfg.py
@@ -53,6 +53,15 @@ ap.add_argument(
     action="store_true",
     )
 
+ap.add_argument(
+    '-d',
+    '--details',
+    dest='details',
+    help="Add detailed parameter description found in 'long'.",
+    action="store_true",
+    default=False,
+    )
+
 
 def _ap():
     return ap
@@ -90,7 +99,12 @@ def maincli():
     cli(ap, main)
 
 
-def main(module=None, explevel="all", global_params=True):
+def main(
+    module: str = None,
+    explevel: str = "all",
+    global_params: bool = True,
+    details: bool = False,
+        ):
     """
     Extract the defaults in the form of a run configuration file.
 
@@ -123,6 +137,7 @@ def main(module=None, explevel="all", global_params=True):
             general_cfg,
             module=None,
             explevel="all",
+            details=details,
             )
         comment = os.linesep.join((
             "# The parameters below are optional parameters. ",
@@ -148,7 +163,7 @@ def main(module=None, explevel="all", global_params=True):
         cfg = module_lib.DEFAULT_CONFIG
 
         ycfg = read_from_yaml(cfg)
-        module_config = yaml2cfg_text(ycfg, module, explevel)
+        module_config = yaml2cfg_text(ycfg, module, explevel, details=details)
 
         new_config = os.linesep.join((new_config, module_config))
 

--- a/src/haddock/clis/cli_cfg.py
+++ b/src/haddock/clis/cli_cfg.py
@@ -124,6 +124,9 @@ def main(
         Whether to add the module's general global parameter. If
         ``True`` and ``module`` is ``None``, outputs only the general
         parameters.
+
+    details : bool
+        Whether to add the 'long' description of each parameter.
     """
     from haddock import modules_defaults_path
     from haddock.gear.yaml2cfg import yaml2cfg_text

--- a/src/haddock/gear/yaml2cfg.py
+++ b/src/haddock/gear/yaml2cfg.py
@@ -32,6 +32,9 @@ def yaml2cfg_text(ymlcfg: dict, module: str, explevel: str,
         The expert level to consider. Provides all parameters for that
         level and those of inferior hierarchy. If you give "all", all
         parameters will be considered.
+
+    details : bool
+        Whether to add the 'long' description of each parameter.
     """
     new_config = []
     if module is not None:
@@ -57,10 +60,21 @@ def _yaml2cfg_text(ymlcfg: dict, module: str, explevel: str,
 
     Parameters
     ----------
-    ycfg : dict
+    ymlcfg : dict
         The dictionary representing the HADDOCK3 YAML configuration.
         This configuration should NOT have the expertise levels. It
         expectes the first level of keys to be the parameter name.
+
+    module : str
+        The module to which the config belongs to.
+
+    explevel : str
+        The expert level to consider. Provides all parameters for that
+        level and those of inferior hierarchy. If you give "all", all
+        parameters will be considered.
+
+    details : bool
+        Whether to add the 'long' description of each parameter.
     """
     params = []
     exp_levels = {

--- a/tests/test_cli_cfg.py
+++ b/tests/test_cli_cfg.py
@@ -26,3 +26,12 @@ def module(request):
 def test_export_cfgs_add_global(module, config_level, global_params):
     """Test export all configs work with `add_global` parameter."""
     cli_cfg.main(module, explevel=config_level, global_params=global_params)
+
+def test_export_cfgs_details(module, config_level, global_params):
+    """Test export all configs work with detailed parameter description."""
+    cli_cfg.main(
+        module,
+        explevel=config_level,
+        global_params=global_params,
+        details=True,
+        )


### PR DESCRIPTION

- [X] You have sticked to Python. Please talk to us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [X] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [ ] You structured the code into small functions as much as possible. You can use classes if there is a (state) purpose
- [X] Your code follows our coding style
- [X] You wrote tests for the new code
- [ ] `tox` tests pass. *Run `tox` command inside the repository folder*
- [ ] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [X] PR does not add any dependencies, unless permission granted by the HADDOCK team
- [X] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---

I was frustrated to not be able to access better exlanation using the `haddock3-cfg` CLI.
Therefore, the idea was to add the optional argument `-d` / `--details` to add the `long` description of the parameter.
