### PR TITLE
Automatically updating HADDOCK patch version

### DIFF
--- a/patch_update.py
+++ b/patch_update.py
@@ -140,15 +140,29 @@ def update_haddock_version(commit_id: str, shorten: int = 6):
     """
     # generate shorten version of the commit
     short_commit = commit_id[:shorten]
+    # generate number version of commit
+    number_commit = commit_to_number(short_commit)
     # modify patch version with current commit
-    modify_patch_version(short_commit)
+    modify_patch_version(number_commit)
     # get current (just modified) version
     current_version = get_current_version()
     # check it was well applied
-    assert current_version.split('.')[-1] == short_commit
-    assert get_current_patch_version() == short_commit
+    assert current_version.split('.')[-1] == number_commit
+    assert get_current_patch_version() == number_commit
     # return current version
     return current_version
+
+
+def commit_to_number(commit_id: str):
+    number_seq = []
+    for letter in commit_id:
+        try:
+            number = int(letter)
+        except ValueError:
+            number = ord(letter)
+        finally:
+            number_seq.append(str(number))
+    return ''.join(number_seq)
 
 
 def modify_patch_version(patch_v: str):

--- a/patch_update.py
+++ b/patch_update.py
@@ -3,13 +3,11 @@
 
 """Update HADDOCK patch version using git logs information."""
 
-import os
 import json
+import os
 import re
-
 from importlib import reload
-
-from subprocess import Popen, PIPE, check_output
+from subprocess import PIPE, Popen, check_output
 
 import haddock
 
@@ -162,7 +160,7 @@ def modify_patch_version(patch_v: str):
         Version of the current patch to apply.
     """
     # path where it is stored
-    from haddock import __file__ as fpath
+    fpath = haddock.__file__
     # build sed cmd line
     sed_cmd_ = f"""sed -i 's|v_patch =.*|v_patch = "{patch_v}"|g' {fpath}"""
     # use sed to modify patch version

--- a/patch_update.py
+++ b/patch_update.py
@@ -9,7 +9,7 @@ import re
 from importlib import reload
 from subprocess import PIPE, Popen, check_output
 
-import haddock
+from src import haddock
 
 
 class ProcessFailure(Exception):
@@ -49,8 +49,8 @@ def get_N_recent_merges(n: int = 10):
     git_cmd_ = [
         'git', 'log',  # to get the logs
         '--merges',  # to get only merges
-        '-n', str(n),  # to get only last N merges
-        '--pretty=format:{"commit": "%H", "subject": "%f"}',  # noqa : E501 # gather commit hash and subject as dict
+        '-n', str(n),  # to get only last `n` merges
+        '--pretty=format:{"commit": "%H", "subject": "%f", "time": "%ct"}',  # noqa : E501 # gather commit hash and subject as dict
         ]
 
     # run the command
@@ -80,9 +80,13 @@ def find_closest_pr_merge(logs: list) -> dict:
     logdt : dict
         First git log data containing a merged pull request in the list.
     """
+    # compile regex to find a merged pull request
     search_flag = re.compile(r'Merge-pull-request-\d{1,6}')
+    # loop over git logs
     for logdt in logs:
+        # check if can find flag in `subject`
         if search_flag.search(logdt["subject"]):
+            # return first time found
             return logdt
 
 
@@ -235,11 +239,11 @@ def main() -> str:
         return get_current_version()
     else:
         # get last merge PR commit hash
-        commit_id = last_merge_log["commit"]
+        patch_id = last_merge_log["commit"]  # could be "time"
 
     # update haddock3 version
     try:
-        version = update_haddock_version(commit_id)
+        version = update_haddock_version(patch_id)
     except AssertionError:
         version = update_haddock_version(init_patch_version)
     

--- a/patch_update.py
+++ b/patch_update.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8 -*-
+
+"""Update HADDOCK patch version using git logs information."""
+
+import os
+import json
+import re
+
+from importlib import reload
+
+from subprocess import Popen, PIPE, check_output
+
+import haddock
+
+
+class ProcessFailure(Exception):
+    """Exception class devoted to unfound merge PR in `git log`.
+
+    Parameters
+    ----------
+    nb_last_merges : int
+        Total number of merges that have been parsed.
+    """
+
+    def __init__(self, nb_last_merges: int):
+        self.nb = nb_last_merges
+
+    def __str__(self):
+        return f"ProcessFailure: {self.__repr__()}"
+
+    def __repr__(self):
+        return (f'After {self.nb} log merges, still no Merged Pull Request'
+                ' found using git log.')
+
+
+def get_N_recent_merges(n: int = 10):
+    """Obtain the `N` most recent git merges.
+
+    Parameters
+    ----------
+    n : int
+        Number of most recent merges to return.
+
+    Return
+    ------
+    loaded_logs : list
+        List of `N` most recent merges.
+    """
+    # initiate git cmd line
+    git_cmd_ = [
+        'git', 'log',  # to get the logs
+        '--merges',  # to get only merges
+        '-n', str(n),  # to get only last N merges
+        '--pretty=format:{"commit": "%H", "subject": "%f"}',  # noqa : E501 # gather commit hash and subject as dict
+        ]
+
+    # run the command
+    git_logs = Popen(git_cmd_, stdout=PIPE)
+
+    # gather outputs
+    logs = git_logs.stdout.read().decode('utf-8')
+
+    # cast string to dict
+    loaded_logs = [json.loads(logstr) for logstr in logs.split(os.linesep)]
+
+    # return list of last N logs
+    return loaded_logs
+
+
+def find_closest_pr_merge(logs: list) -> dict:
+    """Find most recent merged Pull Request.
+
+    Parameters
+    ----------
+    logs : list
+        List of git logs.
+        NOTE: here we consider they are sorted from most recent to ancient.
+
+    Return
+    ------
+    logdt : dict
+        First git log data containing a merged pull request in the list.
+    """
+    search_flag = re.compile(r'Merge-pull-request-\d{1,6}')
+    for logdt in logs:
+        if search_flag.search(logdt["subject"]):
+            return logdt
+
+
+def find_last_pr_merge(init_n: int = 10) -> dict:
+    """Find most recent merged Pull Request.
+
+    Parameters
+    ----------
+    init_n : int
+        Initiale number of merges logs to parse.
+
+    Return
+    ------
+    closest_merge_log : dict
+        Dictionary containing the most recent merged PR log info.
+    """
+    previous_logs = []
+    while True:
+        # gather last n merges
+        logs = get_N_recent_merges(init_n)
+
+        # make sure we are still getting new log entries
+        if logs == previous_logs:
+            raise ProcessFailure(init_n)
+
+        # search last pull request merge
+        closest_merge_log = find_closest_pr_merge(logs)
+
+        # check if something was returned
+        if closest_merge_log:
+            # return clostest merge log
+            return closest_merge_log
+
+        # increase number of merges commit to parse
+        init_n += 10
+        # modify controle variable
+        previous_logs = logs
+        # retry
+
+
+def update_haddock_version(commit_id: str, shorten: int = 6):
+    """Update HADDOCK version with `commit_id` as new patch.
+
+    Parameters
+    ----------
+    commit_id : str
+        Version of the current patch to apply.
+    shorten : int
+        Number of character to shorten commit id.
+
+    Return
+    ------
+    current_version : str
+        The current HADDOCK version.
+    """
+    # generate shorten version of the commit
+    short_commit = commit_id[:shorten]
+    # modify patch version with current commit
+    modify_patch_version(short_commit)
+    # get current (just modified) version
+    current_version = get_current_version()
+    # check it was well applied
+    assert current_version.split('.')[-1] == short_commit
+    assert get_current_patch_version() == short_commit
+    # return current version
+    return current_version
+
+
+def modify_patch_version(patch_v: str):
+    """Optain current haddock3 patch version.
+
+    Parameters
+    ----------
+    patch_v : str
+        Version of the current patch to apply.
+    """
+    # path where it is stored
+    from haddock import __file__ as fpath
+    # build sed cmd line
+    sed_cmd_ = f"""sed -i 's|v_patch =.*|v_patch = "{patch_v}"|g' {fpath}"""
+    # use sed to modify patch version
+    check_output(sed_cmd_, shell=True)
+
+
+def load_current_haddock():
+    """Reload HADDOCK."""
+    reload(haddock)
+
+
+def get_current_version():
+    """Optain current haddock version."""
+    load_current_haddock()
+    return haddock.version
+
+
+def get_current_patch_version():
+    """Optain current haddock3 patch version."""
+    load_current_haddock()
+    return haddock.v_patch
+
+
+def main() -> str:
+    """Process the finding of last merge of pull request.
+
+    Return
+    ------
+    version : str
+        Current HADDOCK version
+    """
+    # get current patch version
+    init_patch_version = get_current_patch_version()
+
+    # search last pull request merge
+    try:
+        last_merge_log = find_last_pr_merge(10)
+    except ProcessFailure:
+        return get_current_version()
+    else:
+        # get last merge PR commit hash
+        commit_id = last_merge_log["commit"]
+
+    # update haddock3 version
+    try:
+        version = update_haddock_version(commit_id)
+    except AssertionError:
+        version = update_haddock_version(init_patch_version)
+    
+    # return current version
+    return version
+
+
+def set_version() -> str:
+    """Explicit name for main wrapper."""
+    return main()
+
+
+############################
+# Command line entry point #
+############################
+if __name__ == "__main__":
+    main()

--- a/patch_update.py
+++ b/patch_update.py
@@ -154,15 +154,34 @@ def update_haddock_version(commit_id: str, shorten: int = 6):
 
 
 def commit_to_number(commit_id: str):
-    number_seq = []
+    """Convert a commit id to a number.
+    
+    Parameters
+    ----------
+    commit_id : str
+        A string containing letters / numbers.
+
+    Return
+    number_seq : str
+        A string containing only numbers.
+    """
+    # initiate holding list
+    number_seq_ = []
+    # loop over letters
     for letter in commit_id:
         try:
+            # check if an integer
             number = int(letter)
         except ValueError:
+            # convert an ascii to letter
             number = ord(letter)
         finally:
-            number_seq.append(str(number))
-    return ''.join(number_seq)
+            # add string casted version of the number
+            number_seq_.append(str(number))
+    # join the sequence
+    number_seq = ''.join(number_seq_)
+    # return it
+    return number_seq
 
 
 def modify_patch_version(patch_v: str):

--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,11 @@
 import warnings
 from os.path import dirname, join
 
-from patch_update import set_version
 from setuptools import SetuptoolsDeprecationWarning, find_packages, setup
 # Import warnings object for later filtering out
 from setuptools.command.easy_install import EasyInstallDeprecationWarning
+
+from patch_update import set_version
 
 
 # Add warnings filtering to the Setup Deprecation Warnings

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 import warnings
 from os.path import dirname, join
 
-from find_version import set_version
+from patch_update import set_version
 from setuptools import SetuptoolsDeprecationWarning, find_packages, setup
 # Import warnings object for later filtering out
 from setuptools.command.easy_install import EasyInstallDeprecationWarning

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,8 @@
 import warnings
 from os.path import dirname, join
 
+from find_version import set_version
+
 from setuptools import SetuptoolsDeprecationWarning, find_packages, setup
 # Import warnings object for later filtering out
 from setuptools.command.easy_install import EasyInstallDeprecationWarning
@@ -30,7 +32,7 @@ long_description = '{}\n{}'.format(
 
 setup(
     name='haddock3',
-    version='3.0.0',
+    version=set_version(),  # updates and get current HADDOCK version
     description='Haddock 3.',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@ import warnings
 from os.path import dirname, join
 
 from find_version import set_version
-
 from setuptools import SetuptoolsDeprecationWarning, find_packages, setup
 # Import warnings object for later filtering out
 from setuptools.command.easy_install import EasyInstallDeprecationWarning

--- a/src/haddock/__init__.py
+++ b/src/haddock/__init__.py
@@ -38,8 +38,12 @@ class EmptyPath:
         return False
 
 
-# version
-version = "3.0.0"
-v_major, v_minor, v_patch = version.split('.')
+# versions
+v_major = 3
+v_minor = 0
+v_patch = "0"
+# full version
+version = f"{v_major}.{v_minor}.{v_patch}"
 
+# link to contact / support
 contact_us = 'https://github.com/haddocking/haddock3/issues'

--- a/src/haddock/__init__.py
+++ b/src/haddock/__init__.py
@@ -41,7 +41,7 @@ class EmptyPath:
 # versions
 v_major = 3
 v_minor = 0
-v_patch = "0"
+v_patch = 100700997
 # full version
 version = f"{v_major}.{v_minor}.{v_patch}"
 

--- a/tox.ini
+++ b/tox.ini
@@ -55,8 +55,8 @@ deps =
     pygments==2.15.1
     isort==5.12.0
 commands =
-    flake8 {posargs:src/haddock tests setup.py examples/run_tests.py examples/compare_runs.py}
-    isort --quiet --check-only --diff {posargs:src/haddock tests setup.py examples/run_tests.py examples/compare_runs.py}
+    flake8 {posargs:src/haddock tests patch_update.py setup.py examples/run_tests.py examples/compare_runs.py}
+    isort --quiet --check-only --diff {posargs:src/haddock tests patch_update.py setup.py examples/run_tests.py examples/compare_runs.py}
 
 # asserts package build integrity
 [testenv:build]


### PR DESCRIPTION
- [X] You have sticked to Python. Please talk to us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [X] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [X] You structured the code into small functions as much as possible. You can use classes if there is a (state) purpose
- [X] Your code follows our coding style
- [ ] You wrote tests for the new code
- [ ] `tox` tests pass. *Run `tox` command inside the repository folder*
- [ ] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [ ] PR does not add any dependencies, unless permission granted by the HADDOCK team
- [ ] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---
The basic idea is to have an automated procedure to update HADDOCK3 versions based on current state of the repository.

For this:
- `git log` data is searched for the last merged pull request and its `commit id` is retrieved.
- This `commit id` is then used to update the patch version (`v_patch`) of haddock.

Also, the `setup.py` uses this function to automatically update the version at setup time.

The file responsible of all of this is `patch_update.py`, and have been added in the `tox.ini` for lint checks.

Hopefully, this closes #679 .