### PR TITLE
automated patch version control

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ tox==3.24.5
 pandas==1.5.1
 plotly==5.11.0
 kaleido==0.2.1
+setuptools-scm=7.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ tox==3.24.5
 pandas==1.5.1
 plotly==5.11.0
 kaleido==0.2.1
-setuptools-scm=7.1.0
+setuptools-scm==7.1.0

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,8 @@ long_description = '{}\n{}'.format(
 
 setup(
     name='haddock3',
-    version='3.0.0',
+    # version='3.0.0',
+    use_scm_version=True,
     description='Haddock 3.',
     long_description=long_description,
     long_description_content_type='text/markdown',
@@ -75,6 +76,7 @@ setup(
     extras_require={
         },
     setup_requires=[
+        'setuptools_scm',
         ],
     entry_points={
         'console_scripts': [

--- a/src/haddock/__init__.py
+++ b/src/haddock/__init__.py
@@ -38,8 +38,33 @@ class EmptyPath:
         return False
 
 
+def get_package_version():
+    """Use package egg info to obain build version."""
+    # point package path
+    ppath = __path__[0]
+    # point setup egg data
+    pkg_info_fpath = f'{ppath}3.egg-info/PKG-INFO'
+    # read this file
+    with open(pkg_info_fpath, 'r') as filin:
+        # loop over lines
+        for _ in filin:
+            # find the line where version is written
+            if _.startswith('Version'):
+                # return the version
+                return _.split(':')[-1].strip()
+
+
+def split_version(version: str) -> tuple:
+    """Split version into major, minor and patch."""
+    s_version = version.split('.')
+    v_major = s_version[0]
+    v_minor = s_version[1]
+    v_patch = '.'.join(s_version[2:])
+    return (v_major, v_minor, v_patch)
+
+
 # version
-version = "3.0.0"
-v_major, v_minor, v_patch = version.split('.')
+version = get_package_version()
+v_major, v_minor, v_patch = split_version(version)
 
 contact_us = 'https://github.com/haddocking/haddock3/issues'


### PR DESCRIPTION
- [X] You have sticked to Python. Please talk to us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [X] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [ ] You structured the code into small functions as much as possible. You can use classes if there is a (state) purpose
- [X] Your code follows our coding style
- [ ] You wrote tests for the new code
- [X] `tox` tests pass. *Run `tox` command inside the repository folder*
- [ ] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [ ] PR does not add any dependencies, unless permission granted by the HADDOCK team
- [ ] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---

As stated by [sverhoeven](https://github.com/sverhoeven) in issue #679  [useful comment](https://github.com/haddocking/haddock3/issues/679#issuecomment-1719429128), this new trial of automated patch implementation uses the `setuptools-scm` approach to handle patch version.

It:
- requires an additional library present in the `requirements.txt`
- small modification in `setup.py` to use `setuptools-scm` to find the current build version.
- addition of functions in the `src/haddock/__init__.py` to look for package data generated during setup.

The length of patch is enormous !