### PR TITLE
no traceback on pure analysis runs

### DIFF
--- a/src/haddock/clis/cli_traceback.py
+++ b/src/haddock/clis/cli_traceback.py
@@ -155,13 +155,6 @@ def main(run_dir):
     log.level = 20
     log.info(f"Running haddock3-traceback on {run_dir}")
 
-    outdir = Path(run_dir, TRACK_FOLDER)
-    try:
-        outdir.mkdir(exist_ok=False)
-        log.info(f"Created directory: {str(outdir.resolve())}")
-    except FileExistsError:
-        log.warning(f"Directory {str(outdir.resolve())} already exists.")
-
     # Reading steps
     log.info("Reading input run directory")
     # get the module folders from the run_dir input
@@ -171,9 +164,17 @@ def main(run_dir):
     # check if there are steps to traceback
     if len(sel_step) == 0:
         log.info("No steps to trace back. Exiting.")
-        sys.exit(0)
+        return
     else:
         log.info(f"Steps to trace back: {', '.join(sel_step)}")
+
+    # creating traceback folder
+    outdir = Path(run_dir, TRACK_FOLDER)
+    try:
+        outdir.mkdir(exist_ok=False)
+        log.info(f"Created directory: {str(outdir.resolve())}")
+    except FileExistsError:
+        log.warning(f"Directory {str(outdir.resolve())} already exists.")
     
     data_dict, rank_dict = {}, {}
     unk_idx, max_topo_len = 0, 0

--- a/src/haddock/clis/cli_traceback.py
+++ b/src/haddock/clis/cli_traceback.py
@@ -168,7 +168,12 @@ def main(run_dir):
     all_steps = get_module_steps_folders(Path(run_dir))
     log.info(f"All_steps: {', '.join(all_steps)}")
     sel_step = [st for st in all_steps if st.split("_")[1] not in ANA_MODULES]
-    log.info(f"Steps to trace back: {', '.join(sel_step)}")
+    # check if there are steps to traceback
+    if len(sel_step) == 0:
+        log.info("No steps to trace back. Exiting.")
+        sys.exit(0)
+    else:
+        log.info(f"Steps to trace back: {', '.join(sel_step)}")
     
     data_dict, rank_dict = {}, {}
     unk_idx, max_topo_len = 0, 0

--- a/tests/test_cli_traceback.py
+++ b/tests/test_cli_traceback.py
@@ -62,3 +62,23 @@ def test_main(rigid_json, flexref_json):
 
     # clean up
     shutil.rmtree(run_dir)
+
+
+def test_analysis():
+    """Test traceback on a pure analysis run."""
+    # build fake run_dir
+    run_dir = "example_dir"
+    step_dirs = [os.path.join(run_dir, "0_topoaa"),
+                 os.path.join(run_dir, "1_caprieval")]
+    
+    if os.path.isdir(run_dir):
+        shutil.rmtree(run_dir)
+    # Loop over directories to be created
+    for d in [run_dir, *step_dirs]:
+        os.mkdir(d)
+
+    # run haddock3-traceback
+    main(run_dir)
+
+    # check traceback folder does not exist
+    assert not os.path.isdir(os.path.join(run_dir, "traceback"))


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and that you comply with the following criteria:

- [ ] You have sticked to Python. Please talk to us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [ ] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [ ] You structured the code into small functions as much as possible. You can use classes if there is a (state) purpose
- [ ] Your code follows our coding style
- [ ] You wrote tests for the new code
- [ ] `tox` tests pass. *Run `tox` command inside the repository folder*
- [ ] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [ ] PR does not add any dependencies, unless permission granted by the HADDOCK team
- [ ] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---

Closes #700 : traceback is not run in postprocessing if the run has only analysis modules