### PR TITLE
Fixing issues running examples

### DIFF
--- a/examples/analysis/topoaa-rmsdmatrix-clustrmsd-test.cfg
+++ b/examples/analysis/topoaa-rmsdmatrix-clustrmsd-test.cfg
@@ -16,7 +16,6 @@ molecules = "./data/ensemble_4G6M.pdb"
 # ====================================================================
 [topoaa]
 [emscoring]
-dielec="jogn"
 [rmsdmatrix]
 
 [clustrmsd]

--- a/examples/compare_runs.py
+++ b/examples/compare_runs.py
@@ -75,6 +75,7 @@ examples = (
     ("docking-protein-protein"     , "docking-protein-protein-test.cfg"),  # noqa: E203, E501
     ("docking-protein-protein"     , "docking-protein-protein-cltsel-test.cfg"),  # noqa: E203, E501
     ("docking-protein-protein"     , "docking-protein-protein-mdref-test.cfg"),  # noqa: E203, E501
+    ("docking-multiple-ambig"      , "docking-multiple-tbls-test.cfg"),  # noqa: E203, E501
     ("docking-protein-protein"     , "docking-exit-test.cfg"),  # noqa: E203, E501
     ("refine-complex"              , "refine-complex-test.cfg"),  # noqa: E203, E501
     ("scoring"                     , "emscoring-test.cfg"),  # noqa: E203, E501

--- a/examples/docking-protein-homotrimer/docking-protein-homotrimer-full.cfg
+++ b/examples/docking-protein-homotrimer/docking-protein-homotrimer-full.cfg
@@ -43,7 +43,7 @@ hisd_1 = 98
 [rigidbody]
 ambig_fname = "data/1qu9_whiscy_air.tbl"
 sampling = 2000
-# Define NCS restraints between molecules
+# Define CNS restraints between molecules
 ncs_on = true
 numncs = 2
 ncs_sta1_1=2
@@ -82,32 +82,32 @@ select = 200
 tolerance = 5
 #randremoval = false
 ambig_fname = "data/1qu9_whiscy_air.tbl"
-# Define NCS restraints between molecules
+# Define CNS restraints between molecules
 ncs_on = true
 numncs = 2
-ncs_sta1_1="2"
-ncs_end1_1="128"
+ncs_sta1_1=2
+ncs_end1_1=128
 ncs_seg1_1="A"
-ncs_sta2_1="2"
-ncs_end2_1="128"
+ncs_sta2_1=2
+ncs_end2_1=128
 ncs_seg2_1="B"
-ncs_sta1_2="2"
-ncs_end1_2="128"
+ncs_sta1_2=2
+ncs_end1_2=128
 ncs_seg1_2="B"
-ncs_sta2_2="2"
-ncs_end2_2="128"
+ncs_sta2_2=2
+ncs_end2_2=128
 ncs_seg2_2="C"
 # Define C3 symmetry restraints
 sym_on = true
 numc3sym = 1
-c3sym_sta1_1="2"
-c3sym_end1_1="128"
+c3sym_sta1_1=2
+c3sym_end1_1=128
 c3sym_seg1_1="A"
-c3sym_sta2_1="2"
-c3sym_end2_1="128"
+c3sym_sta2_1=2
+c3sym_end2_1=128
 c3sym_seg2_1="B"
-c3sym_sta3_1="2"
-c3sym_end3_1="128"
+c3sym_sta3_1=2
+c3sym_end3_1=128
 c3sym_seg3_1="C"
 
 [caprieval]
@@ -115,32 +115,32 @@ reference_fname = "data/1qu9_ABC.pdb"
 
 [emref]
 ambig_fname = "data/1qu9_whiscy_air.tbl"
-# Define NCS restraints between molecules
+# Define CNS restraints between molecules
 ncs_on = true
 numncs = 2
-ncs_sta1_1="2"
-ncs_end1_1="128"
+ncs_sta1_1=2
+ncs_end1_1=128
 ncs_seg1_1="A"
-ncs_sta2_1="2"
-ncs_end2_1="128"
+ncs_sta2_1=2
+ncs_end2_1=128
 ncs_seg2_1="B"
-ncs_sta1_2="2"
-ncs_end1_2="128"
+ncs_sta1_2=2
+ncs_end1_2=128
 ncs_seg1_2="B"
-ncs_sta2_2="2"
-ncs_end2_2="128"
+ncs_sta2_2=2
+ncs_end2_2=128
 ncs_seg2_2="C"
 # Define C3 symmetry restraints
 sym_on = true
 numc3sym = 1
-c3sym_sta1_1="2"
-c3sym_end1_1="128"
+c3sym_sta1_1=2
+c3sym_end1_1=128
 c3sym_seg1_1="A"
-c3sym_sta2_1="2"
-c3sym_end2_1="128"
+c3sym_sta2_1=2
+c3sym_end2_1=128
 c3sym_seg2_1="B"
-c3sym_sta3_1="2"
-c3sym_end3_1="128"
+c3sym_sta3_1=2
+c3sym_end3_1=128
 c3sym_seg3_1="C"
 
 [caprieval]

--- a/examples/docking-protein-homotrimer/docking-protein-homotrimer-test.cfg
+++ b/examples/docking-protein-homotrimer/docking-protein-homotrimer-test.cfg
@@ -36,7 +36,7 @@ hisd_1 = 98
 tolerance = 20
 ambig_fname = "data/1qu9_whiscy_air.tbl"
 sampling = 20
-# Define NCS restraints between molecules
+# Define CNS restraints between molecules
 ncs_on = true
 numncs = 2
 ncs_sta1_1=2
@@ -79,29 +79,29 @@ ambig_fname = "data/1qu9_whiscy_air.tbl"
 # Define NCS restraints between molecules
 ncs_on = true
 numncs = 2
-ncs_sta1_1="2"
-ncs_end1_1="128"
+ncs_sta1_1=2
+ncs_end1_1=128
 ncs_seg1_1="A"
-ncs_sta2_1="2"
-ncs_end2_1="128"
+ncs_sta2_1=2
+ncs_end2_1=128
 ncs_seg2_1="B"
-ncs_sta1_2="2"
-ncs_end1_2="128"
+ncs_sta1_2=2
+ncs_end1_2=128
 ncs_seg1_2="B"
-ncs_sta2_2="2"
-ncs_end2_2="128"
+ncs_sta2_2=2
+ncs_end2_2=128
 ncs_seg2_2="C"
 # Define C3 symmetry restraints
 sym_on = true
 numc3sym = 1
-c3sym_sta1_1="2"
-c3sym_end1_1="128"
+c3sym_sta1_1=2
+c3sym_end1_1=128
 c3sym_seg1_1="A"
-c3sym_sta2_1="2"
-c3sym_end2_1="128"
+c3sym_sta2_1=2
+c3sym_end2_1=128
 c3sym_seg2_1="B"
-c3sym_sta3_1="2"
-c3sym_end3_1="128"
+c3sym_sta3_1=2
+c3sym_end3_1=128
 c3sym_seg3_1="C"
 
 [caprieval]
@@ -114,29 +114,29 @@ ambig_fname = "data/1qu9_whiscy_air.tbl"
 # Define NCS restraints between molecules
 ncs_on = true
 numncs = 2
-ncs_sta1_1="2"
-ncs_end1_1="128"
+ncs_sta1_1=2
+ncs_end1_1=128
 ncs_seg1_1="A"
-ncs_sta2_1="2"
-ncs_end2_1="128"
+ncs_sta2_1=2
+ncs_end2_1=128
 ncs_seg2_1="B"
-ncs_sta1_2="2"
-ncs_end1_2="128"
+ncs_sta1_2=2
+ncs_end1_2=128
 ncs_seg1_2="B"
-ncs_sta2_2="2"
-ncs_end2_2="128"
+ncs_sta2_2=2
+ncs_end2_2=128
 ncs_seg2_2="C"
 # Define C3 symmetry restraints
 sym_on = true
 numc3sym = 1
-c3sym_sta1_1="2"
-c3sym_end1_1="128"
+c3sym_sta1_1=2
+c3sym_end1_1=128
 c3sym_seg1_1="A"
-c3sym_sta2_1="2"
-c3sym_end2_1="128"
+c3sym_sta2_1=2
+c3sym_end2_1=128
 c3sym_seg2_1="B"
-c3sym_sta3_1="2"
-c3sym_end3_1="128"
+c3sym_sta3_1=2
+c3sym_end3_1=128
 c3sym_seg3_1="C"
 
 [caprieval]

--- a/examples/run_examples-full.py
+++ b/examples/run_examples-full.py
@@ -57,6 +57,7 @@ examples = (
     ("docking-protein-protein"     , "docking-protein-protein-full.cfg"),  # noqa: E203, E501
     ("docking-protein-protein"     , "docking-protein-protein-cltsel-full.cfg"),  # noqa: E203, E501
     ("docking-protein-protein"     , "docking-protein-protein-mdref-full.cfg"),  # noqa: E203, E501
+    ("docking-multiple-ambig"      , "docking-multiple-tbls-full.cfg"),  # noqa: E203, E501
     ("docking-antibody-antigen"    , "docking-antibody-antigen-CDR-accessible-full"),  # noqa: E203, E501
     ("docking-antibody-antigen"    , "docking-antibody-antigen-CDR-accessible-clt-full.cfg"),  # noqa: E203, E501
     ("docking-antibody-antigen"    , "docking-antibody-antigen-ranairCDR-full.cfg"),  # noqa: E203, E501

--- a/examples/run_examples-full.py
+++ b/examples/run_examples-full.py
@@ -57,7 +57,7 @@ examples = (
     ("docking-protein-protein"     , "docking-protein-protein-full.cfg"),  # noqa: E203, E501
     ("docking-protein-protein"     , "docking-protein-protein-cltsel-full.cfg"),  # noqa: E203, E501
     ("docking-protein-protein"     , "docking-protein-protein-mdref-full.cfg"),  # noqa: E203, E501
-    ("docking-multiple-ambig"      , "docking-multiple-tbls-full.cfg"),  # noqa: E203, E501
+    ("docking-multiple-ambig"      , "docking-multiple-tbls-clt-full.cfg"),  # noqa: E203, E501
     ("docking-antibody-antigen"    , "docking-antibody-antigen-CDR-accessible-full"),  # noqa: E203, E501
     ("docking-antibody-antigen"    , "docking-antibody-antigen-CDR-accessible-clt-full.cfg"),  # noqa: E203, E501
     ("docking-antibody-antigen"    , "docking-antibody-antigen-ranairCDR-full.cfg"),  # noqa: E203, E501

--- a/examples/run_examples-full.py
+++ b/examples/run_examples-full.py
@@ -1,9 +1,9 @@
 """
-Run all examples in a row.
+Run all full examples in a row.
 
 This script should be executed from inside the haddock3/examples/ folder.
 
-This script runs the `*-test.cfg` files. These test cases are not fetched
+This script runs the `*-full.cfg` files. These test cases are not fetched
 automatically. If you want to add/remove cases you need to edit this script.
 The HADDOCK3 team has defined here only those test cases that are part of the
 integration tests.
@@ -30,8 +30,8 @@ from shutil import rmtree
 
 
 try:
+    from haddock.gear.config import load as read_config
     from haddock.libs.libio import working_directory
-    from haddock.gear.config_reader import read_config
 except Exception:
     print(  # noqa: T001
         "Haddock3 could not be imported. "
@@ -41,7 +41,7 @@ except Exception:
     sys.exit(1)
 
 
-# edit this dictionary to add or remove examples.
+# edit this tuple to add or remove examples.
 # keys are the examples folder, and values are the configuration files
 # spacings are anti-pythonic but facilitate reading :-)
 examples = (
@@ -94,9 +94,13 @@ def main(examples, break_on_errors=True):
         print()  # noqa: T001
 
         with working_directory(folder):
+            # obtain run directory
+            all_params = read_config(file_)
+            rundir = all_params['final_cfg']["run_dir"]
+            # remove eventual previous run
+            rmtree(rundir, ignore_errors=True)
 
-            params = read_config(file_)
-            rmtree(params["run_dir"], ignore_errors=True)
+            # run haddock with config file
             subprocess.run(
                 f"haddock3 {file_}",
                 shell=True,

--- a/examples/run_tests.py
+++ b/examples/run_tests.py
@@ -61,6 +61,7 @@ examples = (
     ("docking-protein-protein"     , "docking-protein-protein-test.cfg"),  # noqa: E203, E501
     ("docking-protein-protein"     , "docking-protein-protein-cltsel-test.cfg"),  # noqa: E203, E501
     ("docking-protein-protein"     , "docking-protein-protein-mdref-test.cfg"),  # noqa: E203, E501
+    ("docking-multiple-ambig"      , "docking-multiple-tbls-test.cfg"),  # noqa: E203, E501
     ("docking-protein-protein"     , "docking-exit-test.cfg"),  # noqa: E203, E501
     ("refine-complex"              , "refine-complex-test.cfg"),  # noqa: E203, E501
     ("scoring"                     , "emscoring-test.cfg"),  # noqa: E203, E501

--- a/examples/run_tests.py
+++ b/examples/run_tests.py
@@ -19,9 +19,9 @@ You should work towards solving that problem or contact the HADDOCK3 team.
 
 USAGE:
 
-    $ python run_examples.py -h
-    $ python run_examples.py     # runs all examples regardless of errors
-    $ python run_examples.py -b  # stops asap an error is found
+    $ python run_tests.py -h
+    $ python run_tests.py     # runs all examples regardless of errors
+    $ python run_tests.py -b  # stops asap an error is found
 """
 import argparse
 import os
@@ -42,7 +42,7 @@ except Exception:
     sys.exit(1)
 
 
-# edit this dictionary to add or remove examples.
+# edit this tuple to add or remove examples.
 # keys are the examples folder, and values are the configuration files
 # the whitespaces below are anti-pythonic but facilitate reading :-)
 examples = (
@@ -68,7 +68,7 @@ examples = (
     ("scoring"                     , "emscoring-mdscoring-test.cfg"),  # noqa: E203, E501
     ("analysis"                    , "topoaa-caprieval-test.cfg"),  # noqa: E203, E501
     ("analysis"                    , "topoaa-clustfcc-test.cfg"),  # noqa: E203, E501
-    ("analysis"                    , "topoaa-rmsdmatrix-clustrmsd-test.cfg")  # noqa: E203, E501
+    ("analysis"                    , "topoaa-rmsdmatrix-clustrmsd-test.cfg"),  # noqa: E203, E501
     )
 
 
@@ -106,8 +106,13 @@ def main(examples, break_on_errors=True):
 
         with working_directory(folder):
 
-            params = read_config(file_)
-            rmtree(params["run_dir"], ignore_errors=True)
+            # obtain run directory
+            all_params = read_config(file_)
+            rundir = all_params['final_cfg']["run_dir"]
+            # remove eventual previous run
+            rmtree(rundir, ignore_errors=True)
+
+            # run example
             subprocess.run(
                 f"haddock3 {file_}",
                 shell=True,


### PR DESCRIPTION
In this PR, issues running examples are solved.
Since PR #658 , parameters values are checked, and some issues with parameters arguments were discovered in the provided examples, making both `run_tests.py` and `run_examples-full.py` script failing.
Also, as the structure of the return value outputed by the `haddock.gear.config.load()` function has changed, the use of this function in both `run_tests.py` and `run_examples-full.py` had to be changed.

Hopefully, this closes #701 , and allow now to smoothly run the two examples scripts.