### PR TITLE
update key deletion logic in topoaa

### DIFF
--- a/src/haddock/libs/libontology.py
+++ b/src/haddock/libs/libontology.py
@@ -221,9 +221,12 @@ class ModuleIO:
         idxs: list[int] = []
         for idx, element in enumerate(self.output):
             if isinstance(element, dict):
+                to_pop = []
                 for key2 in element:
                     if not element[key2].is_present():
-                        element.pop(key2)
+                        to_pop.append(key2)
+                for pop_me in to_pop:
+                    element.pop(pop_me)
             else:
                 if not element.is_present():
                     idxs.append(idx)


### PR DESCRIPTION
Solve the `dictionary changed size during iteration` error in `topoaa` when 

Previous bug:
```
[2023-12-21 17:24:42,019 libutil ERROR] dictionary changed size during iteration
Traceback (most recent call last):
  File "/trinity/login/vreys/benchmarking/haddock3/src/haddock/libs/libutil.py", line 335, in log_error_and_exit
    yield
  File "/trinity/login/vreys/benchmarking/haddock3/src/haddock/clis/cli.py", line 185, in main
    workflow.run()
  File "/trinity/login/vreys/benchmarking/haddock3/src/haddock/libs/libworkflow.py", line 43, in run
    step.execute()
  File "/trinity/login/vreys/benchmarking/haddock3/src/haddock/libs/libworkflow.py", line 155, in execute
    self.module.run()  # type: ignore
  File "/trinity/login/vreys/benchmarking/haddock3/src/haddock/modules/base_cns_module.py", line 61, in run
    self._run()
  File "/trinity/login/vreys/benchmarking/haddock3/src/haddock/modules/topology/topoaa/__init__.py", line 247, in _run
    self.export_io_models(faulty_tolerance=self.params["tolerance"])
  File "/trinity/login/vreys/benchmarking/haddock3/src/haddock/modules/__init__.py", line 285, in export_io_models
    faulty = io.check_faulty()
  File "/trinity/login/vreys/benchmarking/haddock3/src/haddock/libs/libontology.py", line 214, in check_faulty
    self.remove_missing()
  File "/trinity/login/vreys/benchmarking/haddock3/src/haddock/libs/libontology.py", line 224, in remove_missing
    for key2 in element:
RuntimeError: dictionary changed size during iteration
[2023-12-21 17:24:42,030 libutil ERROR] dictionary changed size during iteration
```

This bug could appear when input molecules are not PDB compliant.
Now the error is managed and if one of the molecule failed, the `tolerance` parameter will either accept or terminate the run peroperly.

Closes #759 
