### PR TITLE
Solves issue #785 about unstable energies when changing the param file

### DIFF
--- a/src/haddock/cns/toppar/hemes-allhdg.top
+++ b/src/haddock/cns/toppar/hemes-allhdg.top
@@ -1,7 +1,7 @@
 remark file topallhdg.hemes
 
 set message ? end eval ($old_message=$result) set echo ? end eval ($old_echo=$result)
-set message=off echo off=end
+set message=off echo=off end
 
 autogenerate
   angles=true

--- a/src/haddock/modules/topology/topoaa/cns/build-missing.cns
+++ b/src/haddock/modules/topology/topoaa/cns/build-missing.cns
@@ -74,9 +74,11 @@ if ( $tobuild > 0 ) then
  
         end loop bndto 
 
-        do (x=x+2*random(1.0)-1) (store9)
-        do (y=y+2*random(1.0)-1) (store9)
-        do (z=z+2*random(1.0)-1) (store9)
+        for $id in id (store9) loop radis
+            do (x=x+2*random(1.0)-1) (id $id)
+            do (y=y+2*random(1.0)-1) (id $id)
+            do (z=z+2*random(1.0)-1) (id $id)
+        end loop radis
 
         {- start parameter for the side chain building -}
         parameter
@@ -135,7 +137,7 @@ if ( $tobuild > 0 ) then
             nprint=$nstep
             cmremove=false
         end
-  
+
         parameter
             nbonds
                 rcon=2. nbxmod=-3 repel=0.75
@@ -170,12 +172,10 @@ if ( $tobuild > 0 ) then
 
         flags exclude * include bond angl impr dihe vdw elec end
 
+        minimize powell nstep=500 nprint=50 end
+
         {- return masses to something sensible -}
         do (mass=refy) (store9)
-
-        do (vx=maxwell($bath)) (store9)
-        do (vy=maxwell($bath)) (store9)
-        do (vz=maxwell($bath)) (store9)
 
         dynamics cartesian
             nstep=$nstep

--- a/src/haddock/modules/topology/topoaa/cns/generate-topology.cns
+++ b/src/haddock/modules/topology/topoaa/cns/generate-topology.cns
@@ -712,10 +712,7 @@ end if
 
 delete selection=( &atom_delete ) end
 
-inline @MODULE:build-missing.cns
-
 !check for histidine protonation state if auto mode on
-!but only for the first model
 if ($autohis = true) then
     inline @MODULE:auto-his.cns
 end if
@@ -803,9 +800,6 @@ buffer message
     dump
 end
 buffer message reset end
-
-!do (segid = "    ") (all)
-!do (segid = $prot_segid_1) (all)
 
 write structure output=$output_psf_filename end
 write coordinates format=pdbo output=$output_pdb_filename end


### PR DESCRIPTION
Updated missing atom generation script for issues related to parameter file changes.
Leads to stable energies, solving issue #785 

Now the generation/energies do no longer change when changing the param file

You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and that you comply with the following criteria:

- [ ] You have sticked to Python. Please talk to us before adding other programming languages to HADDOCK3
- [X] Your PR is about CNS
- [ ] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [ ] You structured the code into small functions as much as possible. You can use classes if there is a (state) purpose
- [ ] Your code follows our coding style
- [ ] You wrote tests for the new code
- [X] `tox` tests pass. *Run `tox` command inside the repository folder*
- [X] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [X] PR does not add any dependencies, unless permission granted by the HADDOCK team
- [X] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---

*Delete this line and explain your PR here*
