### PR TITLE
Adding mirror pushing to the Castiel EuroHPC GitLab repo

### DIFF
--- a/.github/workflows/github-to-gitlab-push-sync.yml
+++ b/.github/workflows/github-to-gitlab-push-sync.yml
@@ -1,7 +1,9 @@
 name: build
 
-on: 
+on:
   push:
+    # run only against tags
+    tags:
 
 jobs:
   sync:

--- a/.github/workflows/github-to-gitlab-push-sync.yml
+++ b/.github/workflows/github-to-gitlab-push-sync.yml
@@ -12,7 +12,7 @@ jobs:
       with:
         ref: 'main'
         fetch-depth: 0
-    - uses: haddocking/haddock3@master
+    - uses: haddocking/haddock3@amjjbonvin-patch-1
       with:
         target-url: 'https://codehub.hlrs.de/coes/bioexcel/haddock3.git'
         target-username: ${{ secrets.ACCESS_TOKEN_NAME }}

--- a/.github/workflows/github-to-gitlab-push-sync.yml
+++ b/.github/workflows/github-to-gitlab-push-sync.yml
@@ -12,7 +12,7 @@ jobs:
       with:
         ref: 'main'
         fetch-depth: 0
-    - uses: haddocking/haddock3@amjjbonvin-patch-1
+    - uses: haddocking/haddock3@main
       with:
         target-url: 'https://codehub.hlrs.de/coes/bioexcel/haddock3.git'
         target-username: ${{ secrets.ACCESS_TOKEN_NAME }}

--- a/.github/workflows/github-to-gitlab-push-sync.yml
+++ b/.github/workflows/github-to-gitlab-push-sync.yml
@@ -10,9 +10,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        ref: 'master'
+        ref: 'main'
         fetch-depth: 0
-    - uses: deGrootLab/pmx@master
+    - uses: haddocking/haddock3@main
       with:
         target-url: 'https://codehub.hlrs.de/coes/bioexcel/haddock3.git'
         target-username: ${{ secrets.ACCESS_TOKEN_NAME }}

--- a/.github/workflows/github-to-gitlab-push-sync.yml
+++ b/.github/workflows/github-to-gitlab-push-sync.yml
@@ -1,0 +1,20 @@
+name: build
+
+on: 
+  push:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    name: Git Repo Sync
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: 'master'
+        fetch-depth: 0
+    - uses: deGrootLab/pmx@master
+      with:
+        target-url: 'https://codehub.hlrs.de/coes/bioexcel/haddock3.git'
+        target-username: ${{ secrets.ACCESS_TOKEN_NAME }}
+        target-token: ${{ secrets.ACCESS_TOKEN }}
+        

--- a/.github/workflows/github-to-gitlab-push-sync.yml
+++ b/.github/workflows/github-to-gitlab-push-sync.yml
@@ -12,7 +12,7 @@ jobs:
       with:
         ref: 'main'
         fetch-depth: 0
-    - uses: haddocking/haddock3@main
+    - uses: haddocking/haddock3@master
       with:
         target-url: 'https://codehub.hlrs.de/coes/bioexcel/haddock3.git'
         target-username: ${{ secrets.ACCESS_TOKEN_NAME }}

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,29 @@
+name: 'Git Repo Sync'
+description: 'Git Repo Sync enables you to synchronize code to other code management platforms, such as GitLab, Gitee, etc.'
+
+branding:
+  icon: upload-cloud
+  color: gray-dark
+
+inputs:
+  target-url:
+    description: 'Target Repo URL'
+    required: true
+  target-username:
+    description: 'Target Repo Username'
+    required: true
+  target-token:
+    description: 'Target Token'
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - run: chmod +x ${{ github.action_path }}/entrypoint.sh
+      shell: bash
+    - run: ${{ github.action_path }}/entrypoint.sh
+      shell: bash
+      env:
+        INPUT_TARGET_URL: ${{ inputs.target-url }}
+        INPUT_TARGET_USERNAME: ${{ inputs.target-username }}
+        INPUT_TARGET_TOKEN: ${{ inputs.target-token }}
+        GITHUB_EVENT_REF: ${{ github.event.ref }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,14 @@
+git remote add target https://${INPUT_TARGET_USERNAME}:${INPUT_TARGET_TOKEN}@${INPUT_TARGET_URL#https://}
+
+case "${GITHUB_EVENT_NAME}" in
+    push)
+        git push -f --all target
+        git push -f --tags target
+        ;;
+    delete)
+        git push -d target ${GITHUB_EVENT_REF}
+        ;;
+    *)
+        break
+        ;;
+esac


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and that you comply with the following criteria:

- [ ] You have sticked to Python. Please talk to us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [ ] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [ ] You structured the code into small functions as much as possible. You can use classes if there is a (state) purpose
- [ ] Your code follows our coding style
- [ ] You wrote tests for the new code
- [ ] `tox` tests pass. *Run `tox` command inside the repository folder*
- [ ] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [X] PR does not add any dependencies, unless permission granted by the HADDOCK team
- [X] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---

Following the instructions provided by Castiel to mirror our repo on the GitLab repo for EuroHPC.

Note that the build/action will fail (unless the target was set to this branch in `.github)/workflows/github-to-gitlab-push-sync.yml` ). It is now configured to mirror the main branch. 

Based on the instructions from the following repo: https://github.com/cniethammer/github-push-sync
