### PR TITLE
Add conditional execution for integration job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,6 +58,7 @@ jobs:
   integration:
     needs: unit
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     strategy:
       matrix:
         python-version: [3.9]
@@ -89,13 +90,9 @@ jobs:
           cd -
 
       - name: install integration dependencies
-        # developers outside the organization cannot access secrets
-        #   so we need to make sure that the job does not fail
-        # the test will handle the environment variable not being set
-        #  and will skip the test
-        continue-on-error: true
         run: |
           curl ${{ secrets.CNS_LINK }} -o $CNS_EXEC -s
           chmod +x $CNS_EXEC
 
-      - run: tox -e integration
+      - name: run integration tests
+        run: tox -e integration


### PR DESCRIPTION
Changes the test action not to run the integration tests on actions coming from outside the repository.

This will skip the integration tests for external contributions, this is relevant because these tests depend on CNS which is made available to the workflow via a secret.