### PR TITLE
Round other cluster + dont add score which was not there before

### DIFF
--- a/src/haddock/libs/libplots.py
+++ b/src/haddock/libs/libplots.py
@@ -800,11 +800,11 @@ def create_other_cluster(clusters_df: pd.DataFrame, structs_df: pd.DataFrame, ma
         'caprieval_rank': max_clusters
     }
     for col in AXIS_NAMES.keys():
-        if col not in other_structs_df.columns:
+        if col not in other_structs_df.columns or col not in clusters_df.columns:
             continue
         other_cluster[col] = other_structs_df[col].mean()
         other_cluster[col + '_std'] = other_structs_df[col].std()
-    clusters_df = clusters_df.append(other_cluster, ignore_index=True)
+    clusters_df = clusters_df.append(other_cluster, ignore_index=True).round(2)
 
     return clusters_df, structs_df
 


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and that you comply with the following criteria:

- [ ] You have sticked to Python. Please talk to us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [ ] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [ ] You structured the code into small functions as much as possible. You can use classes if there is a (state) purpose
- [ ] Your code follows our coding style
- [ ] You wrote tests for the new code
- [ ] `tox` tests pass. *Run `tox` command inside the repository folder*
- [ ] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [ ] PR does not add any dependencies, unless permission granted by the HADDOCK team
- [ ] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---

Follow up on #719 
The table report.html for other cluster was not rendered correctly.
![0 0 0 0_8001_analysis_12_caprieval_analysis_report html (2)](https://github.com/haddocking/haddock3/assets/1713488/75e7f3f1-4d43-4229-9469-e9eec24c1116)

With this PR it is rendered as
![0 0 0 0_8001_analysis_12_caprieval_analysis_report html (1)](https://github.com/haddocking/haddock3/assets/1713488/9c4fe678-8c5f-481b-acd2-0c6d4935a5b4)

