### PR TITLE
Chain match coords load issue

### DIFF
--- a/src/haddock/libs/libalign.py
+++ b/src/haddock/libs/libalign.py
@@ -475,6 +475,9 @@ def load_coords(
             coords = np.asarray([x, y, z])
             # Remap chain name
             if model2ref_chain_dict:
+                # Skip chain matching if not present in reference structure
+                if not chain in model2ref_chain_dict.keys():
+                    continue
                 chain = model2ref_chain_dict[chain]
             if numbering_dic and model2ref_chain_dict:
                 try:

--- a/src/haddock/libs/libalign.py
+++ b/src/haddock/libs/libalign.py
@@ -476,20 +476,21 @@ def load_coords(
             # Remap chain name
             if model2ref_chain_dict:
                 # Skip chain matching if not present in reference structure
-                if not chain in model2ref_chain_dict.keys():
+                if chain not in model2ref_chain_dict.keys():
                     continue
                 chain = model2ref_chain_dict[chain]
-            if numbering_dic and model2ref_chain_dict:
-                try:
-                    resnum = numbering_dic[chain][resnum]
-                except KeyError:
-                    # this residue is not matched, and so it should
-                    #  not be considered
-                    # self.log(
-                    #     f"WARNING: {chain}.{resnum}.{atom_name}"
-                    #     " was not matched!"
-                    #     )
-                    continue
+
+                if numbering_dic:
+                    try:
+                        resnum = numbering_dic[chain][resnum]
+                    except KeyError:
+                        # this residue is not matched, and so it should
+                        #  not be considered
+                        # self.log(
+                        #     f"WARNING: {chain}.{resnum}.{atom_name}"
+                        #     " was not matched!"
+                        #     )
+                        continue
 
             # Create identifier tuple
             if add_resname is True:

--- a/src/haddock/modules/analysis/caprieval/capri.py
+++ b/src/haddock/modules/analysis/caprieval/capri.py
@@ -101,11 +101,11 @@ def save_scoring_weights(cns_step: str) -> Path:
 
 
 def load_contacts(
-        pdb_f,
-        cutoff=5.0,
-        numbering_dic=None,
-        model2ref_chain_dict=None,
-        ):
+        pdb_f: Union[Path, PDBFile],
+        cutoff: float = 5.0,
+        numbering_dic: Optional[dict[str, dict[int, int]]] = None,
+        model2ref_chain_dict: Optional[dict[str, str]] = None,
+        ) -> set[tuple]:
     """Load residue-based contacts.
 
     Parameters
@@ -120,7 +120,6 @@ def load_contacts(
     set(con_list) : set
         set of unique contacts
     """
-    con_list: list = []
     if isinstance(pdb_f, PDBFile):
         pdb_f = pdb_f.rel_path
     # get also side chains atoms
@@ -147,6 +146,7 @@ def load_contacts(
     unique_chain_combs = list(combinations(sorted(coord_arrays.keys()), 2))
 
     # calculating contacts
+    con_list: list[tuple] = []
     for pair in unique_chain_combs:
         # cycling over each coordinate of the first chain
         for s in range(coord_arrays[pair[0]].shape[0]):

--- a/src/haddock/modules/analysis/caprieval/capri.py
+++ b/src/haddock/modules/analysis/caprieval/capri.py
@@ -563,23 +563,35 @@ class CAPRI:
             log.debug(f"id {self.identificator}, calculating FNAT")
             fnat_cutoff = self.params["fnat_cutoff"]
             log.debug(f" cutoff: {fnat_cutoff}A")
-            self.calc_fnat(cutoff=fnat_cutoff)
+            try:
+                self.calc_fnat(cutoff=fnat_cutoff)
+            except ALIGNError as alignerror:
+                log.warning(alignerror)
 
         if self.params["irmsd"]:
             log.debug(f"id {self.identificator}, calculating I-RMSD")
             irmsd_cutoff = self.params["irmsd_cutoff"]
             log.debug(f" cutoff: {irmsd_cutoff}A")
-            self.calc_irmsd(cutoff=irmsd_cutoff)
+            try:
+                self.calc_irmsd(cutoff=irmsd_cutoff)
+            except ALIGNError as alignerror:
+                log.warning(alignerror)
 
         if self.params["lrmsd"]:
             log.debug(f"id {self.identificator}, calculating L-RMSD")
-            self.calc_lrmsd()
+            try:
+                self.calc_lrmsd()
+            except ALIGNError as alignerror:
+                log.warning(alignerror)
 
         if self.params["ilrmsd"]:
             log.debug(f"id {self.identificator}, calculating I-L-RMSD")
             ilrmsd_cutoff = self.params["irmsd_cutoff"]
             log.debug(f" cutoff: {ilrmsd_cutoff}A")
-            self.calc_ilrmsd(cutoff=ilrmsd_cutoff)
+            try:
+                self.calc_ilrmsd(cutoff=ilrmsd_cutoff)
+            except ALIGNError as alignerror:
+                log.warning(alignerror)
 
         if self.params["dockq"]:
             log.debug(f"id {self.identificator}, calculating DockQ metric")

--- a/src/haddock/modules/analysis/caprieval/capri.py
+++ b/src/haddock/modules/analysis/caprieval/capri.py
@@ -230,14 +230,17 @@ class CAPRI:
             ref_coord_dic, _ = load_coords(
                 self.reference, self.atoms, ref_interface_resdic
                 )
-
-            mod_coord_dic, _ = load_coords(
-                self.model,
-                self.atoms,
-                ref_interface_resdic,
-                numbering_dic=self.model2ref_numbering,
-                model2ref_chain_dict=self.model2ref_chain_dict,
-                )
+            try:
+                mod_coord_dic, _ = load_coords(
+                    self.model,
+                    self.atoms,
+                    ref_interface_resdic,
+                    numbering_dic=self.model2ref_numbering,
+                    model2ref_chain_dict=self.model2ref_chain_dict,
+                    )
+            except ALIGNError as alignerror:
+                log.warning(alignerror)
+                return
 
             # Here _coord_dic keys are matched
             #  and formatted as (chain, resnum, atom)
@@ -269,13 +272,16 @@ class CAPRI:
     def calc_lrmsd(self) -> None:
         """Calculate the L-RMSD."""
         ref_coord_dic, _ = load_coords(self.reference, self.atoms)
-
-        mod_coord_dic, _ = load_coords(
-            self.model,
-            self.atoms,
-            numbering_dic=self.model2ref_numbering,
-            model2ref_chain_dict=self.model2ref_chain_dict,
-            )
+        try:
+            mod_coord_dic, _ = load_coords(
+                self.model,
+                self.atoms,
+                numbering_dic=self.model2ref_numbering,
+                model2ref_chain_dict=self.model2ref_chain_dict,
+                )
+        except ALIGNError as alignerror:
+            log.warning(alignerror)
+            return
 
         Q = []
         P = []
@@ -376,14 +382,17 @@ class CAPRI:
         ref_int_coord_dic, _ = load_coords(
             self.reference, self.atoms, ref_interface_resdic
             )
-
-        mod_int_coord_dic, _ = load_coords(
-            self.model,
-            self.atoms,
-            ref_interface_resdic,
-            numbering_dic=self.model2ref_numbering,
-            model2ref_chain_dict=self.model2ref_chain_dict,
-            )
+        try:
+            mod_int_coord_dic, _ = load_coords(
+                self.model,
+                self.atoms,
+                ref_interface_resdic,
+                numbering_dic=self.model2ref_numbering,
+                model2ref_chain_dict=self.model2ref_chain_dict,
+                )
+        except ALIGNError as alignerror:
+            log.warning(alignerror)
+            return
 
         # write_coord_dic("ref.pdb", ref_int_coord_dic)
         # write_coord_dic("model.pdb", mod_int_coord_dic)
@@ -470,14 +479,18 @@ class CAPRI:
         """
         ref_contacts = load_contacts(self.reference, cutoff)
         if len(ref_contacts) != 0:
-            model_contacts = load_contacts(
-                self.model,
-                cutoff,
-                numbering_dic=self.model2ref_numbering,
-                model2ref_chain_dict=self.model2ref_chain_dict,
-                )
-            intersection = ref_contacts & model_contacts
-            self.fnat = len(intersection) / float(len(ref_contacts))
+            try:
+                model_contacts = load_contacts(
+                    self.model,
+                    cutoff,
+                    numbering_dic=self.model2ref_numbering,
+                    model2ref_chain_dict=self.model2ref_chain_dict,
+                    )
+            except ALIGNError as alignerror:
+                log.warning(alignerror)
+            else:
+                intersection = ref_contacts & model_contacts
+                self.fnat = len(intersection) / float(len(ref_contacts))
         else:
             log.warning("No reference contacts found")
 
@@ -563,35 +576,23 @@ class CAPRI:
             log.debug(f"id {self.identificator}, calculating FNAT")
             fnat_cutoff = self.params["fnat_cutoff"]
             log.debug(f" cutoff: {fnat_cutoff}A")
-            try:
-                self.calc_fnat(cutoff=fnat_cutoff)
-            except ALIGNError as alignerror:
-                log.warning(alignerror)
+            self.calc_fnat(cutoff=fnat_cutoff)
 
         if self.params["irmsd"]:
             log.debug(f"id {self.identificator}, calculating I-RMSD")
             irmsd_cutoff = self.params["irmsd_cutoff"]
             log.debug(f" cutoff: {irmsd_cutoff}A")
-            try:
-                self.calc_irmsd(cutoff=irmsd_cutoff)
-            except ALIGNError as alignerror:
-                log.warning(alignerror)
+            self.calc_irmsd(cutoff=irmsd_cutoff)
 
         if self.params["lrmsd"]:
             log.debug(f"id {self.identificator}, calculating L-RMSD")
-            try:
-                self.calc_lrmsd()
-            except ALIGNError as alignerror:
-                log.warning(alignerror)
+            self.calc_lrmsd()
 
         if self.params["ilrmsd"]:
             log.debug(f"id {self.identificator}, calculating I-L-RMSD")
             ilrmsd_cutoff = self.params["irmsd_cutoff"]
             log.debug(f" cutoff: {ilrmsd_cutoff}A")
-            try:
-                self.calc_ilrmsd(cutoff=ilrmsd_cutoff)
-            except ALIGNError as alignerror:
-                log.warning(alignerror)
+            self.calc_ilrmsd(cutoff=ilrmsd_cutoff)
 
         if self.params["dockq"]:
             log.debug(f"id {self.identificator}, calculating DockQ metric")


### PR DESCRIPTION
Close #863 .
Adding an extra condition to solve `model2ref_chain_dict` mapping, when model chain is not present in the reference one.
