### PR TITLE
create new CNSScoringModule class

### DIFF
--- a/src/haddock/modules/scoring/__init__.py
+++ b/src/haddock/modules/scoring/__init__.py
@@ -3,13 +3,29 @@ import pandas as pd
 
 from haddock.core.typing import FilePath
 from haddock.modules.base_cns_module import BaseCNSModule
+from haddock.modules import BaseHaddockModule
 
 
-class ScoringModule(BaseCNSModule):
+class ScoringModule(BaseHaddockModule):
     """Parent class for Scoring modules."""
 
-    def output(self, output_fname: FilePath, sep: str = "\t") -> None:
-        """Save the output in comprehensive tables."""
+    def output(
+            self,
+            output_fname: FilePath,
+            sep: str = "\t",
+            ascending_sort: bool = True,
+            ) -> None:
+        r"""Save the output in comprehensive tables.
+
+        Parameters
+        ----------
+        output_fname : FilePath
+            Path to the file where to write scoring data.
+        sep : str, optional
+            Charater used as separator in file, by default "\t"
+        ascending_sort : bool, optional
+            Should the data be sorted in ascending order, by default True
+        """
         # saves scoring data
         sc_data = []
         for pdb in self.output_models:
@@ -18,8 +34,12 @@ class ScoringModule(BaseCNSModule):
         # converts to pandas dataframe and sorts by score
         df_columns = ["structure", "original_name", "md5", "score"]
         df_sc = pd.DataFrame(sc_data, columns=df_columns)
-        df_sc_sorted = df_sc.sort_values(by="score", ascending=True)
+        df_sc_sorted = df_sc.sort_values(by="score", ascending=ascending_sort)
         # writes to disk
         df_sc_sorted.to_csv(output_fname, sep=sep, index=False, na_rep="None")
 
         return
+
+
+class CNSScoringModule(BaseCNSModule, ScoringModule):
+    """Parent class for CNS Scoring modules."""

--- a/src/haddock/modules/scoring/emscoring/__init__.py
+++ b/src/haddock/modules/scoring/emscoring/__init__.py
@@ -10,14 +10,14 @@ from haddock.gear.haddockmodel import HaddockModel
 from haddock.libs.libcns import prepare_cns_input, prepare_expected_pdb
 from haddock.libs.libsubprocess import CNSJob
 from haddock.modules import get_engine
-from haddock.modules.scoring import ScoringModule
+from haddock.modules.scoring import CNSScoringModule
 
 
 RECIPE_PATH = Path(__file__).resolve().parent
 DEFAULT_CONFIG = Path(RECIPE_PATH, "defaults.yaml")
 
 
-class HaddockModule(ScoringModule):
+class HaddockModule(CNSScoringModule):
     """HADDOCK3 module to perform energy minimization scoring."""
 
     name = RECIPE_PATH.name

--- a/src/haddock/modules/scoring/mdscoring/__init__.py
+++ b/src/haddock/modules/scoring/mdscoring/__init__.py
@@ -9,14 +9,14 @@ from haddock.gear.haddockmodel import HaddockModel
 from haddock.libs.libcns import prepare_cns_input, prepare_expected_pdb
 from haddock.libs.libsubprocess import CNSJob
 from haddock.modules import get_engine
-from haddock.modules.scoring import ScoringModule
+from haddock.modules.scoring import CNSScoringModule
 
 
 RECIPE_PATH = Path(__file__).resolve().parent
 DEFAULT_CONFIG = Path(RECIPE_PATH, "defaults.yaml")
 
 
-class HaddockModule(ScoringModule):
+class HaddockModule(CNSScoringModule):
     """HADDOCK3 module to perform energy minimization scoring."""
 
     name = RECIPE_PATH.name


### PR DESCRIPTION
Closes #869 by splitting scoring modules into two classes:
- `CNSScoringModule`
- `ScoringModule`

They both have access to the `ScoringModule` method `self.output()`, writing the final tsv file.
