### PR TITLE
Save outputs in case of faulty tolerance

### DIFF
--- a/src/haddock/modules/__init__.py
+++ b/src/haddock/modules/__init__.py
@@ -285,6 +285,9 @@ class BaseHaddockModule(ABC):
         io.add(self.previous_io.output, "i")
         # add the output models
         io.add(self.output_models, "o")
+        # Save outputs
+        io.save()
+        # Check if number of generated outputs is under the tolrance threshold
         faulty = io.check_faulty()
         if faulty > faulty_tolerance:
             _msg = (
@@ -292,7 +295,7 @@ class BaseHaddockModule(ABC):
                 f"and tolerance was set to {faulty_tolerance:.2f}%."
                 )
             self.finish_with_error(_msg)
-        io.save()
+        
 
     def finish_with_error(self, reason: object = "Module has failed.") -> None:
         """Finish with error message."""

--- a/src/haddock/modules/__init__.py
+++ b/src/haddock/modules/__init__.py
@@ -287,7 +287,7 @@ class BaseHaddockModule(ABC):
         io.add(self.output_models, "o")
         # Save outputs
         io.save()
-        # Check if number of generated outputs is under the tolrance threshold
+        # Check if number of generated outputs is under the tolerance threshold
         faulty = io.check_faulty()
         if faulty > faulty_tolerance:
             _msg = (


### PR DESCRIPTION
- [x] You have sticked to Python. Please talk to us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [x] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [x] You structured the code into small functions as much as possible. You can use classes if there is a (state) purpose
- [x] Your code follows our coding style
- [ ] You wrote tests for the new code
- [x] `tox` tests pass. *Run `tox` command inside the repository folder*
- [x] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [ ] PR does not add any dependencies, unless permission granted by the HADDOCK team
- [x] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---
Closes #879 
Allows to save generated outputs even in the case when tolerance is under faulty threshold.
