### PR TITLE
Improve alascan output

### DIFF
--- a/integration_tests/test_alascan.py
+++ b/integration_tests/test_alascan.py
@@ -55,12 +55,12 @@ def test_alascan_default(alascan_module, mocker):
     
     # check single complex csv
     df = pd.read_csv(expected_csv1, sep="\t", comment="#")
-    assert df.shape == (10, 16), f"{expected_csv1} has wrong shape"
-    # ARG 17 B should have a positive delta_score
-    assert df.loc[df["ori_resname"] == "ARG"].iloc[0,:]["delta_score"] > 0.0
+    assert df.shape == (10, 15), f"{expected_csv1} has wrong shape"
+    # ARG 17 B should have a negative delta_score
+    assert df.loc[df["ori_resname"] == "ARG"].iloc[0,:]["delta_score"] < 0.0
 
     # check clt csv
     df_clt = pd.read_csv(expected_clt_csv, sep="\t", comment="#")
     assert df_clt.shape == (18, 11), f"{expected_clt_csv} has wrong shape"
-    # average delta score of A-38-ASP should be positive
-    assert df_clt.loc[df_clt["full_resname"] == "A-38-ASP"].iloc[0,:]["delta_score"] > 0.0
+    # average delta score of A-38-ASP should be negative
+    assert df_clt.loc[df_clt["full_resname"] == "A-38-ASP"].iloc[0,:]["delta_score"] < 0.0

--- a/src/haddock/libs/libplots.py
+++ b/src/haddock/libs/libplots.py
@@ -1395,7 +1395,7 @@ def make_alascan_plot(
             # dtick=10,
             ),
         yaxis=dict(
-            title="Weigted delta",
+            title="Average Delta (WT - mutant)",
             titlefont_size=16,
             tickfont_size=14,
             ),

--- a/src/haddock/modules/analysis/alascan/scan.py
+++ b/src/haddock/modules/analysis/alascan/scan.py
@@ -299,7 +299,6 @@ def alascan_cluster_analysis(models):
     # now average the data
     for cl_id in clt_scan:
         scan_clt_filename = f"scan_clt_{cl_id}.csv"
-        #scan_clt_filename = Path(path, f"scan_clt_{cl_id}.csv")
         log.info(f"Writing {scan_clt_filename}")
         clt_data = []
         for ident in clt_scan[cl_id]:
@@ -451,14 +450,8 @@ class Scan:
     def run(self):
         """Run alascan calculations."""
         for native in self.model_list:
-            # original score from the workflow
-            ori_score = native.score
-            try:
-                ori_score = float(ori_score)
-            except ValueError:
-                ori_score = np.nan
-            # here we rescore the native model for consistency, as the ori_score
-            # could come from any module in principle
+            # here we rescore the native model for consistency, as the score
+            # attribute could come from any module in principle
             sc_dir = f"haddock3-score-{self.core}"
             n_score, n_vdw, n_elec, n_des, n_bsa = calc_score(native.rel_path,
                                                               run_dir=sc_dir)
@@ -489,7 +482,7 @@ class Scan:
                     ori_resname = resname_dict[f"{chain}-{res}"]
                     end_resname = self.scan_res
                     if ori_resname == self.scan_res:
-                        # we do not re-score
+                        # we do not re-score equal residues (e.g. ALA = ALA)
                         c_score = n_score
                         c_vdw = n_vdw
                         c_elec = n_elec
@@ -507,29 +500,24 @@ class Scan:
                         c_score, c_vdw, c_elec, c_des, c_bsa = calc_score(
                             mut_pdb_name,
                             run_dir=sc_dir)
-                        # difference with the original score
-                        if ori_score != "-":
-                            delta_ori_score = c_score - ori_score
-                        else:
-                            delta_ori_score = np.nan
-                        # now the deltas with the native
-                        delta_score = c_score - n_score
-                        delta_vdw = c_vdw - n_vdw
-                        delta_elec = c_elec - n_elec
-                        delta_desolv = c_des - n_des
-                        delta_bsa = c_bsa - n_bsa
+                        # now the deltas (wildtype - mutant)
+                        delta_score = n_score - c_score
+                        delta_vdw = n_vdw - c_vdw
+                        delta_elec = n_elec - c_elec
+                        delta_desolv = n_des - c_des
+                        delta_bsa = n_bsa - c_bsa
  
                         scan_data.append([chain, res, ori_resname, end_resname,
                                           c_score, c_vdw, c_elec, c_des,
-                                          c_bsa, delta_ori_score, delta_score,
+                                          c_bsa, delta_score,
                                           delta_vdw, delta_elec, delta_desolv,
                                           delta_bsa])
                         os.remove(mut_pdb_name)
             # write output
             df_columns = ['chain', 'res', 'ori_resname', 'end_resname',
                           'score', 'vdw', 'elec', 'desolv', 'bsa',
-                          'delta_ori_score', 'delta_score', 'delta_vdw',
-                          'delta_elec', 'delta_desolv', 'delta_bsa']
+                          'delta_score', 'delta_vdw', 'delta_elec',
+                          'delta_desolv', 'delta_bsa']
             self.df_scan = pd.DataFrame(scan_data, columns=df_columns)
             alascan_fname = Path(self.path, f"scan_{native.file_name.rstrip('.pdb')}.csv")
             # add zscore

--- a/tests/golden_data/scan_protprot_complex_1.csv
+++ b/tests/golden_data/scan_protprot_complex_1.csv
@@ -3,8 +3,8 @@
 #
 # z_score is calculated with respect to the other residues
 ##########################################################
-chain	res	ori_resname	end_resname	score	vdw	elec	desolv	bsa	delta_ori_score	delta_score	delta_vdw	delta_elec	delta_desolv	delta_bsa	z_score
-A	94	ASP	ALA	-106.700	-29	-316	-13	1494		0.000	0	0	0	0	0.000
-A	90	NEP	ALA	-106.700	-29	-316	-13	1494		0.000	0	0	0	0	0.000
-A	38	ASP	ALA	-106.700	-29	-316	-13	1494		0.000	0	0	0	0	0.000
-A	39	VAL	ALA	-106.700	-29	-316	-13	1494		0.000	0	0	0	0	0.000
+chain	res	ori_resname	end_resname	score	vdw	elec	desolv	bsa	delta_score	delta_vdw	delta_elec	delta_desolv	delta_bsa	z_score
+A	94	ASP	ALA	-106.700	-29	-316	-13	1494	-4.000	-4	0	0	0	0.000
+A	90	NEP	ALA	-106.700	-30	-316	-13	1494	-3.000	-3	0	0	0	0.000
+A	38	ASP	ALA	-106.700	-31	-316	-13	1494	-2.000	-2	0	0	0	0.000
+A	39	VAL	ALA	-106.700	-32	-316	-13	1494	-1.000	-1	0	0	0	0.000

--- a/tests/test_module_alascan.py
+++ b/tests/test_module_alascan.py
@@ -100,7 +100,6 @@ def example_df_scan():
             -275.271,
             -10.252,
             1589.260,
-            -0.243,
             5.401,
             0.119,
             28.482,
@@ -118,7 +117,6 @@ def example_df_scan():
             -270.271,
             -11.252,
             589.260,
-            +0.243,
             4.401,
             0.109,
             27.482,
@@ -137,7 +135,6 @@ def example_df_scan():
         "elec",
         "desolv",
         "bsa",
-        "delta_ori_score",
         "delta_score",
         "delta_vdw",
         "delta_elec",
@@ -277,7 +274,6 @@ def test_scan_run_output(
     """Test Scan run and output method."""
     mocker.patch("haddock.modules.analysis.alascan.scan.calc_score", return_value = (-106.7, -29, -316, -13, 1494))
     scan_obj.run()
-    print(f"os listdir {scan_obj.path}: {os.listdir(scan_obj.path)}")
     assert Path(scan_obj.path, "scan_protprot_complex_1.csv").exists()
     assert scan_obj.df_scan.shape[0] == 2
 
@@ -294,16 +290,6 @@ def test_scan_run_interface(mocker, scan_obj):
 
     assert Path(scan_obj.path, "scan_protprot_complex_1.csv").exists()
     assert scan_obj.df_scan.shape[0] == 5
-
-
-def test_no_oriscore(mocker, scan_obj):
-    """Test Scan run with no ori score"""
-    scan_obj.model_list[0].ori_score = None
-    mocker.patch("haddock.modules.analysis.alascan.scan.calc_score", return_value = (-106.7, -29, -316, -13, 1494))
-    scan_obj.run()
-    df = pd.read_csv(Path(scan_obj.path, "scan_protprot_complex_1.csv"), sep="\t", comment="#")
-    # column delta_ori_score should be nan
-    assert np.isnan(df["delta_ori_score"][0])
     
 
 def test_calc_score(mocker):


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and that you comply with the following criteria:

- [ ] You have sticked to Python. Please talk to us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [ ] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [ ] You structured the code into small functions as much as possible. You can use classes if there is a (state) purpose
- [ ] Your code follows our coding style
- [ ] You wrote tests for the new code
- [ ] `tox` tests pass. *Run `tox` command inside the repository folder*
- [ ] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [ ] PR does not add any dependencies, unless permission granted by the HADDOCK team
- [ ] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---

Closes #866 by:

- changing the plot title
- changing the sign of the deltas
- removing the `ori_score` field, that was containing the difference between the emscoring score of the mutant and the existing score attribute of the wildtype (potentially coming from any module). This does not make much sense, as the only thing that matters is the difference between the two emscoring values