### PR TITLE
Avoid generating `.seed` files

### DIFF
--- a/src/haddock/libs/libontology.py
+++ b/src/haddock/libs/libontology.py
@@ -1,4 +1,5 @@
 """Describe the Haddock3 ontology used for communicating between modules."""
+
 import datetime
 import itertools
 from enum import Enum
@@ -84,6 +85,7 @@ class PDBFile(Persistent):
         self.clt_model_rank: Optional[int] = None
         self.len = score
         self.unw_energies = unw_energies
+        self.seed = None
 
     def __lt__(self, other: "PDBFile") -> bool:
         return self.score < other.score

--- a/src/haddock/modules/refinement/emref/__init__.py
+++ b/src/haddock/modules/refinement/emref/__init__.py
@@ -8,6 +8,7 @@ from haddock.libs.libcns import prepare_cns_input, prepare_expected_pdb
 from haddock.libs.libsubprocess import CNSJob
 from haddock.modules import get_engine
 from haddock.modules.base_cns_module import BaseCNSModule
+from haddock.libs.libontology import PDBFile
 
 
 RECIPE_PATH = Path(__file__).resolve().parent
@@ -81,7 +82,7 @@ class HaddockModule(BaseCNSModule):
             model_idx += 1
 
             for _ in range(self.params["sampling_factor"]):
-                emref_inpyt = prepare_cns_input(
+                emref_input = prepare_cns_input(
                     idx,
                     model,
                     self.path,
@@ -91,6 +92,7 @@ class HaddockModule(BaseCNSModule):
                     ambig_fname=ambig_fname,
                     native_segid=True,
                     less_io=self.params["less_io"],
+                    seed=model.seed if isinstance(model, PDBFile) else None,
                 )
                 out_file = f"emref_{idx}.out"
 
@@ -103,7 +105,7 @@ class HaddockModule(BaseCNSModule):
                     expected_pdb.ori_name = None
                 self.output_models.append(expected_pdb)
 
-                job = CNSJob(emref_inpyt, out_file, envvars=self.envvars)
+                job = CNSJob(emref_input, out_file, envvars=self.envvars)
 
                 jobs.append(job)
 

--- a/src/haddock/modules/refinement/emref/__init__.py
+++ b/src/haddock/modules/refinement/emref/__init__.py
@@ -5,10 +5,10 @@ from pathlib import Path
 from haddock.core.typing import FilePath
 from haddock.gear.haddockmodel import HaddockModel
 from haddock.libs.libcns import prepare_cns_input, prepare_expected_pdb
+from haddock.libs.libontology import PDBFile
 from haddock.libs.libsubprocess import CNSJob
 from haddock.modules import get_engine
 from haddock.modules.base_cns_module import BaseCNSModule
-from haddock.libs.libontology import PDBFile
 
 
 RECIPE_PATH = Path(__file__).resolve().parent

--- a/src/haddock/modules/refinement/emref/cns/emref.cns
+++ b/src/haddock/modules/refinement/emref/cns/emref.cns
@@ -152,22 +152,14 @@ else
 end if
 
 
-{* Read and write random seed in case randremoval=true ===============*}
-
-! The seed definition logic is handled at haddock.libs.libcns.prepare_cns_input (July 2024)
-set seed $seed end
-
-
 {* Read the distance restraints ================================ *}
+set seed $seed end
 set message=normal echo=on end
 inline @MODULE:read_data.cns
 
 ! random removal of restaints
 if ($data.randremoval eq true) then
-    set message=on echo=on end
     noe cv $npart ? end
-else
-    evaluate ($npart = 0)
 end if
 
 if ( $log_level = "verbose" ) then
@@ -412,14 +404,25 @@ if ($data.flags.sym eq true) then
         display CV values set therefore to 0
     end if
     noe reset end
-    set message=normal echo=on end
+    set seed=$seed end
     !read back all the distance restraints:
     @@MODULE:read_noes.cns
+    !random removal of restaints
+    if ($data.randremoval eq true) then
+        noe cv $npart ? end
+    end if
     noe
         scale dist $data.unamb_scale
         scale ambi $data.amb_scale
         scale hbon $data.hbond_scale
     end
+    print threshold=0.3 noe
+    evaluate ($rms_noe=$result)
+    evaluate ($violations_noe=$violations)
+    if ($data.randremoval eq true) then
+        evaluate ($rms_test_noe=$test_rms)
+        evaluate ($violations_test_noe=$test_violations)
+    end if
 else
     print threshold=0.3 noe
     evaluate ($rms_noe=$result)

--- a/src/haddock/modules/refinement/emref/cns/emref.cns
+++ b/src/haddock/modules/refinement/emref/cns/emref.cns
@@ -1,5 +1,5 @@
 ! emref.cns
-!    Performs an energy minimization 
+!    Performs an energy minimization
 !
 ! ***********************************************************************
 ! * Copyright 2003-2022 Alexandre Bonvin, Utrecht University.           *
@@ -74,7 +74,7 @@ evaluate ($data.numc5sym = $numc5sym)
 evaluate ($data.numc6sym = $numc6sym)
 
 !Dihedral angle energy term:
-evaluate ($data.flags.dihed = true) 
+evaluate ($data.flags.dihed = true)
 
 !Electrostatics:
 evaluate ($data.flags.elec =$elecflag)
@@ -154,27 +154,7 @@ end if
 
 {* Read and write random seed in case randremoval=true ===============*}
 
-if ($data.randremoval eq true) then
-    evaluate ($fileseed= $input_pdb_filename_1 - ".pdb" + ".seed")
-    fileexist $fileseed end
-    if ($result eq true) then
-        @@$fileseed (seed=$seed;npart=$npart )
-    else
-        evaluate ($seed = $count*$Saprotocol.iniseed)
-    end if
-    evaluate ($fileseed=$output_pdb_filename - ".pdb" + ".seed")
-    set display=$fileseed end
-    display module(seed;npart)
-    display define (
-    display currentseed = $seed;
-    display currentpart = $npart;
-    display )
-    display evaluate (&seed=&currentseed)
-    display evaluate (&npart=&currentpart)
-    close $fileseed end
-else
-    evaluate ($seed = $count*$Saprotocol.iniseed)
-end if
+! The seed definition logic is handled at haddock.libs.libcns.prepare_cns_input (July 2024)
 set seed $seed end
 
 
@@ -216,7 +196,7 @@ noe
     averaging  * sum
     potential  * soft
     scale      * 1.0
-    scale ambi $amb_scale 
+    scale ambi $amb_scale
     scale dist $unamb_scale
     scale hbon $hbond_scale
     sqconstant * 1.0
@@ -259,9 +239,9 @@ if ($data.ssdihed eq "alphabeta" ) then
 end if
 
 
-restraints dihedral 
+restraints dihedral
     scale=$data.dihedrals_scale
-end 
+end
 
 if ($data.flags.cdih eq true) then
   flag incl cdih end
@@ -279,7 +259,7 @@ fix sele = (not all) end
 ! fix the shape
 fix sele = (resn SHA) end
 
-! fix rigid molecules 
+! fix rigid molecules
 evaluate($nchain1 = 0)
 while ($nchain1 < $data.ncomponents) loop nloop1
     evaluate($nchain1 = $nchain1 + 1)
@@ -295,7 +275,7 @@ end loop nloop1
 do (refx=x) (all)
 do (refy=y) (all)
 do (refz=z) (all)
-restraints harmonic 
+restraints harmonic
    exponent = 2
 end
 do (harm = 0)  (all)
@@ -307,7 +287,7 @@ do (harm = 5)  (not name h* and not resn ANI and not resn DAN and not resn XAN a
 eval ($nchain1 = 0)
 while ($nchain1 < $data.ncomponents) loop nloop1
     eval ($nchain1=$nchain1+1)
-    do (harm = 0)  (attribute store5 = $nchain1) 
+    do (harm = 0)  (attribute store5 = $nchain1)
 end loop nloop1
 
 if ($nemsteps > 0) then
@@ -321,7 +301,7 @@ do (harm = 1)  (name CA or name BB or name C or name N or name P or name C# or n
 eval ($nchain1 = 0)
 while ($nchain1 < $data.ncomponents) loop nloop1
     eval ($nchain1=$nchain1+1)
-    do (harm = 0)  (attribute store5 = $nchain1) 
+    do (harm = 0)  (attribute store5 = $nchain1)
 end loop nloop1
 
 if ($nemsteps > 0) then
@@ -336,7 +316,7 @@ mini powell nstep 200 drop=10 end
 {* ======================= calculate free molecules internal energy ============ *}
 
 igroup
-    interaction (not (resn ANI or resn DAN or resn XAN or resn SHA or resn WAT or resn HOH or resn TIP* or resn DUM)) 
+    interaction (not (resn ANI or resn DAN or resn XAN or resn SHA or resn WAT or resn HOH or resn TIP* or resn DUM))
                 (not (resn ANI or resn DAN or resn XAN or resn SHA or resn WAT or resn HOH or resn TIP* or resn DUM)) weight * 1 end
 end
 
@@ -448,7 +428,7 @@ else
         evaluate ($rms_test_noe=$test_rms)
         evaluate ($violations_test_noe=$test_violations)
     end if
-end if 
+end if
 
 if ($data.dnarest eq true ) then
     @MODULE:dna-rna_restraints.cns

--- a/src/haddock/modules/refinement/emref/cns/emref.cns
+++ b/src/haddock/modules/refinement/emref/cns/emref.cns
@@ -21,8 +21,6 @@ end if
 ! Initialisation of variables
 !==================================================================!
 
-evaluate ($saprotocol.iniseed=$iniseed)
-
 evaluate ($ini_count    =1)
 
 evaluate ($data.ncomponents=$ncomponents)

--- a/src/haddock/modules/refinement/flexref/__init__.py
+++ b/src/haddock/modules/refinement/flexref/__init__.py
@@ -93,6 +93,7 @@ class HaddockModule(BaseCNSModule):
                     ambig_fname=ambig_fname,
                     native_segid=True,
                     less_io=self.params["less_io"],
+                    seed=model.seed if isinstance(model, PDBFile) else None,
                 )
 
                 out_file = f"flexref_{idx}.out"

--- a/src/haddock/modules/refinement/flexref/cns/flexref.cns
+++ b/src/haddock/modules/refinement/flexref/cns/flexref.cns
@@ -225,21 +225,14 @@ if ($SaProtocol.randorien eq true) then
     @MODULE:random_rotations.cns
 end if
 
-{* Read and write random seed in case randremoval=true ===============*}
-
-! The seed definition logic is handled at haddock.libs.libcns.prepare_cns_input (July 2024)
-set seed $seed end
-
-
 {* Read the distance restraints ================================ *}
+set seed $seed end
 set message=normal echo=on end
 inline @MODULE:read_data.cns
 
 ! random removal of restaints
 if ($Data.randremoval eq true) then
     noe cv $npart ? end
-else
-    evaluate ($npart = 0)
 end if
 
 if ( $log_level = "verbose" ) then
@@ -531,22 +524,26 @@ if ($Data.flags.sym eq true) then
     end
     energy end
     evaluate ($esym = $noe)
-    if ($Data.randremoval eq true) then
-        evaluate ($violations_test_noe=0)
-        evaluate ($rms_test_noe=0.0)
-        display Print out of cross-validated violations and rms not
-        display possible in combination with symmetry restraints
-        display CV values set therefore to 0
-    end if
     noe reset end
-    set message=normal echo=on end
+    set seed=$seed end
     !read back all the distance restraints:
     @@MODULE:read_noes.cns
+    ! random removal of restaints
+    if ($Data.randremoval eq true) then
+        noe cv $npart ? end
+    end if
     noe
         scale dist $Data.unamb_cool3
         scale ambi $Data.amb_cool3
         scale hbon $Data.hbond_cool3
     end
+    print threshold=0.3 noe
+    evaluate ($rms_noe=$result)
+    evaluate ($violations_noe=$violations)
+    if ($Data.randremoval eq true) then
+        evaluate ($rms_test_noe=$test_rms)
+        evaluate ($violations_test_noe=$test_violations)
+    end if
 else
     print threshold=0.3 noe
     evaluate ($rms_noe=$result)

--- a/src/haddock/modules/refinement/flexref/cns/flexref.cns
+++ b/src/haddock/modules/refinement/flexref/cns/flexref.cns
@@ -23,7 +23,6 @@ end if
 !==================================================================!
 
 evaluate ($saprotocol.randorien=$randorien)
-evaluate ($saprotocol.iniseed=$iniseed)
 evaluate ($saprotocol.tadhigh_t=$temp_high)
 evaluate ($saprotocol.t1_init=$temp_cool1_init)
 evaluate ($saprotocol.t2_init=$temp_cool2_init)

--- a/src/haddock/modules/refinement/flexref/cns/flexref.cns
+++ b/src/haddock/modules/refinement/flexref/cns/flexref.cns
@@ -227,27 +227,7 @@ end if
 
 {* Read and write random seed in case randremoval=true ===============*}
 
-if ($Data.randremoval eq true) then
-    evaluate ($fileseed= $input_pdb_filename_1 - ".pdb" + ".seed")
-    fileexist $fileseed end
-    if ($result eq true) then
-        @@$fileseed (seed=$seed;npart=$npart )
-    else
-        evaluate ($seed = $count*$Saprotocol.iniseed)
-    end if
-    evaluate ($fileseed=$output_pdb_filename - ".pdb" + ".seed")
-    set display=$fileseed end
-    display module(seed;npart)
-    display define (
-    display currentseed = $seed;
-    display currentpart = $npart;
-    display )
-    display evaluate (&seed=&currentseed)
-    display evaluate (&npart=&currentpart)
-    close $fileseed end
-else
-    evaluate ($seed = $count*$Saprotocol.iniseed)
-end if
+! The seed definition logic is handled at haddock.libs.libcns.prepare_cns_input (July 2024)
 set seed $seed end
 
 
@@ -388,7 +368,7 @@ fix sele=(resn SHA) end
 ! in cases where the number of steps is set to 0 (avoid issues with isolated atoms)
 eval ($torsiondone = false)
 
-! start SA in torsion angle unless a failure was detected 
+! start SA in torsion angle unless a failure was detected
 if ($failure eq false) then
 
     {* Stage 1 ======================================= rigid body high temperature search*}
@@ -443,7 +423,7 @@ if ($failure eq false) then
         evaluate ($SaProtocol.tadfactor = 1)
         @MODULE:sa_ltad_cool3.cns
     end if
-    
+
 end if
 
 {* Stage 5 =========================== final minimization *}
@@ -463,7 +443,7 @@ fix sele=(not all) end
 {* ======================= calculate free molecules internal energy *}
 
 igroup
-    interaction (not (resn ANI or resn DAN or resn XAN or resn SHA or resn WAT or resn HOH or resn TIP* or resn DUM)) 
+    interaction (not (resn ANI or resn DAN or resn XAN or resn SHA or resn WAT or resn HOH or resn TIP* or resn DUM))
                 (not (resn ANI or resn DAN or resn XAN or resn SHA or resn WAT or resn HOH or resn TIP* or resn DUM)) weight * 1 end
 end
 
@@ -575,7 +555,7 @@ else
         evaluate ($rms_test_noe=$test_rms)
         evaluate ($violations_test_noe=$test_violations)
     end if
-end if 
+end if
 
 if ($Data.dnarest eq true ) then
     @MODULE:dna-rna_restraints.cns

--- a/src/haddock/modules/refinement/mdref/__init__.py
+++ b/src/haddock/modules/refinement/mdref/__init__.py
@@ -92,6 +92,7 @@ class HaddockModule(BaseCNSModule):
                     ambig_fname=ambig_fname,
                     native_segid=True,
                     less_io=self.params["less_io"],
+                    seed=model.seed if isinstance(model, PDBFile) else None,
                 )
                 out_file = f"mdref_{idx}.out"
 

--- a/src/haddock/modules/refinement/mdref/cns/mdref.cns
+++ b/src/haddock/modules/refinement/mdref/cns/mdref.cns
@@ -177,27 +177,7 @@ end if
 
 {* Read and write random seed in case randremoval=true ===============*}
 
-if ($Data.randremoval eq true) then
-    evaluate ($fileseed= $input_pdb_filename_1 - ".pdb" + ".seed")
-    fileexist $fileseed end
-    if ($result eq true) then
-        @@$fileseed (seed=$seed;npart=$npart )
-    else
-        evaluate ($seed = $count*$Saprotocol.iniseed)
-    end if
-    evaluate ($fileseed=$output_pdb_filename - ".pdb" + ".seed")
-    set display=$fileseed end
-    display module(seed;npart)
-    display define (
-    display currentseed = $seed;
-    display currentpart = $npart;
-    display )
-    display evaluate (&seed=&currentseed)
-    display evaluate (&npart=&currentpart)
-    close $fileseed end
-else
-    evaluate ($seed = $count*$Saprotocol.iniseed)
-end if
+! The seed definition logic is handled at haddock.libs.libcns.prepare_cns_input (July 2024)
 set seed $seed end
 
 
@@ -242,7 +222,7 @@ noe
     averaging  * sum
     potential  * soft
     scale      * 1.0
-    scale ambi $amb_scale 
+    scale ambi $amb_scale
     scale dist $unamb_scale
     scale hbon $hbond_scale
     sqconstant * 1.0
@@ -311,7 +291,7 @@ fix sele = (not all) end
 ! fix the shape
 fix sele = (resn SHA) end
 
-! fix rigid molecules 
+! fix rigid molecules
 evaluate($nchain1 = 0)
 while ($nchain1 < $data.ncomponents) loop nloop1
     evaluate($nchain1 = $nchain1 + 1)
@@ -328,7 +308,7 @@ do (refy=y) (all)
 do (refz=z) (all)
 
 ! Define harmonic restraints on heavy atoms of molecules
-restraints harmonic 
+restraints harmonic
     exponent = 2
 end
 do (harm = 0)  (all)
@@ -362,7 +342,7 @@ do (harm = 20) (resn DAN and name OO)
 eval ($nchain1 = 0)
 while ($nchain1 < $data.ncomponents) loop nloop1
     eval ($nchain1=$nchain1+1)
-    do (harm = 0)  (attribute store5 = $nchain1 and 
+    do (harm = 0)  (attribute store5 = $nchain1 and
                     not ( name CA or name BB or name C or name N or name P or name C# or name C## ))
 end loop nloop1
 
@@ -372,19 +352,19 @@ end loop nloop1
 do (mass =$Saprotocol.mass) (all)
 do (mass=1000) (resn ANI or resn DAN or resn XAN)
 do (fbeta = 0) (all)
-do (fbeta = $Saprotocol.fbeta {1/ps} ) ( all )                
+do (fbeta = $Saprotocol.fbeta {1/ps} ) ( all )
 
 ! heat to 300 K
 for $bath in (100 200 300) loop heat
 
     do (vx=maxwell($bath)) (all)
     do (vy=maxwell($bath)) (all)
-    do (vz=maxwell($bath)) (all)  
+    do (vz=maxwell($bath)) (all)
 
     dynamics cartesian
-        nstep=$refine.heatsteps timest=0.002{ps}       
+        nstep=$refine.heatsteps timest=0.002{ps}
         temperature=$bath  tcoupling = true
-        nprint=50 
+        nprint=50
     end
 
 end loop heat
@@ -402,17 +382,17 @@ do (harm = 1)  (not name h* and not resn ANI and not resn DAN and not resn XAN a
 eval ($nchain1 = 0)
 while ($nchain1 < $data.ncomponents) loop nloop1
     eval ($nchain1=$nchain1+1)
-    do (harm = 0)  (attribute store5 = $nchain1) 
+    do (harm = 0)  (attribute store5 = $nchain1)
 end loop nloop1
 do (harm = 20) (resn ANI and name OO)
 do (harm = 20) (resn DAN and name OO)
 
 ! MD refinement
 dynamics cartesian
-   nstep=$refine.steps timest=0.002{ps}      
+   nstep=$refine.steps timest=0.002{ps}
    temperature=$bath  tcoupling = true
-   nprint=50 
-end 
+   nprint=50
+end
 
 do (refx=x) (all)
 do (refy=y) (all)
@@ -426,21 +406,21 @@ do (harm = 1)  (name CA or name BB or name C or name N or name P or name C# or n
 eval ($nchain1 = 0)
 while ($nchain1 < $data.ncomponents) loop nloop1
     eval ($nchain1=$nchain1+1)
-    do (harm = 0)  (attribute store5 = $nchain1) 
+    do (harm = 0)  (attribute store5 = $nchain1)
 end loop nloop1
 do (harm = 20) (resn ANI and name OO)
 do (harm = 20) (resn DAN and name OO)
 
 
-! cooling phase 
+! cooling phase
 for $bath in (300 200 100) loop cool
 
     dynamics cartesian
-       nstep=$refine.coolsteps timest=0.002{ps}      
-       temperature=$bath  tcoupling = true                       
-       nprint=50 
+       nstep=$refine.coolsteps timest=0.002{ps}
+       temperature=$bath  tcoupling = true
+       nprint=50
     end
-    
+
 end loop cool
 
 
@@ -456,7 +436,7 @@ end if
 {* ======================= calculate free molecules internal energy *}
 
 igroup
-    interaction (not (resn ANI or resn DAN or resn XAN or resn SHA or resn WAT or resn HOH or resn TIP* or resn DUM)) 
+    interaction (not (resn ANI or resn DAN or resn XAN or resn SHA or resn WAT or resn HOH or resn TIP* or resn DUM))
                 (not (resn ANI or resn DAN or resn XAN or resn SHA or resn WAT or resn HOH or resn TIP* or resn DUM)) weight * 1 end
 end
 
@@ -568,7 +548,7 @@ else
         evaluate ($rms_test_noe=$test_rms)
         evaluate ($violations_test_noe=$test_violations)
     end if
-end if 
+end if
 
 if ($Data.dnarest eq true ) then
     @MODULE:dna-rna_restraints.cns

--- a/src/haddock/modules/refinement/mdref/cns/mdref.cns
+++ b/src/haddock/modules/refinement/mdref/cns/mdref.cns
@@ -175,21 +175,15 @@ elseif ($refine.solvent = "dmso") then
     do (segid = "    ") (segid "PROT")
 end if
 
-{* Read and write random seed in case randremoval=true ===============*}
-
-! The seed definition logic is handled at haddock.libs.libcns.prepare_cns_input (July 2024)
-set seed $seed end
-
 
 {* Read the distance restraints ================================ *}
+set seed $seed end
 set message=normal echo=on end
 inline @MODULE:read_data.cns
 
 ! random removal of restaints
 if ($Data.randremoval eq true) then
     noe cv $npart ? end
-else
-    evaluate ($npart = 0)
 end if
 
 if ( $log_level = "verbose" ) then
@@ -524,22 +518,26 @@ if ($Data.flags.sym eq true) then
     end
     energy end
     evaluate ($esym = $noe)
-    if ($Data.randremoval eq true) then
-        evaluate ($violations_test_noe=0)
-        evaluate ($rms_test_noe=0.0)
-        display Print out of cross-validated violations and rms not
-        display possible in combination with symmetry restraints
-        display CV values set therefore to 0
-    end if
     noe reset end
-    set message=normal echo=on end
+    set seed=$seed end
     !read back all the distance restraints:
     @@MODULE:read_noes.cns
+    !random removal of restaints
+    if ($Data.randremoval eq true) then
+        noe cv $npart ? end
+    end if
     noe
         scale dist $Data.unamb_scale
         scale ambi $Data.amb_scale
         scale hbon $Data.hbond_scale
     end
+    print threshold=0.3 noe
+    evaluate ($rms_noe=$result)
+    evaluate ($violations_noe=$violations)
+    if ($Data.randremoval eq true) then
+        evaluate ($rms_test_noe=$test_rms)
+        evaluate ($violations_test_noe=$test_violations)
+    end if
 else
     print threshold=0.3 noe
     evaluate ($rms_noe=$result)

--- a/src/haddock/modules/refinement/mdref/cns/mdref.cns
+++ b/src/haddock/modules/refinement/mdref/cns/mdref.cns
@@ -21,7 +21,6 @@ end if
 ! Initialisation of variables
 !==================================================================!
 
-evaluate ($saprotocol.iniseed=$iniseed)
 evaluate ($saprotocol.timestep=$timestep)
 evaluate ($saprotocol.fbeta=100)
 evaluate ($saprotocol.mass=100)

--- a/src/haddock/modules/sampling/rigidbody/__init__.py
+++ b/src/haddock/modules/sampling/rigidbody/__init__.py
@@ -109,6 +109,8 @@ class HaddockModule(BaseCNSModule):
                     ambig_fname = ambig_fnames[idx - 1]
                 else:
                     ambig_fname = self.params["ambig_fname"]
+
+                seed = self.params["iniseed"] * idx
                 # prepare cns input
                 rigidbody_input = prepare_cns_input(
                     idx,
@@ -121,6 +123,7 @@ class HaddockModule(BaseCNSModule):
                     default_params_path=self.toppar_path,
                     native_segid=True,
                     less_io=self.params["less_io"],
+                    seed=seed,
                 )
 
                 log_fname = f"rigidbody_{idx}.out"
@@ -129,6 +132,8 @@ class HaddockModule(BaseCNSModule):
                 # Create a model for the expected output
                 model = PDBFile(output_pdb_fname, path=".", restr_fname=ambig_fname)
                 model.topology = [e.topology for e in combination]
+                model.set_seed(seed)
+
                 self.output_models.append(model)
 
                 job = CNSJob(rigidbody_input, log_fname, envvars=self.envvars)

--- a/src/haddock/modules/sampling/rigidbody/__init__.py
+++ b/src/haddock/modules/sampling/rigidbody/__init__.py
@@ -88,7 +88,7 @@ class HaddockModule(BaseCNSModule):
 
         # get all the different ambig files
         prev_ambig_fnames = [None for model in range(self.params["sampling"])]
-        diff_ambig_fnames = self.get_ambig_fnames(prev_ambig_fnames)
+        diff_ambig_fnames = self.get_ambig_fnames(prev_ambig_fnames)  # type: ignore
         # if no files are found, we will stick to self.params["ambig_fname"]
         if diff_ambig_fnames:
             n_diffs = len(diff_ambig_fnames)
@@ -131,8 +131,8 @@ class HaddockModule(BaseCNSModule):
 
                 # Create a model for the expected output
                 model = PDBFile(output_pdb_fname, path=".", restr_fname=ambig_fname)
-                model.topology = [e.topology for e in combination]
-                model.set_seed(seed)
+                model.topology = [e.topology for e in combination]  # type: ignore
+                model.seed = seed
 
                 self.output_models.append(model)
 

--- a/src/haddock/modules/sampling/rigidbody/cns/bestener.cns
+++ b/src/haddock/modules/sampling/rigidbody/cns/bestener.cns
@@ -77,7 +77,6 @@ evaluate ($etot = $etot + $w_lcc * $lcc)
 if ($nfirst = 1) then
     evaluate ($bestener = $etot)
     evaluate ($bestair = $eair)
-    evaluate ($ncvbest = $npart)
     do (refx = x) (all)
     do (refy = y) (all)
     do (refz = z) (all)
@@ -87,7 +86,6 @@ else
     if ($etot < $bestener) then
         evaluate ($bestener = $etot)
         evaluate ($bestair = $eair)
-        evaluate ($ncvbest = $npart)
         do (refx = x) (all)
         do (refy = y) (all)
         do (refz = z) (all)

--- a/src/haddock/modules/sampling/rigidbody/cns/rigidbody.cns
+++ b/src/haddock/modules/sampling/rigidbody/cns/rigidbody.cns
@@ -27,7 +27,6 @@ evaluate ($saprotocol.crossdock=$crossdock)
 evaluate ($saprotocol.randorien=$randorien)
 evaluate ($saprotocol.rigidtrans=$rigidtrans)
 evaluate ($saprotocol.ntrials=$ntrials)
-evaluate ($saprotocol.iniseed=$iniseed)
 evaluate ($saprotocol.inter_rigid=$inter_rigid)
 evaluate ($saprotocol.rotate180=$rotate180)
 

--- a/src/haddock/modules/sampling/rigidbody/cns/rigidbody.cns
+++ b/src/haddock/modules/sampling/rigidbody/cns/rigidbody.cns
@@ -156,22 +156,7 @@ end
 
 flag include bond angle impr vdw end
 
-if ($Data.randremoval eq true) then
-    evaluate ($npart = 1 + mod($count,$Data.npart))
-    evaluate ($fileseed=$output_pdb_filename - ".pdb" + ".seed")
-    evaluate ($seed = $count*$Saprotocol.iniseed)
-    set display=$fileseed end
-    display module(seed;npart)
-    display define (
-    display currentseed = $seed;
-    display currentpart = $npart;
-    display )
-    display evaluate (&seed=&currentseed)
-    display evaluate (&npart=&currentpart)
-    close $fileseed end
-else
-    evaluate ($seed = $count*$Saprotocol.iniseed)
-end if
+! The seed definition logic is handled at haddock.libs.libcns.prepare_cns_input (July 2024)
 set seed $seed end
 
 do (refx=x) (all)
@@ -516,7 +501,7 @@ end if
 energy end
 
 evaluate ($eintcplx = $bond + $angl + $impr + $dihe + $vdw + $elec)
-evaluate ($eintfree = $eintcplx) 
+evaluate ($eintfree = $eintcplx)
 {* at this stage the two are similar since rigid-body EM only *}
 
 {* =========================== write out structure after rigid body refinement *}

--- a/src/haddock/modules/sampling/rigidbody/cns/rigidbody.cns
+++ b/src/haddock/modules/sampling/rigidbody/cns/rigidbody.cns
@@ -122,11 +122,6 @@ while ($nmol1 <=$data.ncomponents) loop mol1
     evaluate ($nmol1 = $nmol1 + 1)
 end loop mol1
 
-
-! Restraints
-evaluate ($npart = $npart)
-
-
 ! Unsupported restraints
 evaluate ($Data.flags.cdih = false)
 evaluate ($Data.flags.em   = false)
@@ -156,9 +151,6 @@ end
 
 flag include bond angle impr vdw end
 
-! The seed definition logic is handled at haddock.libs.libcns.prepare_cns_input (July 2024)
-set seed $seed end
-
 do (refx=x) (all)
 do (refy=y) (all)
 do (refz=z) (all)
@@ -168,17 +160,22 @@ set seed $seed end
 set message=normal echo=on end
 inline @MODULE:read_noes.cns  ! rigidbody version with only distance restraints support
 
+{* random removal of restaints ================================== *}
+if ($Data.randremoval eq true) then
+    noe cv $npart ? end
+end if
+
+if ( $log_level = "verbose" ) then
+    set message=normal echo=on end
+elseif ( $log_level = "normal" ) then
+    set message=normal echo=off end
+else
+    set message=off echo=off end
+end if
+
 {* set distance restraint energy flag =========================== *}
 if ($Data.flags.noe  =  TRUE) then
      flags include noe end
-end if
-
-{* random removal of restaints ================================== *}
-if ($Data.randremoval eq true) then
-    set message=on echo=on end
-    noe cv $npart ? end
-else
-    evaluate ($npart = 0)
 end if
 
 {* ============================================================== *}
@@ -530,28 +527,21 @@ if ($Data.flags.sym eq true) then
         display CV values set therefore to 0
     end if
     noe reset end
-    set message=normal echo=on end
+    set seed=$seed end
     !read again the NOE data, needed to remove the symmetry restraints
     inline @@MODULE:read_noes.cns
-    if ( $log_level = "verbose" ) then
-        set message=normal echo=on end
-    elseif ( $log_level = "normal" ) then
-        set message=normal echo=off end
-    else
-        set message=off echo=off end
+    !random removal of restaints
+    if ($Data.randremoval eq true) then
+        noe cv $npart ? end
+    end if
+    print threshold=0.3 noe
+    evaluate ($rms_noe=$result)
+    evaluate ($violations_noe=$violations)
+    if ($Data.randremoval eq true) then
+        evaluate ($rms_test_noe=$test_rms)
+        evaluate ($violations_test_noe=$test_violations)
     end if
 else
-    if ($Data.randremoval eq true) then
-        set message=on echo=on end
-        noe cv $ncvbest ? end
-    end if
-    if ( $log_level = "verbose" ) then
-        set message=normal echo=on end
-    elseif ( $log_level = "normal" ) then
-        set message=normal echo=off end
-    else
-        set message=off echo=off end
-    end if
     print threshold=0.3 noe
     evaluate ($rms_noe=$result)
     evaluate ($violations_noe=$violations)

--- a/src/haddock/modules/scoring/emscoring/__init__.py
+++ b/src/haddock/modules/scoring/emscoring/__init__.py
@@ -9,10 +9,10 @@ from pathlib import Path
 from haddock.core.typing import FilePath
 from haddock.gear.haddockmodel import HaddockModel
 from haddock.libs.libcns import prepare_cns_input, prepare_expected_pdb
+from haddock.libs.libontology import PDBFile
 from haddock.libs.libsubprocess import CNSJob
 from haddock.modules import get_engine
 from haddock.modules.scoring import CNSScoringModule
-from haddock.libs.libontology import PDBFile
 
 
 RECIPE_PATH = Path(__file__).resolve().parent

--- a/src/haddock/modules/scoring/emscoring/__init__.py
+++ b/src/haddock/modules/scoring/emscoring/__init__.py
@@ -12,6 +12,7 @@ from haddock.libs.libcns import prepare_cns_input, prepare_expected_pdb
 from haddock.libs.libsubprocess import CNSJob
 from haddock.modules import get_engine
 from haddock.modules.scoring import CNSScoringModule
+from haddock.libs.libontology import PDBFile
 
 
 RECIPE_PATH = Path(__file__).resolve().parent
@@ -55,6 +56,7 @@ class HaddockModule(CNSScoringModule):
                 "emscoring",
                 native_segid=True,
                 less_io=self.params["less_io"],
+                seed=model.seed if isinstance(model, PDBFile) else None,
             )
 
             scoring_out = f"emscoring_{model_num}.out"

--- a/src/haddock/modules/scoring/mdscoring/__init__.py
+++ b/src/haddock/modules/scoring/mdscoring/__init__.py
@@ -9,10 +9,10 @@ from pathlib import Path
 from haddock.core.typing import FilePath
 from haddock.gear.haddockmodel import HaddockModel
 from haddock.libs.libcns import prepare_cns_input, prepare_expected_pdb
+from haddock.libs.libontology import PDBFile
 from haddock.libs.libsubprocess import CNSJob
 from haddock.modules import get_engine
 from haddock.modules.scoring import CNSScoringModule
-from haddock.libs.libontology import PDBFile
 
 
 RECIPE_PATH = Path(__file__).resolve().parent

--- a/src/haddock/modules/scoring/mdscoring/__init__.py
+++ b/src/haddock/modules/scoring/mdscoring/__init__.py
@@ -12,6 +12,7 @@ from haddock.libs.libcns import prepare_cns_input, prepare_expected_pdb
 from haddock.libs.libsubprocess import CNSJob
 from haddock.modules import get_engine
 from haddock.modules.scoring import CNSScoringModule
+from haddock.libs.libontology import PDBFile
 
 
 RECIPE_PATH = Path(__file__).resolve().parent
@@ -55,6 +56,7 @@ class HaddockModule(CNSScoringModule):
                 "mdscoring",
                 native_segid=True,
                 less_io=self.params["less_io"],
+                seed=model.seed if isinstance(model, PDBFile) else None,
             )
 
             scoring_out = f"mdscoring_{model_num}.out"

--- a/src/haddock/modules/scoring/mdscoring/cns/mdscoring.cns
+++ b/src/haddock/modules/scoring/mdscoring/cns/mdscoring.cns
@@ -149,7 +149,7 @@ elseif ($refine.solvent = "dmso") then
     do (segid = "    ") (segid "PROT")
 end if
 
-evaluate ($seed = $count*$refine.iniseed)
+! The seed definition logic is handled at haddock.libs.libcns.prepare_cns_input (July 2024)
 set seed $seed end
 
 
@@ -172,7 +172,7 @@ if ($Data.contactairs eq true ) then
         ceiling 1000
         averaging  * sum
         potential  * soft
-        scale      * $kcont 
+        scale      * $kcont
         sqconstant * 1.0
         sqexponent * 2
         soexponent * 1
@@ -234,7 +234,7 @@ do (refy=y) (all)
 do (refz=z) (all)
 
 ! Define harmonic restraints on heavy atoms of molecules
-restraints harmonic 
+restraints harmonic
     exponent = 2
 end
 do (harm = 0)  (all)
@@ -268,7 +268,7 @@ do (harm = 20) (resn DAN and name OO)
 eval ($nchain1 = 0)
 while ($nchain1 < $data.ncomponents) loop nloop1
     eval ($nchain1=$nchain1+1)
-    do (harm = 0)  (attribute store5 = $nchain1 and 
+    do (harm = 0)  (attribute store5 = $nchain1 and
                     not ( name CA or name BB or name C or name N or name P or name C# or name C## ))
 end loop nloop1
 
@@ -278,19 +278,19 @@ end loop nloop1
 do (mass =$refine.mass) (all)
 do (mass=1000) (resn ANI or resn DAN or resn XAN)
 do (fbeta = 0) (all)
-do (fbeta = $refine.fbeta {1/ps} ) ( all )                
+do (fbeta = $refine.fbeta {1/ps} ) ( all )
 
 ! heat to 300 K
 for $bath in (100 200 300) loop heat
 
     do (vx=maxwell($bath)) (all)
     do (vy=maxwell($bath)) (all)
-    do (vz=maxwell($bath)) (all)  
+    do (vz=maxwell($bath)) (all)
 
     dynamics cartesian
-        nstep=$refine.heatsteps timest=0.002{ps}       
+        nstep=$refine.heatsteps timest=0.002{ps}
         temperature=$bath  tcoupling = true
-        nprint=50 
+        nprint=50
     end
 
 end loop heat
@@ -308,17 +308,17 @@ do (harm = 1)  (not name h* and not resn ANI and not resn DAN and not resn XAN a
 eval ($nchain1 = 0)
 while ($nchain1 < $data.ncomponents) loop nloop1
     eval ($nchain1=$nchain1+1)
-    do (harm = 0)  (attribute store5 = $nchain1) 
+    do (harm = 0)  (attribute store5 = $nchain1)
 end loop nloop1
 do (harm = 20) (resn ANI and name OO)
 do (harm = 20) (resn DAN and name OO)
 
 ! MD refinement
 dynamics cartesian
-   nstep=$refine.steps timest=0.002{ps}      
+   nstep=$refine.steps timest=0.002{ps}
    temperature=$bath  tcoupling = true
-   nprint=50 
-end 
+   nprint=50
+end
 
 do (refx=x) (all)
 do (refy=y) (all)
@@ -332,21 +332,21 @@ do (harm = 1)  (name CA or name BB or name C or name N or name P or name C# or n
 eval ($nchain1 = 0)
 while ($nchain1 < $data.ncomponents) loop nloop1
     eval ($nchain1=$nchain1+1)
-    do (harm = 0)  (attribute store5 = $nchain1) 
+    do (harm = 0)  (attribute store5 = $nchain1)
 end loop nloop1
 do (harm = 20) (resn ANI and name OO)
 do (harm = 20) (resn DAN and name OO)
 
 
-! cooling phase 
+! cooling phase
 for $bath in (300 200 100) loop cool
 
     dynamics cartesian
-       nstep=$refine.coolsteps timest=0.002{ps}      
-       temperature=$bath  tcoupling = true                       
-       nprint=50 
+       nstep=$refine.coolsteps timest=0.002{ps}
+       temperature=$bath  tcoupling = true
+       nprint=50
     end
-    
+
 end loop cool
 
 
@@ -362,7 +362,7 @@ end if
 {* ======================= calculate free molecules internal energy *}
 
 igroup
-    interaction (not (resn ANI or resn DAN or resn XAN or resn SHA or resn WAT or resn HOH or resn TIP* or resn DUM)) 
+    interaction (not (resn ANI or resn DAN or resn XAN or resn SHA or resn WAT or resn HOH or resn TIP* or resn DUM))
                 (not (resn ANI or resn DAN or resn XAN or resn SHA or resn WAT or resn HOH or resn TIP* or resn DUM)) weight * 1 end
 end
 

--- a/tests/test_libcns.py
+++ b/tests/test_libcns.py
@@ -129,6 +129,7 @@ def test_prepare_cns_input(pdbfile):
         native_segid=False,
         default_params_path=None,
         less_io=True,
+        seed=pdbfile.seed,
     )
 
     expected_cns_input = f"""
@@ -171,7 +172,6 @@ eval ($input_pdb_filename_1="pdb_1")
 coor @@pdb_2
 eval ($input_pdb_filename_2="pdb_2")
 eval ($ncomponents=1)
-eval ($seed=726)
 """
 
     assert observed_input == expected_input

--- a/tests/test_libcns.py
+++ b/tests/test_libcns.py
@@ -81,7 +81,7 @@ def pdbfile():
                 file_type=Format.TOPOLOGY,
             ),
         )
-        pdb.seed = 42
+        pdb.seed = 42  # type: ignore
         yield pdb
 
 

--- a/tests/test_libcns.py
+++ b/tests/test_libcns.py
@@ -1,9 +1,9 @@
 """Test libcns."""
 
 import os
-from pathlib import Path
-import tempfile
 import random
+import tempfile
+from pathlib import Path
 
 import pytest
 
@@ -11,11 +11,10 @@ from haddock import EmptyPath
 from haddock.libs import libcns
 from haddock.libs.libcns import (
     prepare_cns_input,
-    prepare_multiple_input,
     prepare_expected_pdb,
+    prepare_multiple_input,
 )
-from haddock.libs.libontology import PDBFile, Persistent, Format
-from haddock.core.typing import FilePath
+from haddock.libs.libontology import Format, PDBFile, Persistent
 
 
 @pytest.mark.parametrize(

--- a/tests/test_libcns.py
+++ b/tests/test_libcns.py
@@ -1,22 +1,32 @@
 """Test libcns."""
+
 import os
 from pathlib import Path
+import tempfile
+import random
 
 import pytest
 
 from haddock import EmptyPath
 from haddock.libs import libcns
+from haddock.libs.libcns import (
+    prepare_cns_input,
+    prepare_multiple_input,
+    prepare_expected_pdb,
+)
+from haddock.libs.libontology import PDBFile, Persistent, Format
+from haddock.core.typing import FilePath
 
 
 @pytest.mark.parametrize(
-    'value',
+    "value",
     [
-        {'dic': 1},
+        {"dic": 1},
         tuple([1, 2]),
         [1, 2],
         set([1, 2]),
-        ]
-    )
+    ],
+)
 def test_empty_vars_error(value):
     """Test empty vars of types that are not supported."""
     with pytest.raises(TypeError):
@@ -24,18 +34,18 @@ def test_empty_vars_error(value):
 
 
 @pytest.mark.parametrize(
-    'value',
+    "value",
     [
         True,
         False,
         1,
         12,
         3453.543,
-        'str',
-        Path('path'),
+        "str",
+        Path("path"),
         EmptyPath(),  # empty paths need to be written as ""
-        ]
-    )
+    ],
+)
 def test_empty_vars_True(value):
     """Test empty vars of types that are not supported."""
     result = libcns.filter_empty_vars(value)
@@ -44,13 +54,13 @@ def test_empty_vars_True(value):
 
 
 @pytest.mark.parametrize(
-    'value',
+    "value",
     [
         None,
-        '',
-        float('nan'),
-        ],
-    )
+        "",
+        float("nan"),
+    ],
+)
 def test_empty_vars_False(value):
     """Test empty vars of types that are not supported."""
     result = libcns.filter_empty_vars(value)
@@ -58,28 +68,126 @@ def test_empty_vars_False(value):
     assert type(result) is bool
 
 
+@pytest.fixture
+def pdbfile():
+    """Create a temporary file."""
+    with tempfile.NamedTemporaryFile() as pdb_f, tempfile.NamedTemporaryFile() as top_f:
+
+        pdb = PDBFile(
+            file_name=pdb_f.name,
+            path=Path(pdb_f.name).parent,
+            topology=Persistent(
+                file_name=top_f.name,
+                path=Path(top_f.name).parent,
+                file_type=Format.TOPOLOGY,
+            ),
+        )
+        pdb.seed = 42
+        yield pdb
+
+
 def test_load_workflow_params():
     """Test workflow params."""
     params = {
-        'var1': 1,
-        'var2': 'some string',
-        'var3': True,
-        'var4': Path('some/path'),
-        'var5': 5.5,
-        'var6': '',
-        'var7': None,
-        }
+        "var1": 1,
+        "var2": "some string",
+        "var3": True,
+        "var4": Path("some/path"),
+        "var5": 5.5,
+        "var6": "",
+        "var7": None,
+    }
 
     result = libcns.load_workflow_params(**params)
 
     expected = (
-        f'{os.linesep}'
-        f'! Parameters{os.linesep}'
-        f'eval ($var1=1){os.linesep}'
+        f"{os.linesep}"
+        f"! Parameters{os.linesep}"
+        f"eval ($var1=1){os.linesep}"
         f'eval ($var2="some string"){os.linesep}'
-        f'eval ($var3=true){os.linesep}'
+        f"eval ($var3=true){os.linesep}"
         f'eval ($var4="some/path"){os.linesep}'
-        f'eval ($var5=5.5){os.linesep}'
-        )
+        f"eval ($var5=5.5){os.linesep}"
+    )
 
     assert result == expected
+
+
+def test_prepare_cns_input(pdbfile):
+
+    # TODO: Improve this test to increase coverage AND refactor `prepare_cns_input`
+
+    model_number = 1
+    observed_cns_input = prepare_cns_input(
+        model_number=model_number,
+        input_element=pdbfile,
+        step_path=Path("."),
+        recipe_str="",
+        defaults={},
+        identifier="",
+        ambig_fname="",
+        native_segid=False,
+        default_params_path=None,
+        less_io=True,
+    )
+
+    expected_cns_input = f"""
+! Parameters
+eval ($ambig_fname="")
+
+! Input structure
+structure
+  @@{pdbfile.topology.rel_path}
+end
+coor @@{pdbfile.rel_path}
+eval ($input_pdb_filename_1="{pdbfile.rel_path}")
+eval ($ncomponents=0)
+eval ($seed={pdbfile.seed})
+
+! Output structure
+eval ($output_pdb_filename="_{model_number}.pdb")
+eval ($count=1)
+"""
+
+    assert observed_cns_input == expected_cns_input
+
+
+def test_prepare_multiple_input(mocker):
+
+    mocker.patch("haddock.libs.libpdb.identify_chainseg", return_value="A")
+
+    observed_input = prepare_multiple_input(
+        pdb_input_list=["pdb_1", "pdb_2"],
+        psf_input_list=["psf_1"],
+    )
+
+    expected_input = """
+! Input structure
+structure
+  @@psf_1
+end
+coor @@pdb_1
+eval ($input_pdb_filename_1="pdb_1")
+coor @@pdb_2
+eval ($input_pdb_filename_2="pdb_2")
+eval ($ncomponents=1)
+eval ($seed=726)
+"""
+
+    assert observed_input == expected_input
+
+
+def test_prepare_expected_pdb(pdbfile):
+
+    model_number = random.randint(1, 100)
+    output_pdb = prepare_expected_pdb(
+        model_obj=pdbfile,
+        model_nb=model_number,
+        path=Path.cwd(),
+        identifier="",
+    )
+
+    assert isinstance(output_pdb, PDBFile)
+    assert output_pdb.file_name == f"_{model_number}.pdb"
+    assert output_pdb.topology is not None
+    assert output_pdb.topology.file_name == pdbfile.topology.file_name

--- a/tests/test_libontology.py
+++ b/tests/test_libontology.py
@@ -127,6 +127,7 @@ def test_pdbfile_init_empty():
     assert pdbfile.clt_model_rank is None
     assert math.isnan(pdbfile.len)
     assert pdbfile.unw_energies is None
+    assert pdbfile.seed is None
 
 
 def test_pdbfile_init():

--- a/tests/test_libontology.py
+++ b/tests/test_libontology.py
@@ -13,7 +13,7 @@ from haddock.libs.libontology import (
     Persistent,
     RMSDFile,
     TopologyFile,
-    )
+)
 
 
 @pytest.fixture
@@ -61,7 +61,8 @@ def module_io_with_persistent():
     yield m
 
     for f in file_list:
-        Path(f.name).unlink()
+        if Path(f.name).exists():
+            Path(f.name).unlink()
 
 
 @pytest.fixture

--- a/tests/test_libontology.py
+++ b/tests/test_libontology.py
@@ -13,7 +13,7 @@ from haddock.libs.libontology import (
     Persistent,
     RMSDFile,
     TopologyFile,
-)
+    )
 
 
 @pytest.fixture

--- a/tests/test_libontology.py
+++ b/tests/test_libontology.py
@@ -1,0 +1,339 @@
+import json
+import math
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from haddock.core.typing import Generator
+from haddock.libs.libontology import (
+    Format,
+    ModuleIO,
+    PDBFile,
+    Persistent,
+    RMSDFile,
+    TopologyFile,
+)
+
+
+@pytest.fixture
+def input_pdbfile() -> Generator[PDBFile, None, None]:
+    with tempfile.NamedTemporaryFile() as f:
+        yield PDBFile(file_name=f.name)
+
+
+@pytest.fixture
+def output_pdbfile() -> Generator[PDBFile, None, None]:
+    with tempfile.NamedTemporaryFile() as f:
+        yield PDBFile(file_name=f.name)
+
+
+@pytest.fixture
+def moduleio_with_pdbfile_list(input_pdbfile, output_pdbfile):
+    m = ModuleIO()
+    m.input = [input_pdbfile]
+    m.output = [output_pdbfile, output_pdbfile]
+    return m
+
+
+@pytest.fixture
+def moduleio_with_pdbfile_dict(output_pdbfile):
+    m = ModuleIO()
+    m.input = []
+    m.output = [
+        {0: output_pdbfile, 1: output_pdbfile},
+        {0: output_pdbfile, 1: output_pdbfile},
+    ]
+    return m
+
+
+@pytest.fixture
+def module_io_with_persistent():
+    m = ModuleIO()
+
+    # Create 10 random PDBFile instances and add them to the output list
+    file_list = [tempfile.NamedTemporaryFile(delete=False) for _ in range(10)]
+
+    for f in file_list:
+        p = Persistent(file_name=f.name, file_type=Format.PDB, path=Path(f.name).parent)
+        m.output.append(p)
+
+    yield m
+
+    for f in file_list:
+        Path(f.name).unlink()
+
+
+@pytest.fixture
+def io_data() -> dict:
+    return {"input": ["input"], "output": ["output"]}
+
+
+@pytest.fixture
+def io_json_file(io_data) -> Generator[Path, None, None]:
+    with tempfile.NamedTemporaryFile(mode="w+") as f:
+
+        json.dump(io_data, f)
+
+        f.seek(0)
+
+        yield Path(f.name)
+
+
+def test_persistent_init():
+    target_path = Path(".")
+    file_name = Path("/some/path/test")
+
+    p = Persistent(file_name=file_name, file_type=Format.PDB, path=target_path)
+
+    assert p.created is not None
+    assert p.file_name == file_name.name
+    assert p.file_type == Format.PDB
+    assert p.path == str(target_path.resolve())
+    assert p.full_name == str(target_path / file_name.name)
+    assert p.rel_path == Path("..", Path(target_path).name, file_name)
+    assert p.md5 is None
+    assert p.restr_fname is None
+
+
+def test_persistent_is_present():
+    with tempfile.NamedTemporaryFile() as f:
+
+        p = Persistent(file_name=f.name, file_type=Format.PDB, path=Path(f.name).parent)
+
+        is_present = p.is_present()
+
+        assert is_present
+
+    p = Persistent(file_name="non_existent_file", file_type=Format.PDB)
+
+    assert not p.is_present()
+
+
+def test_pdbfile_init_empty():
+
+    pdbfile = PDBFile(file_name="test.pdb")
+
+    assert pdbfile.file_name == "test.pdb"
+    assert pdbfile.file_type == Format.PDB
+    assert pdbfile.path == str(Path.cwd())
+    assert pdbfile.md5 is None
+    assert pdbfile.restr_fname is None
+    assert pdbfile.topology is None
+    assert math.isnan(pdbfile.score)
+    assert pdbfile.ori_name is None
+    assert pdbfile.clt_id is None
+    assert pdbfile.clt_rank is None
+    assert pdbfile.clt_model_rank is None
+    assert math.isnan(pdbfile.len)
+    assert pdbfile.unw_energies is None
+
+
+def test_pdbfile_init():
+    target_path = Path(".")
+    file_name = Path("/some/path/test")
+    topology = "some topology"
+    score = 10.0
+    md5 = "some md5"
+    restr_fname = "some restraint file"
+
+    pdbfile = PDBFile(
+        file_name=file_name,
+        topology=topology,
+        path=target_path,
+        score=score,
+        md5=md5,
+        restr_fname=restr_fname,
+    )
+
+    assert pdbfile.file_name == file_name.name
+    assert pdbfile.file_type == Format.PDB
+    assert pdbfile.path == str(target_path.resolve())
+    assert pdbfile.full_name == str(target_path / file_name.name)
+    assert pdbfile.rel_path == Path("..", Path(target_path).name, file_name)
+    assert pdbfile.md5 == md5
+    assert pdbfile.restr_fname == restr_fname
+    assert pdbfile.topology == topology
+    assert pdbfile.score == score
+    assert pdbfile.ori_name is None
+    assert pdbfile.clt_id is None
+    assert pdbfile.clt_rank is None
+    assert pdbfile.clt_model_rank is None
+    assert pdbfile.len == score
+    assert pdbfile.unw_energies is None
+
+
+def test_rmsdfile_init():
+
+    npairs = 42
+    file_name = Path("/some/path/test.rmsd")
+    rmsdfile = RMSDFile(file_name=file_name, npairs=npairs)
+
+    assert rmsdfile.file_name == file_name.name
+    assert rmsdfile.file_type == Format.MATRIX
+    assert rmsdfile.path == str(Path.cwd())
+    assert rmsdfile.npairs == npairs
+
+
+def test_topologyfile_init():
+
+    file_name = Path("/some/path/test.top")
+    topologyfile = TopologyFile(file_name=file_name)
+
+    assert topologyfile.file_name == file_name.name
+    assert topologyfile.file_type == Format.TOPOLOGY
+    assert topologyfile.path == str(Path.cwd())
+
+
+def test_moduleio_init():
+
+    moduleio = ModuleIO()
+
+    assert isinstance(moduleio.input, list)
+    assert isinstance(moduleio.output, list)
+
+
+def test_moduleio_add_anything():
+
+    input = "literally anything"
+
+    moduleio = ModuleIO()
+
+    moduleio.add(input, mode="i")
+
+    assert moduleio.input == [input]
+    assert moduleio.output == []
+
+    moduleio = ModuleIO()
+
+    moduleio.add(input, mode="anything not i")
+
+    assert moduleio.input == []
+    assert moduleio.output == [input]
+
+
+def test_moduleio_add_list():
+
+    input = ["literally", "anything"]
+
+    moduleio = ModuleIO()
+
+    moduleio.add(input, mode="i")
+
+    assert moduleio.input == ["literally", "anything"]
+    assert moduleio.output == []
+
+    moduleio = ModuleIO()
+
+    moduleio.add(input, mode="anything not i")
+
+    assert moduleio.input == []
+    assert moduleio.output == ["literally", "anything"]
+
+
+def test_moduleio_save(mocker, moduleio_with_pdbfile_list):
+
+    with tempfile.NamedTemporaryFile() as temp_module_io_f:
+        mocker.patch("haddock.core.defaults", temp_module_io_f.name)
+
+        observed_io_filename = moduleio_with_pdbfile_list.save(
+            filename=temp_module_io_f.name
+        )
+
+        assert observed_io_filename.exists()
+        assert observed_io_filename.stat().st_size > 0
+
+        expected_io_filename = Path.cwd() / temp_module_io_f.name
+
+        assert observed_io_filename == expected_io_filename
+
+        with open(observed_io_filename, "r") as f:
+            observed_data = json.load(f)
+
+        assert isinstance(observed_data, dict)
+
+
+def test_moduleio_load(io_json_file, io_data):
+
+    moduleio = ModuleIO()
+    moduleio.load(filename=io_json_file)
+
+    assert moduleio.input == io_data["input"]
+    assert moduleio.output == io_data["output"]
+
+
+def test_moduleio_retrieve_models_list(moduleio_with_pdbfile_list):
+
+    result = moduleio_with_pdbfile_list.retrieve_models()
+
+    assert isinstance(result, list)
+    assert isinstance(result[0], PDBFile)
+    assert isinstance(result[1], PDBFile)
+
+
+def test_moduleio_retrieve_models_dict(moduleio_with_pdbfile_dict):
+
+    result = moduleio_with_pdbfile_dict.retrieve_models(
+        crossdock=True, individualize=True
+    )
+
+    assert isinstance(result, list)
+    assert isinstance(result[0], PDBFile)
+
+    result = moduleio_with_pdbfile_dict.retrieve_models(
+        crossdock=True, individualize=False
+    )
+
+    assert isinstance(result, list)
+    assert isinstance(result[0], tuple)
+    assert isinstance(result[0][0], PDBFile)
+
+    result = moduleio_with_pdbfile_dict.retrieve_models(
+        crossdock=False, individualize=True
+    )
+
+    assert isinstance(result, list)
+    assert isinstance(result[0], PDBFile)
+
+    result = moduleio_with_pdbfile_dict.retrieve_models(
+        crossdock=False, individualize=False
+    )
+
+    assert isinstance(result, list)
+    assert isinstance(result[0], tuple)
+    assert isinstance(result[0][0], PDBFile)
+
+
+def test_moduleio_check_faulty(mocker, module_io_with_persistent):
+
+    mocker.patch.object(module_io_with_persistent, "remove_missing", return_value=None)
+
+    result = module_io_with_persistent.check_faulty()
+
+    assert isinstance(result, float)
+    assert result == pytest.approx(0.0)
+
+    # Remove 10% of the files
+    total = len(module_io_with_persistent.output)
+    to_remove = int(total * 0.1)
+
+    for i in range(to_remove):
+        module_io_with_persistent.output[i].rel_path.unlink()
+
+    result = module_io_with_persistent.check_faulty()
+
+    assert result == pytest.approx(10.0)
+
+
+def test_moduleio_remove_missing(module_io_with_persistent):
+
+    # Remove the first file
+    first_file = module_io_with_persistent.output[0].rel_path
+    first_file.unlink()
+
+    module_io_with_persistent.remove_missing()
+
+    assert len(module_io_with_persistent.output) == 9
+
+    # Make sure the first file is not in the list anymore
+    assert first_file not in [p.rel_path for p in module_io_with_persistent.output]


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and that you comply with the following criteria:

- [x] You have sticked to Python. Please talk to us before adding other programming languages to HADDOCK3
- [x] Your PR is about CNS
- [x] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [x] You structured the code into small functions as much as possible. You can use classes if there is a (state) purpose
- [x] Your code follows our coding style
- [x] You wrote tests for the new code
- [x] `tox` tests pass. *Run `tox` command inside the repository folder*
- [ ] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [x] PR does not add any dependencies, unless permission granted by the HADDOCK team
- [x] PR does not break licensing
- [x] Your PR is about writing documentation for already existing code :fire:
- [x] Your PR is about writing tests for already existing code :godmode:

---

This PR adds a `seed` property to `libontology.PDBFile` and refactors `libcns` to use this seed when creating the `.inp` files/strings. I also added several tests that were missing for both `libontology` and `libcns`.

I have also changed the `.cns` files that would create this `.seed` files.

In summary what happens is; in `rigidbody` the seed is set according to:

```python
seed = self.params["iniseed"] * idx
```

This is passed to `libcns.prepare_cns_input` which will create a "eval line" with this value.

This seed number is also added to the _expected output_, and subsequent modules will either read this seed - if present, or generate a random one. This should ensure compatibility and not break the current workflows.

@amjjbonvin I have found the place in the CNS routines that would write this `.seed` file but I didn't find the places where it would be read - could you please check if I missed something?
