### PR TITLE
Use `less_io` parameter in `caprieval`

### DIFF
--- a/integration_tests/test_caprieval.py
+++ b/integration_tests/test_caprieval.py
@@ -22,6 +22,14 @@ def caprieval_module():
         )
 
 
+@pytest.fixture
+def model_list():
+    return [
+        PDBFile(file_name="protprot_complex_1.pdb", path="."),
+        PDBFile(file_name="protprot_complex_2.pdb", path="."),
+    ]
+
+
 class MockPreviousIO:
     def __init__(self, path):
         self.path = path
@@ -46,7 +54,7 @@ class MockPreviousIO:
         return None
 
 
-def test_caprieval_default(caprieval_module):
+def test_caprieval_default(caprieval_module, model_list):
 
     caprieval_module.previous_io = MockPreviousIO(path=caprieval_module.path)
     caprieval_module.run()
@@ -66,9 +74,8 @@ def test_caprieval_default(caprieval_module):
 
     # Check if the `output_models` are the same as the `input_models`
     #  they will change locations, so check the filenames
-    input_models = caprieval_module.previous_io.retrieve_models()
-    assert caprieval_module.output_models[0].file_name == input_models[0].file_name
-    assert caprieval_module.output_models[1].file_name == input_models[1].file_name
+    assert caprieval_module.output_models[0].file_name == model_list[0].file_name
+    assert caprieval_module.output_models[1].file_name == model_list[1].file_name
 
     # The models do not hold the capri metrics, so check the output files to see if they were written
     with open(Path(caprieval_module.path, "capri_ss.tsv")) as f:

--- a/integration_tests/test_caprieval.py
+++ b/integration_tests/test_caprieval.py
@@ -54,10 +54,8 @@ class MockPreviousIO:
         return None
 
 
-def test_caprieval_default(caprieval_module, model_list):
-
-    caprieval_module.previous_io = MockPreviousIO(path=caprieval_module.path)
-    caprieval_module.run()
+def evaluate_caprieval_execution(module: CaprievalModule, model_list):
+    """Helper function to check if `caprieval` executed properly."""
 
     # Check if the files were written
     expected_files = [
@@ -69,16 +67,16 @@ def test_caprieval_default(caprieval_module, model_list):
     ]
 
     for file in expected_files:
-        assert Path(caprieval_module.path, file).exists(), f"{file} does not exist"
-        assert Path(caprieval_module.path, file).stat().st_size > 0, f"{file} is empty"
+        assert Path(module.path, file).exists(), f"{file} does not exist"
+        assert Path(module.path, file).stat().st_size > 0, f"{file} is empty"
 
     # Check if the `output_models` are the same as the `input_models`
     #  they will change locations, so check the filenames
-    assert caprieval_module.output_models[0].file_name == model_list[0].file_name
-    assert caprieval_module.output_models[1].file_name == model_list[1].file_name
+    assert module.output_models[0].file_name == model_list[0].file_name
+    assert module.output_models[1].file_name == model_list[1].file_name
 
     # The models do not hold the capri metrics, so check the output files to see if they were written
-    with open(Path(caprieval_module.path, "capri_ss.tsv")) as f:
+    with open(Path(module.path, "capri_ss.tsv")) as f:
         lines = f.readlines()
 
     # Check the values
@@ -171,3 +169,20 @@ def test_caprieval_default(caprieval_module, model_list):
                     ), f"Value mismatch for {key}"
             else:
                 assert v1 == v2, f"Value mismatch for {key}"
+
+
+def test_caprieval_default(caprieval_module, model_list):
+
+    caprieval_module.previous_io = MockPreviousIO(path=caprieval_module.path)
+    caprieval_module.run()
+
+    evaluate_caprieval_execution(caprieval_module, model_list)
+
+
+def test_caprieval_less_io(caprieval_module, model_list):
+    caprieval_module.previous_io = MockPreviousIO(path=caprieval_module.path)
+    caprieval_module.params["less_io"] = True
+
+    caprieval_module.run()
+
+    evaluate_caprieval_execution(caprieval_module, model_list)

--- a/integration_tests/test_caprieval.py
+++ b/integration_tests/test_caprieval.py
@@ -1,14 +1,14 @@
-import pytest
-import tempfile
-from haddock.modules.analysis.caprieval import HaddockModule as CaprievalModule
-from haddock.modules.analysis.caprieval import (
-    DEFAULT_CONFIG as DEFAULT_CAPRIEVAL_CONFIG,
-)
-from haddock.libs.libontology import PDBFile
-from pathlib import Path
 import math
-
 import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from haddock.libs.libontology import PDBFile
+from haddock.modules.analysis.caprieval import \
+    DEFAULT_CONFIG as DEFAULT_CAPRIEVAL_CONFIG
+from haddock.modules.analysis.caprieval import HaddockModule as CaprievalModule
 from tests import golden_data
 
 

--- a/integration_tests/test_caprieval.py
+++ b/integration_tests/test_caprieval.py
@@ -1,0 +1,166 @@
+import pytest
+import tempfile
+from haddock.modules.analysis.caprieval import HaddockModule as CaprievalModule
+from haddock.modules.analysis.caprieval import (
+    DEFAULT_CONFIG as DEFAULT_CAPRIEVAL_CONFIG,
+)
+from haddock.libs.libontology import PDBFile
+from pathlib import Path
+import math
+
+import shutil
+from tests import golden_data
+
+
+@pytest.fixture
+def caprieval_module():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield CaprievalModule(
+            order=0,
+            path=Path(tmpdir),
+            init_params=DEFAULT_CAPRIEVAL_CONFIG,
+        )
+
+
+class MockPreviousIO:
+    def __init__(self, path):
+        self.path = path
+
+    def retrieve_models(self, individualize: bool = True):
+        shutil.copy(
+            Path(golden_data, "protprot_complex_1.pdb"),
+            Path(".", "protprot_complex_1.pdb"),
+        )
+        shutil.copy(
+            Path(golden_data, "protprot_complex_2.pdb"),
+            Path(".", "protprot_complex_2.pdb"),
+        )
+        model_list = [
+            PDBFile(file_name="protprot_complex_1.pdb", path="."),
+            PDBFile(file_name="protprot_complex_2.pdb", path="."),
+        ]
+
+        return model_list
+
+    def output(self):
+        return None
+
+
+def test_caprieval_default(caprieval_module):
+
+    caprieval_module.previous_io = MockPreviousIO(path=caprieval_module.path)
+    caprieval_module.run()
+
+    # Check if the files were written
+    expected_files = [
+        "blosum62.izone",
+        "blosum62_A.aln",
+        "blosum62_B.aln",
+        "capri_clt.tsv",
+        "capri_ss.tsv",
+    ]
+
+    for file in expected_files:
+        assert Path(caprieval_module.path, file).exists(), f"{file} does not exist"
+        assert Path(caprieval_module.path, file).stat().st_size > 0, f"{file} is empty"
+
+    # Check if the `output_models` are the same as the `input_models`
+    #  they will change locations, so check the filenames
+    input_models = caprieval_module.previous_io.retrieve_models()
+    assert caprieval_module.output_models[0].file_name == input_models[0].file_name
+    assert caprieval_module.output_models[1].file_name == input_models[1].file_name
+
+    # The models do not hold the capri metrics, so check the output files to see if they were written
+    with open(Path(caprieval_module.path, "capri_ss.tsv")) as f:
+        lines = f.readlines()
+
+    # Check the values
+    assert len(lines) == 3, "There should be 3 lines in the capri_ss.tsv"
+
+    # Check the header
+    # model   md5     caprieval_rank  score   irmsd   fnat    lrmsd   ilrmsd  dockq   cluster_id      cluster_ranking model-cluster_ranking
+    expected_colnames = [
+        "model",
+        "md5",
+        "caprieval_rank",
+        "score",
+        "irmsd",
+        "fnat",
+        "lrmsd",
+        "ilrmsd",
+        "dockq",
+        "cluster_ranking",
+        "model-cluster_ranking",
+    ]
+    header = lines[0].strip().split("\t")
+    for col_name in expected_colnames:
+        assert col_name in header, f"{col_name} not found in the header"
+
+    # Check the values
+    data = lines[1:]
+    expected_data = [
+        {
+            "model": "",
+            "md5": "-",
+            "caprieval_rank": 1,
+            "score": float("nan"),
+            "irmsd": 0.000,
+            "fnat": 1.000,
+            "lrmsd": 0.000,
+            "ilrmsd": 0.000,
+            "dockq": 1.000,
+            "cluster_id": "-",
+            "cluster_ranking": "-",
+            "model-cluster_ranking": "-",
+        },
+        {
+            "model": "",
+            "md5": "-",
+            "caprieval_rank": 2,
+            "score": float("nan"),
+            "irmsd": 8.327,
+            "fnat": 0.050,
+            "lrmsd": 20.937,
+            "ilrmsd": 18.248,
+            "dockq": 0.074,
+            "cluster_id": "-",
+            "cluster_ranking": "-",
+            "model-cluster_ranking": "-",
+        },
+    ]
+    oberseved_data = []
+    for line in data:
+        values = line.strip().split("\t")
+        data_dict = {
+            "model": "",  # don't check this, it's a path and will change
+            "md5": str(values[1]),
+            "caprieval_rank": int(values[2]),
+            "score": float(values[3]),
+            "irmsd": float(values[4]),
+            "fnat": float(values[5]),
+            "lrmsd": float(values[6]),
+            "ilrmsd": float(values[7]),
+            "dockq": float(values[8]),
+            "cluster_id": str(values[9]),
+            "cluster_ranking": str(values[10]),
+            "model-cluster_ranking": str(values[11]),
+        }
+        oberseved_data.append(data_dict)
+
+    for k, v in zip(expected_data, oberseved_data):
+        for key in k:
+            v1 = k[key]
+            v2 = v[key]
+
+            # Check the type
+            assert type(v1) == type(v2), f"Type mismatch for {key}"
+
+            if isinstance(v1, float):
+                if math.isnan(v1):
+                    assert math.isnan(v2), f"Value mismatch for {key}"
+                else:
+                    assert (
+                        pytest.approx(v1, rel=1e-3) == v2
+                    ), f"Value mismatch for {key}"
+            else:
+                assert v1 == v2, f"Value mismatch for {key}"

--- a/src/haddock/modules/analysis/caprieval/capri.py
+++ b/src/haddock/modules/analysis/caprieval/capri.py
@@ -9,7 +9,6 @@ from pathlib import Path
 
 
 os.environ["OPENBLAS_NUM_THREADS"] = "1"
-from typing import Any
 
 import numpy as np
 from pdbtools import pdb_segxchain
@@ -18,6 +17,7 @@ from scipy.spatial.distance import cdist
 from haddock import log
 from haddock.core.defaults import CNS_MODULES
 from haddock.core.typing import (
+    Any,
     AtomsDict,
     FilePath,
     Iterable,

--- a/src/haddock/modules/analysis/caprieval/capri.py
+++ b/src/haddock/modules/analysis/caprieval/capri.py
@@ -907,7 +907,7 @@ def extract_data_from_capri_class(
     sort_key: str,
     sort_ascending: bool,
     output_fname: Path,
-):
+) -> Union[dict[int, ParamDict], None]:
     """
     Extracts data attributes from a list of CAPRI objects into a structured dictionary,
     optionally sorts the data based on a specified key, and writes the sorted data to

--- a/src/haddock/modules/analysis/caprieval/capri.py
+++ b/src/haddock/modules/analysis/caprieval/capri.py
@@ -1,11 +1,12 @@
 """CAPRI module."""
+
 import os
 import shutil
 import tempfile
 from itertools import combinations
 from pathlib import Path
 
-os.environ['OPENBLAS_NUM_THREADS'] = '1'
+os.environ["OPENBLAS_NUM_THREADS"] = "1"
 import numpy as np
 from pdbtools import pdb_segxchain
 from scipy.spatial.distance import cdist
@@ -22,7 +23,7 @@ from haddock.core.typing import (
     ParamDict,
     ParamMap,
     Union,
-    )
+)
 from haddock.libs.libalign import (
     ALIGNError,
     calc_rmsd,
@@ -32,7 +33,7 @@ from haddock.libs.libalign import (
     kabsch,
     load_coords,
     make_range,
-    )
+)
 from haddock.libs.libio import write_dic_to_file, write_nested_dic_to_file
 from haddock.libs.libontology import PDBFile, PDBPath
 from haddock.modules import get_module_steps_folders
@@ -80,33 +81,33 @@ def save_scoring_weights(cns_step: str) -> Path:
     ----------
     cns_step : str
         Name of the CNS step.
-    
+
     Returns
     -------
     scoring_params_fname : Path
         Path to the json file.
     """
     cns_params = read_config(Path("..", cns_step, "params.cfg"))
-    key = list(cns_params['final_cfg'].keys())[0]
-    scoring_pars = {kv: cns_params['final_cfg'][key][kv] for kv in WEIGHTS}
+    key = list(cns_params["final_cfg"].keys())[0]
+    scoring_pars = {kv: cns_params["final_cfg"][key][kv] for kv in WEIGHTS}
 
     scoring_params_fname = Path("weights_params.json")
     # write json file
-    with open(scoring_params_fname, 'w', encoding='utf-8') as jsonf:
+    with open(scoring_params_fname, "w", encoding="utf-8") as jsonf:
         json.dump(
             scoring_pars,
             jsonf,
             indent=4,
-            )
+        )
     return scoring_params_fname
 
 
 def load_contacts(
-        pdb_f: Union[Path, PDBFile],
-        cutoff: float = 5.0,
-        numbering_dic: Optional[dict[str, dict[int, int]]] = None,
-        model2ref_chain_dict: Optional[dict[str, str]] = None,
-        ) -> set[tuple]:
+    pdb_f: Union[Path, PDBFile],
+    cutoff: float = 5.0,
+    numbering_dic: Optional[dict[str, dict[int, int]]] = None,
+    model2ref_chain_dict: Optional[dict[str, str]] = None,
+) -> set[tuple]:
     """Load residue-based contacts.
 
     Parameters
@@ -130,7 +131,7 @@ def load_contacts(
         atoms,
         numbering_dic=numbering_dic,
         model2ref_chain_dict=model2ref_chain_dict,
-        )
+    )
     # create coordinate arrays
     coord_arrays: dict[str, NDFloat] = {}
     coord_ids: dict[str, list[int]] = {}
@@ -166,13 +167,13 @@ class CAPRI:
     """CAPRI class."""
 
     def __init__(
-            self,
-            identificator: str,
-            model: PDBPath,
-            path: Path,
-            reference: PDBPath,
-            params: ParamMap,
-            ) -> None:
+        self,
+        identificator: str,
+        model: PDBPath,
+        path: Path,
+        reference: PDBPath,
+        params: ParamMap,
+    ) -> None:
         """
         Initialize the class.
 
@@ -196,11 +197,11 @@ class CAPRI:
             self.model = model
         self.path = path
         self.params = params
-        self.irmsd = float('nan')
-        self.lrmsd = float('nan')
-        self.ilrmsd = float('nan')
-        self.fnat = float('nan')
-        self.dockq = float('nan')
+        self.irmsd = float("nan")
+        self.lrmsd = float("nan")
+        self.ilrmsd = float("nan")
+        self.fnat = float("nan")
+        self.dockq = float("nan")
         self.allatoms = params["allatoms"]
         self.atoms = self._load_atoms(model, reference, full=self.allatoms)
         self.r_chain = params["receptor_chain"]
@@ -231,7 +232,7 @@ class CAPRI:
             # Load interface coordinates
             ref_coord_dic, _ = load_coords(
                 self.reference, self.atoms, ref_interface_resdic
-                )
+            )
             try:
                 mod_coord_dic, _ = load_coords(
                     self.model,
@@ -239,7 +240,7 @@ class CAPRI:
                     ref_interface_resdic,
                     numbering_dic=self.model2ref_numbering,
                     model2ref_chain_dict=self.model2ref_chain_dict,
-                    )
+                )
             except ALIGNError as alignerror:
                 log.warning(alignerror)
                 return
@@ -280,7 +281,7 @@ class CAPRI:
                 self.atoms,
                 numbering_dic=self.model2ref_numbering,
                 model2ref_chain_dict=self.model2ref_chain_dict,
-                )
+            )
         except ALIGNError as alignerror:
             log.warning(alignerror)
             return
@@ -322,8 +323,8 @@ class CAPRI:
             # write_coords("model_first.pdb", P)
 
             # get receptor and ligand coordinates
-            Q_r_first = Q[r_start:r_end + 1]
-            P_r_first = P[r_start:r_end + 1]
+            Q_r_first = Q[r_start : r_end + 1]
+            P_r_first = P[r_start : r_end + 1]
             # write_coords("ref_r_first.pdb", Q_r_first)
             # write_coords("model_r_first.pdb", P_r_first)
             # Q_l_first = Q[l_start: l_end + 1]
@@ -337,8 +338,8 @@ class CAPRI:
             P = P - centroid(P_r_first)
 
             # get receptor coordinates
-            Q_r = Q[r_start:r_end + 1]
-            P_r = P[r_start:r_end + 1]
+            Q_r = Q[r_start : r_end + 1]
+            P_r = P[r_start : r_end + 1]
             # Center receptors and get rotation matrix
             # Q_r = Q_r - centroid(Q_r)
             # P_r = P_r - centroid(P_r)
@@ -358,8 +359,8 @@ class CAPRI:
             Q_l = np.empty((0, 3))
             P_l = np.empty((0, 3))
             for l_start, l_end in zip(l_starts, l_ends):
-                Q_l = np.concatenate((Q_l, Q[l_start:l_end + 1]))
-                P_l = np.concatenate((P_l, P[l_start:l_end + 1]))
+                Q_l = np.concatenate((Q_l, Q[l_start : l_end + 1]))
+                P_l = np.concatenate((P_l, P[l_start : l_end + 1]))
             # Q_l = Q[l_start: l_end + 1]
             # P_l = P[l_start: l_end + 1]
 
@@ -383,7 +384,7 @@ class CAPRI:
 
         ref_int_coord_dic, _ = load_coords(
             self.reference, self.atoms, ref_interface_resdic
-            )
+        )
         try:
             mod_int_coord_dic, _ = load_coords(
                 self.model,
@@ -391,7 +392,7 @@ class CAPRI:
                 ref_interface_resdic,
                 numbering_dic=self.model2ref_numbering,
                 model2ref_chain_dict=self.model2ref_chain_dict,
-                )
+            )
         except ALIGNError as alignerror:
             log.warning(alignerror)
             return
@@ -437,16 +438,16 @@ class CAPRI:
             # write_coords("model.pdb", P)
 
             # put system at origin of the receptor interface
-            Q_r_int = Q_int[r_start:r_end + 1]
-            P_r_int = P_int[r_start:r_end + 1]
+            Q_r_int = Q_int[r_start : r_end + 1]
+            P_r_int = P_int[r_start : r_end + 1]
 
             Q_int = Q_int - centroid(Q_r_int)
             P_int = P_int - centroid(P_r_int)
             # put interfaces at the origin
 
             # find the rotation that minimizes the receptor interface rmsd
-            Q_r_int = Q_int[r_start:r_end + 1]
-            P_r_int = P_int[r_start:r_end + 1]
+            Q_r_int = Q_int[r_start : r_end + 1]
+            P_r_int = P_int[r_start : r_end + 1]
 
             U_int = kabsch(P_r_int, Q_r_int)
             P_int = np.dot(P_int, U_int)
@@ -460,8 +461,8 @@ class CAPRI:
             Q_l_int = np.empty((0, 3))
             P_l_int = np.empty((0, 3))
             for l_start, l_end in zip(l_starts, l_ends):
-                Q_l_int = np.concatenate((Q_l_int, Q_int[l_start:l_end + 1]))
-                P_l_int = np.concatenate((P_l_int, P_int[l_start:l_end + 1]))
+                Q_l_int = np.concatenate((Q_l_int, Q_int[l_start : l_end + 1]))
+                P_l_int = np.concatenate((P_l_int, P_int[l_start : l_end + 1]))
             # prior to multibody:
             # Q_l_int = Q_int[l_start: l_end + 1]
             # P_l_int = P_int[l_start: l_end + 1]
@@ -487,7 +488,7 @@ class CAPRI:
                     cutoff,
                     numbering_dic=self.model2ref_numbering,
                     model2ref_chain_dict=self.model2ref_chain_dict,
-                    )
+                )
             except ALIGNError as alignerror:
                 log.warning(alignerror)
             else:
@@ -562,15 +563,15 @@ class CAPRI:
             align_func = get_align(
                 method=self.params["alignment_method"],
                 lovoalign_exec=self.params["lovoalign_exec"],
-                )
+            )
             self.model2ref_numbering, self.model2ref_chain_dict = align_func(
                 self.reference, self.model, self.path
-                )
+            )
         except ALIGNError:
             log.warning(
                 f"Alignment failed between {self.reference} "
                 f"and {self.model}, skipping..."
-                )
+            )
             return
         # print(f"model2ref_numbering {self.model2ref_numbering}")
         # print(f"model2ref_chain_dict {self.model2ref_chain_dict}")
@@ -640,10 +641,10 @@ class CAPRI:
 
     @staticmethod
     def _load_atoms(
-            model: PDBPath,
-            reference: PDBPath,
-            full: bool = False,
-            ) -> AtomsDict:
+        model: PDBPath,
+        reference: PDBPath,
+        full: bool = False,
+    ) -> AtomsDict:
         """
         Load atoms from a model and reference.
 
@@ -670,9 +671,9 @@ class CAPRI:
 
     @staticmethod
     def identify_interface(
-            pdb_f: PDBPath,
-            cutoff: float = 5.0,
-            ) -> dict[str, list[int]]:
+        pdb_f: PDBPath,
+        cutoff: float = 5.0,
+    ) -> dict[str, list[int]]:
         """Identify the interface.
 
         Parameters
@@ -765,12 +766,12 @@ def merge_data(capri_jobs: list[CAPRI]) -> list[CAPRI]:
 
 
 def rearrange_ss_capri_output(
-        output_name: str,
-        output_count: int,
-        sort_key: str,
-        sort_ascending: bool,
-        path: FilePath,
-        ) -> None:
+    output_name: str,
+    output_count: int,
+    sort_key: str,
+    sort_ascending: bool,
+    path: FilePath,
+) -> None:
     """Combine different capri outputs in a single file.
 
     Parameters
@@ -791,7 +792,7 @@ def rearrange_ss_capri_output(
     split_dict = {
         "capri_ss": "model-cluster_ranking",
         "capri_clt": "caprieval_rank",
-        }
+    }
     if keyword not in split_dict.keys():
         raise Exception(f"Keyword {keyword} does not exist.")
 
@@ -806,8 +807,8 @@ def rearrange_ss_capri_output(
                 (
                     f"Output file {out_file} does not exist. "
                     "Caprieval will not be exhaustive..."
-                    )
                 )
+            )
             continue
 
         data[ident] = {}
@@ -843,7 +844,7 @@ def rearrange_ss_capri_output(
     rankkey_values.sort(
         key=lambda x: x[1],
         reverse=True if not sort_ascending else False,
-        )
+    )
 
     _data = {}
     for i, (data_idx, _) in enumerate(rankkey_values):
@@ -877,19 +878,22 @@ def calc_stats(data: list) -> tuple[float, float]:
     stdev = np.std(data)
     return mean, stdev
 
+
 # Define dict types
-CltData = dict[tuple[Optional[int], Union[int, str, None]], list[tuple[CAPRI, PDBFile]]]  # noqa : E501
+CltData = dict[
+    tuple[Optional[int], Union[int, str, None]], list[tuple[CAPRI, PDBFile]]
+]  # noqa : E501
 
 
 def capri_cluster_analysis(
-        capri_list: Iterable[CAPRI],
-        model_list: Iterable[PDBFile],
-        output_fname: FilePath,
-        clt_threshold: int,
-        sort_key: str,
-        sort_ascending: bool,
-        path: FilePath,
-        ) -> None:
+    capri_list: Iterable[CAPRI],
+    model_list: Iterable[PDBFile],
+    output_fname: FilePath,
+    clt_threshold: int,
+    sort_key: str,
+    sort_ascending: bool,
+    path: FilePath,
+) -> None:
     """Consider the cluster results for the CAPRI evaluation."""
     capri_keys = ["irmsd", "fnat", "lrmsd", "dockq"]
     model_keys = ["air", "bsa", "desolv", "elec", "total", "vdw"]
@@ -918,9 +922,7 @@ def capri_cluster_analysis(
             data["under_eval"] = "-"
         # score
         try:
-            score_array = [
-                e[1].score for e in clt_data[element][:clt_threshold]
-                ]
+            score_array = [e[1].score for e in clt_data[element][:clt_threshold]]
             data["score"], data["score_std"] = calc_stats(score_array)
         except KeyError:
             data["score"] = float("nan")
@@ -930,9 +932,7 @@ def capri_cluster_analysis(
         for key in capri_keys:
             std_key = f"{key}_std"
             try:
-                key_array = [
-                    vars(e[0])[key] for e in clt_data[element][:clt_threshold]
-                    ]
+                key_array = [vars(e[0])[key] for e in clt_data[element][:clt_threshold]]
                 data[key], data[std_key] = calc_stats(key_array)
             except KeyError:
                 data[key] = float("nan")
@@ -946,7 +946,7 @@ def capri_cluster_analysis(
                     key_array = [
                         vars(e[1])["unw_energies"][key]
                         for e in clt_data[element][:clt_threshold]
-                        ]
+                    ]
                     data[key], data[std_key] = calc_stats(key_array)
                 except KeyError:
                     data[key] = float("nan")
@@ -966,7 +966,7 @@ def capri_cluster_analysis(
     rankkey_values.sort(
         key=lambda x: x[1],
         reverse=True if not sort_ascending else False,
-        )
+    )
 
     _output_dic = {}
     for i, k in enumerate(rankkey_values):
@@ -986,19 +986,15 @@ def capri_cluster_analysis(
     info_header += (
         "# NOTE: if under_eval=yes, it means that there were less models in"
         " a cluster than" + os.linesep
-        )
+    )
     info_header += (
-        "#    clt_threshold, thus these values were under "
-        "evaluated." + os.linesep
-        )
+        "#    clt_threshold, thus these values were under " "evaluated." + os.linesep
+    )
     info_header += (
         "#   You might need to tweak the value of clt_threshold or change"
         " some parameters" + os.linesep
-        )
-    info_header += (
-        "#    in `clustfcc` depending on your "
-        "analysis." + os.linesep
-        )
+    )
+    info_header += "#    in `clustfcc` depending on your " "analysis." + os.linesep
     info_header += "#" + os.linesep
     info_header += "#" * 40
 
@@ -1010,7 +1006,7 @@ def capri_cluster_analysis(
             output_dic,
             output_fname,
             info_header=info_header,
-            )
+        )
 
 
 class CAPRIError(Exception):
@@ -1019,6 +1015,17 @@ class CAPRIError(Exception):
     def __init__(self, msg: str = "") -> None:
         self.msg = msg
         super().__init__(self.msg)
+
+
+def dump_weights(order: int) -> None:
+    sel_steps = get_module_steps_folders(Path(".."))
+    cns_step = get_previous_cns_step(sel_steps=sel_steps, st_order=order)
+    if cns_step:
+        log.info(f"Found previous CNS step: {cns_step}")
+        scoring_params_fname = save_scoring_weights(cns_step)
+        log.info(f"Saved scoring weights to: {scoring_params_fname}")
+    else:
+        log.info("No previous CNS step found. Cannot save scoring weights.")
 
 
 # # debug only

--- a/tests/test_module_caprieval.py
+++ b/tests/test_module_caprieval.py
@@ -1,5 +1,7 @@
 """Test the CAPRI module."""
+
 import os
+import random
 import shutil
 import tempfile
 from pathlib import Path
@@ -22,17 +24,20 @@ from . import golden_data
 
 def remove_aln_files(class_name):
     """Remove intermediary alignment files."""
-    file_l = [Path(class_name.path, 'blosum62.izone'),
-              Path(class_name.path, 'blosum62_A.aln'),
-              Path(class_name.path, 'blosum62_B.aln')]
+    file_l = [
+        Path(class_name.path, "blosum62.izone"),
+        Path(class_name.path, "blosum62_A.aln"),
+        Path(class_name.path, "blosum62_B.aln"),
+    ]
     for f in file_l:
         if f.exists():
             os.unlink(f)
 
 
 def read_capri_file(fname):
-    file_content = [e.split()[1:] for e in open(fname).readlines()
-                    if not e.startswith('#')]
+    file_content = [
+        e.split()[1:] for e in open(fname).readlines() if not e.startswith("#")
+    ]
     return file_content
 
 
@@ -41,8 +46,8 @@ def protprot_input_list():
     """Prot-prot input."""
     return [
         PDBFile(Path(golden_data, "protprot_complex_1.pdb"), path=golden_data),
-        PDBFile(Path(golden_data, "protprot_complex_2.pdb"), path=golden_data)
-        ]
+        PDBFile(Path(golden_data, "protprot_complex_2.pdb"), path=golden_data),
+    ]
 
 
 @pytest.fixture
@@ -54,8 +59,8 @@ def protprot_1bkd_input_list():
     """
     return [
         PDBFile(Path(golden_data, "protprot_1bkd_1.pdb"), path=golden_data),
-        PDBFile(Path(golden_data, "protprot_1bkd_2.pdb"), path=golden_data)
-        ]
+        PDBFile(Path(golden_data, "protprot_1bkd_2.pdb"), path=golden_data),
+    ]
 
 
 @pytest.fixture
@@ -63,8 +68,8 @@ def protdna_input_list():
     """Prot-DNA input."""
     return [
         PDBFile(Path(golden_data, "protdna_complex_1.pdb"), path=golden_data),
-        PDBFile(Path(golden_data, "protdna_complex_2.pdb"), path=golden_data)
-        ]
+        PDBFile(Path(golden_data, "protdna_complex_2.pdb"), path=golden_data),
+    ]
 
 
 @pytest.fixture
@@ -73,15 +78,13 @@ def protlig_input_list():
     return [
         PDBFile(Path(golden_data, "protlig_complex_1.pdb"), path=golden_data),
         PDBFile(Path(golden_data, "protlig_complex_2.pdb"), path=golden_data),
-        ]
+    ]
 
 
 @pytest.fixture
 def protprot_onechain_list():
     """Protein-Protein complex with a single chain ID."""
-    return [
-        PDBFile(Path(golden_data, "protprot_onechain.pdb"), path=golden_data)
-        ]
+    return [PDBFile(Path(golden_data, "protprot_onechain.pdb"), path=golden_data)]
 
 
 @pytest.fixture
@@ -91,7 +94,7 @@ def params():
         "ligand_chains": ["B"],
         "aln_method": "sequence",
         "allatoms": False,
-        }
+    }
 
 
 @pytest.fixture
@@ -101,7 +104,7 @@ def params_all():
         "ligand_chains": ["B"],
         "aln_method": "sequence",
         "allatoms": True,
-        }
+    }
 
 
 @pytest.fixture
@@ -115,7 +118,7 @@ def protdna_caprimodule(protdna_input_list, params):
         model=model,
         path=golden_data,
         params=params,
-        )
+    )
 
     yield capri
 
@@ -133,7 +136,7 @@ def protlig_caprimodule(protlig_input_list, params):
         model=model,
         path=golden_data,
         params=params,
-        )
+    )
 
     yield capri
 
@@ -151,7 +154,7 @@ def protprot_caprimodule(protprot_input_list, params):
         model=model,
         path=golden_data,
         params=params,
-        )
+    )
 
     yield capri
 
@@ -169,7 +172,7 @@ def protprot_allatm_caprimodule(protprot_input_list, params_all):
         model=model,
         path=golden_data,
         params=params_all,
-        )
+    )
 
     yield capri
 
@@ -187,7 +190,7 @@ def protprot_1bkd_caprimodule(protprot_1bkd_input_list, params):
         model=model,
         path=golden_data,
         params=params,
-        )
+    )
 
     yield capri
 
@@ -207,8 +210,8 @@ def protprot_caprimodule_parallel(protprot_input_list):
         aln_method="sequence",
         path=golden_data,
         identificator=0,
-        core_model_idx=0
-        )
+        core_model_idx=0,
+    )
 
     yield capri
 
@@ -253,23 +256,15 @@ def test_protprot_dockq(protprot_caprimodule):
 
 
 def test_protprot_bb_vs_all_atoms(
-        protprot_caprimodule,
-        protprot_allatm_caprimodule,
-        ):
+    protprot_caprimodule,
+    protprot_allatm_caprimodule,
+):
     """Test difference between all and backbone atoms selection."""
     assert protprot_caprimodule.allatoms is False
     assert protprot_allatm_caprimodule.allatoms is True
     assert protprot_caprimodule.atoms != protprot_allatm_caprimodule.atoms
-    only_bb_atoms = [
-        a
-        for atn in protprot_caprimodule.atoms.values()
-        for a in atn
-        ]
-    all_atoms = [
-        a
-        for atn in protprot_allatm_caprimodule.atoms.values()
-        for a in atn
-        ]
+    only_bb_atoms = [a for atn in protprot_caprimodule.atoms.values() for a in atn]
+    all_atoms = [a for atn in protprot_allatm_caprimodule.atoms.values() for a in atn]
     # Check length
     assert len(only_bb_atoms) < len(all_atoms)
     # Make sure all bb are also included in all atoms
@@ -330,7 +325,7 @@ def test_protprot_1bkd_allatoms(protprot_1bkd_caprimodule):
         protprot_1bkd_caprimodule.model,
         protprot_1bkd_caprimodule.reference,
         full=protprot_1bkd_caprimodule.allatoms,
-        )
+    )
     # Compute values with all atoms calculations
     protprot_1bkd_caprimodule.calc_fnat()
     protprot_1bkd_caprimodule.calc_lrmsd()
@@ -377,7 +372,7 @@ def test_protlig_allatoms(protlig_caprimodule):
         protlig_caprimodule.model,
         protlig_caprimodule.reference,
         full=protlig_caprimodule.allatoms,
-        )
+    )
     # Compute values with all atoms calculations
     protlig_caprimodule.calc_fnat()
     protlig_caprimodule.calc_lrmsd()
@@ -421,7 +416,7 @@ def test_protdna_allatoms(protdna_caprimodule):
         protdna_caprimodule.model,
         protdna_caprimodule.reference,
         full=protdna_caprimodule.allatoms,
-        )
+    )
     # Compute values with all atoms calculations
     protdna_caprimodule.calc_fnat()
     protdna_caprimodule.calc_lrmsd()
@@ -445,9 +440,8 @@ def test_make_output(protprot_caprimodule):
     protprot_caprimodule.make_output()
 
     ss_fname = Path(
-        protprot_caprimodule.path,
-        f"capri_ss_{protprot_caprimodule.identificator}.tsv"
-        )
+        protprot_caprimodule.path, f"capri_ss_{protprot_caprimodule.identificator}.tsv"
+    )
 
     assert ss_fname.stat().st_size != 0
 
@@ -455,9 +449,21 @@ def test_make_output(protprot_caprimodule):
     #  the test
     observed_outf_l = read_capri_file(ss_fname)
     expected_outf_l = [
-        ['md5', 'caprieval_rank', 'score', 'irmsd', 'fnat', 'lrmsd', 'ilrmsd',
-         'dockq', 'cluster_id', 'cluster_ranking', 'model-cluster_ranking'],
-        ['-', '-', 'nan', 'nan', 'nan', 'nan', 'nan', 'nan', '1', '1', '10'], ]
+        [
+            "md5",
+            "caprieval_rank",
+            "score",
+            "irmsd",
+            "fnat",
+            "lrmsd",
+            "ilrmsd",
+            "dockq",
+            "cluster_id",
+            "cluster_ranking",
+            "model-cluster_ranking",
+        ],
+        ["-", "-", "nan", "nan", "nan", "nan", "nan", "nan", "1", "1", "10"],
+    ]
 
     assert observed_outf_l == expected_outf_l
 
@@ -470,11 +476,11 @@ def test_identify_protprotinterface(protprot_caprimodule, protprot_input_list):
 
     observed_interface = protprot_caprimodule.identify_interface(
         protprot_complex, cutoff=5.0
-        )
+    )
     expected_interface = {
         "A": [37, 38, 39, 43, 45, 71, 75, 90, 94, 96, 132],
         "B": [52, 51, 16, 54, 53, 56, 11, 12, 17, 48],
-        }
+    }
 
     for ch in expected_interface.keys():
         assert sorted(observed_interface[ch]) == sorted(expected_interface[ch])
@@ -486,11 +492,11 @@ def test_identify_protdnainterface(protdna_caprimodule, protdna_input_list):
 
     observed_interface = protdna_caprimodule.identify_interface(
         protdna_complex, cutoff=5.0
-        )
+    )
     expected_interface = {
         "A": [10, 16, 17, 18, 27, 28, 29, 30, 32, 33, 38, 39, 41, 42, 43, 44],
         "B": [4, 3, 2, 33, 32, 5, 6, 34, 35, 31, 7, 30],
-        }
+    }
 
     for ch in expected_interface.keys():
         assert sorted(observed_interface[ch]) == sorted(expected_interface[ch])
@@ -502,7 +508,7 @@ def test_identify_protliginterface(protlig_caprimodule, protlig_input_list):
 
     observed_interface = protlig_caprimodule.identify_interface(
         protlig_complex, cutoff=5.0
-        )
+    )
     expected_interface = {
         "A": [
             118,
@@ -522,10 +528,10 @@ def test_identify_protliginterface(protlig_caprimodule, protlig_input_list):
             348,
             371,
             406,
-            ],
+        ],
         "B": [500],
-        }
-    
+    }
+
     for ch in expected_interface.keys():
         assert sorted(observed_interface[ch]) == sorted(expected_interface[ch])
 
@@ -533,9 +539,7 @@ def test_identify_protliginterface(protlig_caprimodule, protlig_input_list):
 def test_load_contacts(protprot_input_list):
     """Test loading contacts."""
     protprot_complex = protprot_input_list[0]
-    observed_con_set = load_contacts(
-        protprot_complex, cutoff=5.0
-        )
+    observed_con_set = load_contacts(protprot_complex, cutoff=5.0)
     expected_con_set = {
         ("A", 39, "B", 52),
         ("A", 43, "B", 54),
@@ -557,7 +561,7 @@ def test_load_contacts(protprot_input_list):
         ("A", 94, "B", 51),
         ("A", 37, "B", 52),
         ("A", 45, "B", 11),
-        }
+    }
 
     assert observed_con_set == expected_con_set
 
@@ -578,23 +582,26 @@ def test_add_chain_from_segid(protprot_caprimodule):
 
 def test_rearrange_ss_capri_output():
     """Test rearranging the capri output."""
-    with open(f"{golden_data}/capri_ss_1.tsv", 'w') as fh:
+    with open(f"{golden_data}/capri_ss_1.tsv", "w") as fh:
         fh.write(
             "model	caprieval_rank	score	irmsd	fnat	lrmsd	ilrmsd	"
             "dockq	cluster_id	cluster_ranking	"
-            "model-cluster_ranking" + os.linesep)
+            "model-cluster_ranking" + os.linesep
+        )
         fh.write(
             "../1_emscoring/emscoring_909.pdb	1	-424.751	0.000	"
-            "1.000	0.000	0.000	1.000	-	-	-" + os.linesep)
+            "1.000	0.000	0.000	1.000	-	-	-" + os.linesep
+        )
     rearrange_ss_capri_output(
-        'capri_ss.txt',
+        "capri_ss.txt",
         output_count=1,
         sort_key="score",
         sort_ascending=True,
-        path=golden_data)
+        path=golden_data,
+    )
 
-    assert Path('capri_ss.txt').stat().st_size != 0
-    Path('capri_ss.txt').unlink()
+    assert Path("capri_ss.txt").stat().st_size != 0
+    Path("capri_ss.txt").unlink()
 
 
 def test_calc_stats():
@@ -621,21 +628,64 @@ def test_capri_cluster_analysis(protprot_caprimodule, protprot_input_list):
         clt_threshold=5,
         sort_key="score",
         sort_ascending=True,
-        path=Path("."))
+        path=Path("."),
+    )
 
-    assert Path('capri_clt.txt').stat().st_size != 0
+    assert Path("capri_clt.txt").stat().st_size != 0
 
     observed_outf_l = read_capri_file("capri_clt.txt")
     expected_outf_l = [
-        ['cluster_id', 'n', 'under_eval', 'score', 'score_std', 'irmsd',
-         'irmsd_std', 'fnat', 'fnat_std', 'lrmsd', 'lrmsd_std', 'dockq',
-         'dockq_std', 'caprieval_rank'],
-        ['1', '1', 'yes', '42.000', '0.000', '0.100', '0.000', '1.000',
-         '0.000', '1.200', '0.000', 'nan', 'nan', '1'],
-        ['2', '1', 'yes', '50.000', '0.000', '0.100', '0.000', '1.000',
-         '0.000', '1.200', '0.000', 'nan', 'nan', '2']]
+        [
+            "cluster_id",
+            "n",
+            "under_eval",
+            "score",
+            "score_std",
+            "irmsd",
+            "irmsd_std",
+            "fnat",
+            "fnat_std",
+            "lrmsd",
+            "lrmsd_std",
+            "dockq",
+            "dockq_std",
+            "caprieval_rank",
+        ],
+        [
+            "1",
+            "1",
+            "yes",
+            "42.000",
+            "0.000",
+            "0.100",
+            "0.000",
+            "1.000",
+            "0.000",
+            "1.200",
+            "0.000",
+            "nan",
+            "nan",
+            "1",
+        ],
+        [
+            "2",
+            "1",
+            "yes",
+            "50.000",
+            "0.000",
+            "0.100",
+            "0.000",
+            "1.000",
+            "0.000",
+            "1.200",
+            "0.000",
+            "nan",
+            "nan",
+            "2",
+        ],
+    ]
     assert observed_outf_l == expected_outf_l
-    
+
     # test sorting
     capri_cluster_analysis(
         capri_list=[protprot_caprimodule, protprot_caprimodule],
@@ -644,35 +694,82 @@ def test_capri_cluster_analysis(protprot_caprimodule, protprot_input_list):
         clt_threshold=5,
         sort_key="cluster_rank",
         sort_ascending=False,
-        path=Path("."))
-    
+        path=Path("."),
+    )
+
     observed_outf_l = read_capri_file("capri_clt.txt")
     expected_outf_l = [
-        ['cluster_id', 'n', 'under_eval', 'score', 'score_std', 'irmsd',
-         'irmsd_std', 'fnat', 'fnat_std', 'lrmsd', 'lrmsd_std', 'dockq',
-         'dockq_std', 'caprieval_rank'],
-        ['2', '1', 'yes', '50.000', '0.000', '0.100', '0.000', '1.000',
-         '0.000', '1.200', '0.000', 'nan', 'nan', '2'],
-        ['1', '1', 'yes', '42.000', '0.000', '0.100', '0.000', '1.000',
-         '0.000', '1.200', '0.000', 'nan', 'nan', '1']]
+        [
+            "cluster_id",
+            "n",
+            "under_eval",
+            "score",
+            "score_std",
+            "irmsd",
+            "irmsd_std",
+            "fnat",
+            "fnat_std",
+            "lrmsd",
+            "lrmsd_std",
+            "dockq",
+            "dockq_std",
+            "caprieval_rank",
+        ],
+        [
+            "2",
+            "1",
+            "yes",
+            "50.000",
+            "0.000",
+            "0.100",
+            "0.000",
+            "1.000",
+            "0.000",
+            "1.200",
+            "0.000",
+            "nan",
+            "nan",
+            "2",
+        ],
+        [
+            "1",
+            "1",
+            "yes",
+            "42.000",
+            "0.000",
+            "0.100",
+            "0.000",
+            "1.000",
+            "0.000",
+            "1.200",
+            "0.000",
+            "nan",
+            "nan",
+            "1",
+        ],
+    ]
 
-    Path('capri_clt.txt').unlink()
+    Path("capri_clt.txt").unlink()
 
 
 def test_check_chains(protprot_caprimodule):
     """Test correct checking of chains."""
-    obs_ch = [["A", "C"],
-              ["A", "B"],
-              ["S", "E", "B", "A"],
-              ["S", "E", "P", "A"],
-              ["C", "D"]]
-    
+    obs_ch = [
+        ["A", "C"],
+        ["A", "B"],
+        ["S", "E", "B", "A"],
+        ["S", "E", "P", "A"],
+        ["C", "D"],
+    ]
+
     # assuming exp chains are A and B
-    exp_ch = [["A", ["C"]],
-              ["A", ["B"]],
-              ["A", ["B"]],  # S and E are ignored when B is present
-              ["A", ["S", "E", "P"]],
-              ["C", ["D"]]]
+    exp_ch = [
+        ["A", ["C"]],
+        ["A", ["B"]],
+        ["A", ["B"]],  # S and E are ignored when B is present
+        ["A", ["S", "E", "P"]],
+        ["C", ["D"]],
+    ]
 
     for n in range(len(obs_ch)):
         obs_r_chain, obs_l_chain = protprot_caprimodule.check_chains(obs_ch[n])
@@ -682,9 +779,9 @@ def test_check_chains(protprot_caprimodule):
 
 
 @pytest.fixture
-def protprot_onechain_ref_caprimodule(protprot_input_list,
-                                      protprot_onechain_list,
-                                      params):
+def protprot_onechain_ref_caprimodule(
+    protprot_input_list, protprot_onechain_list, params
+):
     """Protein-Protein CAPRI module with a single chain structure as ref."""
     reference = protprot_onechain_list[0].rel_path
     model = protprot_input_list[1].rel_path
@@ -694,7 +791,7 @@ def protprot_onechain_ref_caprimodule(protprot_input_list,
         model=model,
         path=golden_data,
         params=params,
-        )
+    )
 
     yield capri
 
@@ -702,9 +799,9 @@ def protprot_onechain_ref_caprimodule(protprot_input_list,
 
 
 @pytest.fixture
-def protprot_onechain_mod_caprimodule(protprot_input_list,
-                                      protprot_onechain_list,
-                                      params):
+def protprot_onechain_mod_caprimodule(
+    protprot_input_list, protprot_onechain_list, params
+):
     """Protein-Protein CAPRI module with a single chain structure as model."""
     reference = protprot_input_list[0].rel_path
     model = protprot_onechain_list[0].rel_path
@@ -714,7 +811,7 @@ def protprot_onechain_mod_caprimodule(protprot_input_list,
         model=model,
         path=golden_data,
         params=params,
-        )
+    )
 
     yield capri
 
@@ -765,3 +862,71 @@ def test_get_previous_cns_step():
     assert get_previous_cns_step(mock_steps, 2) == "1_emscoring"
     mock_steps_2 = ["bla", "test"]
     assert get_previous_cns_step(mock_steps_2, 1) is None
+
+
+def test_capri_run(mocker):
+
+    mock_get_align_func = mocker.Mock(
+        return_value={"numbering": {1: 1, 2: 2}, "chain_dict": {1: 2}}
+    )
+    mocker.patch(
+        "haddock.modules.analysis.caprieval.capri.get_align",
+        return_value=mock_get_align_func,
+    )
+
+    mocker.patch.object(CAPRI, "_load_atoms", return_value=None)
+    capri = CAPRI(
+        identificator="test",
+        model=Path("some-file"),
+        path=Path("."),
+        reference=Path("some-file"),
+        params={
+            "fnat": True,
+            "irmsd": True,
+            "lrmsd": True,
+            "ilrmsd": True,
+            "dockq": True,
+            "allatoms": True,
+            "receptor_chain": "A",
+            "ligand_chains": ["B"],
+            "alignment_method": None,
+            "lovoalign_exec": None,
+            "fnat_cutoff": 10,
+            "irmsd_cutoff": 10,
+        },
+    )
+    rand_fnat = random.random()
+    mocker.patch.object(
+        capri, "calc_fnat", side_effect=lambda cutoff: setattr(capri, "fnat", rand_fnat)
+    )
+    rand_irmsd = random.random()
+    mocker.patch.object(
+        capri,
+        "calc_irmsd",
+        side_effect=lambda cutoff: setattr(capri, "irmsd", rand_irmsd),
+    )
+    rand_lrmsd = random.random()
+    mocker.patch.object(
+        capri, "calc_lrmsd", side_effect=lambda: setattr(capri, "lrmsd", rand_lrmsd)
+    )
+    rand_ilrmsd = random.random()
+    mocker.patch.object(
+        capri,
+        "calc_ilrmsd",
+        side_effect=lambda cutoff: setattr(capri, "ilrmsd", rand_ilrmsd),
+    )
+    rand_dockq = random.random()
+    mocker.patch.object(
+        capri, "calc_dockq", side_effect=lambda: setattr(capri, "dockq", rand_dockq)
+    )
+
+    mocker.patch.object(capri, "make_output")
+
+    capri.run()
+
+    # The only logic to be tested is if the methods are called
+    assert capri.fnat == pytest.approx(rand_fnat)
+    assert capri.irmsd == pytest.approx(rand_irmsd)
+    assert capri.lrmsd == pytest.approx(rand_lrmsd)
+    assert capri.ilrmsd == pytest.approx(rand_ilrmsd)
+    assert capri.dockq == pytest.approx(rand_dockq)


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and that you comply with the following criteria:

- [x] You have sticked to Python. Please talk to us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [x] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [x] You structured the code into small functions as much as possible. You can use classes if there is a (state) purpose
- [x] Your code follows our coding style
- [x] You wrote tests for the new code
- [x] `tox` tests pass. *Run `tox` command inside the repository folder*
- [ ] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [x] PR does not add any dependencies, unless permission granted by the HADDOCK team
- [x] PR does not break licensing
- [x] Your PR is about writing documentation for already existing code :fire:
- [x] Your PR is about writing tests for already existing code :godmode:

---

This PR updates the `caprieval` module to benefit from the `less_io` parameter. Now when setting this `less_io` parameter, no "intermediary" files will be generated.

To achieve this I had to refactor `CAPRI.run` to return a copy of itself so that an instance with the updated values (`self.fnat`, `self.irmsd`, etc) can be retrieved as a simple `results` property of the `Scheduler` execution engine. 

There is a `rearrange_ss_capri_output` which is responsible for joining the intermediate files - however this function was also ranking according to the score. So I removed this logic of ranking into another `rank_according_to_score` function. Then this refactored ranking function can be used in the `extract_data_from_capri_class` helper function that does the same as `rearrange_ss_capri_output` but without loading files.

I also added integration tests for the `caprieval` module and new tests for the new functions plus some linting and type fixes.
