### PR TITLE
Add logic to check for incompatible parameters

### DIFF
--- a/src/haddock/gear/prepare_run.py
+++ b/src/haddock/gear/prepare_run.py
@@ -944,7 +944,7 @@ def validate_module_names_are_not_misspelled(params: ParamMap) -> None:
     return
 
 
-def validate_parameters_are_not_incompatible(params: ParamMap):
+def validate_parameters_are_not_incompatible(params: ParamMap) -> None:
     """Validate parameters are not incompatible.
 
     Args:

--- a/src/haddock/gear/prepare_run.py
+++ b/src/haddock/gear/prepare_run.py
@@ -1,4 +1,5 @@
 """Logic pertraining to preparing the run files and folders."""
+
 import difflib
 import importlib
 import itertools as it
@@ -76,6 +77,7 @@ from haddock.modules import (
     modules_category,
     modules_names,
     non_mandatory_general_parameters_defaults,
+    incompatible_params,
 )
 from haddock.modules.analysis import (
     confirm_resdic_chainid_length,
@@ -268,6 +270,8 @@ def setup_run(
         general_params,
         reference_parameters=ALL_POSSIBLE_GENERAL_PARAMETERS,
     )
+
+    validate_parameters_are_not_incompatible(general_params)
 
     # --extend-run configs do not define the run directory
     # in the config file. So we take it from the argument.
@@ -938,6 +942,27 @@ def validate_module_names_are_not_misspelled(params: ParamMap) -> None:
     )
 
     return
+
+
+def validate_parameters_are_not_incompatible(params: ParamMap):
+    """Validate parameters are not incompatible.
+
+    Args:
+        params (ParamMap): A mapping of parameter names to their values.
+
+    Raises:
+        ValueError: If any parameter in `params` is incompatible with another parameter as defined by `incompatible_params`.
+    """
+    for limiting_param, incompatibilities in incompatible_params.items():
+        # Check if the limiting parameter is present in the parameters
+        if limiting_param in params:
+            # Check each incompatibility for the limiting parameter
+            for incompatible_param, incompatible_value in incompatibilities.items():
+                # Check if the incompatible parameter is present and has the incompatible value
+                if params.get(incompatible_param) == incompatible_value:
+                    raise ValueError(
+                        f"Parameter `{limiting_param}` is incompatible with `{incompatible_param}={incompatible_value}`."
+                    )
 
 
 def validate_parameters_are_not_misspelled(

--- a/src/haddock/gear/prepare_run.py
+++ b/src/haddock/gear/prepare_run.py
@@ -77,7 +77,7 @@ from haddock.modules import (
     modules_category,
     modules_names,
     non_mandatory_general_parameters_defaults,
-    incompatible_params,
+    incompatible_defaults_params,
 )
 from haddock.modules.analysis import (
     confirm_resdic_chainid_length,
@@ -945,15 +945,20 @@ def validate_module_names_are_not_misspelled(params: ParamMap) -> None:
 
 
 def validate_parameters_are_not_incompatible(params: ParamMap) -> None:
-    """Validate parameters are not incompatible.
-
-    Args:
-        params (ParamMap): A mapping of parameter names to their values.
-
-    Raises:
-        ValueError: If any parameter in `params` is incompatible with another parameter as defined by `incompatible_params`.
     """
-    for limiting_param, incompatibilities in incompatible_params.items():
+    Validate parameters are not incompatible.
+
+    Parameters
+    ----------
+    params : ParamMap
+        A mapping of parameter names to their values.
+
+    Raises
+    ------
+    ValueError
+        If any parameter in `params` is incompatible with another parameter as defined by `incompatible_params`.
+    """
+    for limiting_param, incompatibilities in incompatible_defaults_params.items():
         # Check if the limiting parameter is present in the parameters
         if limiting_param in params:
             # Check each incompatibility for the limiting parameter

--- a/src/haddock/gear/yaml2cfg.py
+++ b/src/haddock/gear/yaml2cfg.py
@@ -5,6 +5,7 @@ Accross this file you will see references to "yaml" as variables and
 function names. In these cases, we always mean the HADDOCK3 YAML
 configuration files which have specific keys.
 """
+
 import os
 from collections.abc import Mapping
 from pathlib import Path
@@ -214,3 +215,15 @@ def flat_yaml_cfg(cfg: ParamMap) -> ParamDict:
         new[param] = new_value
 
     return new
+
+
+def find_incompatible_parameters(yaml_file: Path) -> dict[str, dict[str, str]]:
+
+    config = read_from_yaml(yaml_file=yaml_file)
+
+    # Go over each node and see which contains the `incompatible` key
+    incompatible_parameters = {}
+    for node, values in config.items():
+        if "incompatible" in values:
+            incompatible_parameters[node] = values["incompatible"]
+    return incompatible_parameters

--- a/src/haddock/gear/yaml2cfg.py
+++ b/src/haddock/gear/yaml2cfg.py
@@ -217,7 +217,7 @@ def flat_yaml_cfg(cfg: ParamMap) -> ParamDict:
     return new
 
 
-def find_incompatible_parameters(yaml_file: Path) -> dict[str, dict[str, str]]:
+def find_incompatible_parameters(yaml_file: Path) -> dict[str, ParamDict]:
     """
     Reads a YAML configuration file and identifies nodes containing the 'incompatible' key.
 

--- a/src/haddock/gear/yaml2cfg.py
+++ b/src/haddock/gear/yaml2cfg.py
@@ -218,7 +218,20 @@ def flat_yaml_cfg(cfg: ParamMap) -> ParamDict:
 
 
 def find_incompatible_parameters(yaml_file: Path) -> dict[str, dict[str, str]]:
+    """
+    Reads a YAML configuration file and identifies nodes containing the 'incompatible' key.
 
+    This function takes the path to a YAML file, reads its contents, and searches for nodes
+    that include an 'incompatible' key. It returns a dictionary where each key is a node name
+    and each value is another dictionary representing the 'incompatible' parameters for that node.
+
+    Args:
+        yaml_file (Path): The path to the YAML file to be read.
+
+    Returns:
+        dict[str, dict[str, str]]: A dictionary with node names as keys and their corresponding
+                                   'incompatible' parameters as values.
+    """
     config = read_from_yaml(yaml_file=yaml_file)
 
     # Go over each node and see which contains the `incompatible` key

--- a/src/haddock/gear/yaml2cfg.py
+++ b/src/haddock/gear/yaml2cfg.py
@@ -225,12 +225,16 @@ def find_incompatible_parameters(yaml_file: Path) -> dict[str, ParamDict]:
     that include an 'incompatible' key. It returns a dictionary where each key is a node name
     and each value is another dictionary representing the 'incompatible' parameters for that node.
 
-    Args:
-        yaml_file (Path): The path to the YAML file to be read.
+    Parameters
+    ----------
+    yaml_file : Path
+        The path to the YAML file to be read.
 
-    Returns:
-        dict[str, dict[str, str]]: A dictionary with node names as keys and their corresponding
-                                   'incompatible' parameters as values.
+    Return
+    ------
+    incompatible_parameters : dict[str, dict[str, str]]
+        A dictionary with node names as keys and their corresponding
+        'incompatible' parameters as values.
     """
     config = read_from_yaml(yaml_file=yaml_file)
 

--- a/src/haddock/modules/__init__.py
+++ b/src/haddock/modules/__init__.py
@@ -65,7 +65,7 @@ non_mandatory_general_parameters_defaults = read_from_yaml_config(
     modules_defaults_path
 )  # noqa : E501
 
-incompatible_params = find_incompatible_parameters(modules_defaults_path)
+incompatible_defaults_params = find_incompatible_parameters(modules_defaults_path)
 
 config_readers = {
     ".yaml": read_from_yaml_config,

--- a/src/haddock/modules/__init__.py
+++ b/src/haddock/modules/__init__.py
@@ -1,4 +1,5 @@
 """HADDOCK3 modules."""
+
 import re
 from abc import ABC, abstractmethod
 from contextlib import contextmanager, suppress
@@ -18,11 +19,11 @@ from haddock.core.typing import (
     Optional,
     ParamDict,
     Union,
-    )
+)
 from haddock.gear import config
 from haddock.gear.clean_steps import clean_output
 from haddock.gear.parameters import config_mandatory_general_parameters
-from haddock.gear.yaml2cfg import read_from_yaml_config
+from haddock.gear.yaml2cfg import read_from_yaml_config, find_incompatible_parameters
 from haddock.libs.libhpc import HPCScheduler
 from haddock.libs.libio import folder_exists, working_directory
 from haddock.libs.libmpi import MPIScheduler
@@ -39,7 +40,7 @@ modules_category = {
     module.name: category.name
     for category in modules_folder.glob(_folder_match_regex)
     for module in category.glob(_folder_match_regex)
-    }
+}
 """Indexes each module in its specific category. Keys are Paths to the module,
 values are their categories. Categories are the modules parent folders."""
 
@@ -52,7 +53,7 @@ category_hierarchy = [
     "scoring",
     "analysis",
     "extras",
-    ]
+]
 
 # this dictionary defines non-mandatory general parameters that can be defined
 # as global parameters thus affect all modules, or, instead, can be defined per
@@ -60,17 +61,20 @@ category_hierarchy = [
 # modules will use these parameters. It is the responsibility of the module to
 # extract the parameters it needs.
 # the config file is in modules/defaults.cfg
-non_mandatory_general_parameters_defaults = read_from_yaml_config(modules_defaults_path)  # noqa : E501
+non_mandatory_general_parameters_defaults = read_from_yaml_config(
+    modules_defaults_path
+)  # noqa : E501
+
+incompatible_params = find_incompatible_parameters(modules_defaults_path)
 
 config_readers = {
     ".yaml": read_from_yaml_config,
     ".cfg": config.load,
-    }
+}
 
 _step_folder_regex = tuple(
-    r"[0-9]+_" + mod_name
-    for mod_name in modules_category.keys()
-    )
+    r"[0-9]+_" + mod_name for mod_name in modules_category.keys()
+)
 step_folder_regex = "(" + "|".join(_step_folder_regex) + ")"
 """
 String for regular expression to match module folders in a run directory.
@@ -100,7 +104,7 @@ def _not_valid_config() -> Generator[None, None, None]:
         emsg = (
             "The configuration file extension is not supported. "
             f"Supported types are {', '.join(config_readers.keys())}."
-            )
+        )
         raise ConfigurationError(emsg) from err
 
 
@@ -144,10 +148,10 @@ class BaseHaddockModule(ABC):
         self.update_params(**self._original_params)
 
     def update_params(
-            self,
-            update_from_cfg_file: Optional[FilePath] = None,
-            **params: Any,
-            ) -> None:
+        self,
+        update_from_cfg_file: Optional[FilePath] = None,
+        **params: Any,
+    ) -> None:
         """
         Update the modules parameters.
 
@@ -180,9 +184,8 @@ class BaseHaddockModule(ABC):
         """
         if update_from_cfg_file and params:
             _msg = (
-                "You can not provide both `update_from_cfg_file` "
-                "and key arguments."
-                )
+                "You can not provide both `update_from_cfg_file` " "and key arguments."
+            )
             raise TypeError(_msg)
 
         if update_from_cfg_file:
@@ -193,7 +196,7 @@ class BaseHaddockModule(ABC):
         # the updating order is relevant
         _n = recursive_dict_update(
             non_mandatory_general_parameters_defaults, self._params
-            )
+        )
         self._params = recursive_dict_update(_n, params)
         self._fill_emptypaths()
         self._confirm_fnames_exist()
@@ -226,8 +229,7 @@ class BaseHaddockModule(ABC):
         return
 
     @abstractmethod
-    def _run(self) -> None:
-        ...
+    def _run(self) -> None: ...
 
     def run(self, **params: Any) -> None:
         """Execute the module."""
@@ -294,9 +296,8 @@ class BaseHaddockModule(ABC):
             _msg = (
                 f"{faulty:.2f}% of output was not generated for this module "
                 f"and tolerance was set to {faulty_tolerance:.2f}%."
-                )
+            )
             self.finish_with_error(_msg)
-        
 
     def finish_with_error(self, reason: object = "Module has failed.") -> None:
         """Finish with error message."""
@@ -307,9 +308,9 @@ class BaseHaddockModule(ABC):
             raise RuntimeError(reason)
 
     def _load_previous_io(
-            self,
-            filename: FilePath = MODULE_IO_FILE,
-            ) -> ModuleIO:
+        self,
+        filename: FilePath = MODULE_IO_FILE,
+    ) -> ModuleIO:
         if self.order == 0:
             self._num_of_input_molecules = 0
             return ModuleIO()
@@ -337,10 +338,7 @@ class BaseHaddockModule(ABC):
     @staticmethod
     def last_step_folder(folders, index):
         """Retrieve last step folder."""
-        with_ind = [
-            folder for folder in folders
-            if int(folder.split('_')[0]) == index
-            ]
+        with_ind = [folder for folder in folders if int(folder.split("_")[0]) == index]
         nb_with_ind = len(with_ind)
         # No matching index
         if nb_with_ind == 0:
@@ -351,7 +349,7 @@ class BaseHaddockModule(ABC):
         # Case of multiple matching index
         else:
             for folder in with_ind:
-                if folder.split('_')[-1] != INTERACTIVE_RE_SUFFIX:
+                if folder.split("_")[-1] != INTERACTIVE_RE_SUFFIX:
                     return folder
             return with_ind[0]
 
@@ -389,9 +387,9 @@ EngineMode = Literal["batch", "local", "mpi"]
 
 
 def get_engine(
-        mode: str,
-        params: dict[Any, Any],
-        ) -> partial[Union[HPCScheduler, Scheduler, MPIScheduler]]:
+    mode: str,
+    params: dict[Any, Any],
+) -> partial[Union[HPCScheduler, Scheduler, MPIScheduler]]:
     """
     Create an engine to run the jobs.
 
@@ -413,14 +411,14 @@ def get_engine(
             target_queue=params["queue"],
             queue_limit=params["queue_limit"],
             concat=params["concat"],
-            )
+        )
 
     elif mode == "local":
         return partial(  # type: ignore
             Scheduler,
             ncores=params["ncores"],
             max_cpus=params["max_cpus"],
-            )
+        )
     elif mode == "mpi":
         return partial(MPIScheduler, ncores=params["ncores"])  # type: ignore
 
@@ -429,13 +427,13 @@ def get_engine(
         raise ValueError(
             f"Scheduler `mode` {mode!r} not recognized. "
             f"Available options are {', '.join(available_engines)}"
-            )
+        )
 
 
 def get_module_steps_folders(
-        folder: FilePath,
-        modules: Optional[Container[int]] = None,
-        ) -> list[str]:
+    folder: FilePath,
+    modules: Optional[Container[int]] = None,
+) -> list[str]:
     """
     Return a sorted list of the step folders in a running directory.
 
@@ -468,16 +466,18 @@ def get_module_steps_folders(
     steps = sorted(
         (f for f in folders if step_folder_regex_re.search(f)),
         key=lambda x: int(x.split("_")[0]),
-        )
+    )
     if modules:
         steps = [
             st
             for st in steps
-            if all([
-                int(st.split("_")[0]) in modules,
-                st.split("_")[1] in modules_names,
-                ])
-            ]
+            if all(
+                [
+                    int(st.split("_")[0]) in modules,
+                    st.split("_")[1] in modules_names,
+                ]
+            )
+        ]
     return steps
 
 

--- a/src/haddock/modules/defaults.yaml
+++ b/src/haddock/modules/defaults.yaml
@@ -148,3 +148,5 @@ less_io:
     a network file system where I/O operations are slow.
   group: "execution"
   explevel: easy
+  incompatible:
+    mode: batch

--- a/tests/test_gear_prepare_run.py
+++ b/tests/test_gear_prepare_run.py
@@ -1,4 +1,5 @@
 """Test prepare run module."""
+
 import shutil
 from math import isnan
 from pathlib import Path
@@ -19,7 +20,8 @@ from haddock.gear.prepare_run import (
     validate_param_type,
     validate_parameters_are_not_misspelled,
     validate_value,
-    )
+    validate_parameters_are_not_incompatible,
+)
 from haddock.gear.yaml2cfg import read_from_yaml_config
 from haddock.modules import modules_names
 from haddock.modules.topology.topoaa import DEFAULT_CONFIG
@@ -37,11 +39,11 @@ DEFAULT_DICT = read_from_yaml_config(DEFAULT_CONFIG)
             {
                 "autohis": None,
                 "mol1": {"nhisd", "hisd_1", "hisd_2", "nhise", "hise_1"},
-                },
+            },
             {"hisd_1", "hisd_2", "hise_1"},
-            )
-        ]
-    )
+        )
+    ],
+)
 def test_get_expandable_parameters_topoaa(inp, expected):
     """Test get blocks."""
     result = get_expandable_parameters(inp, DEFAULT_DICT, "topoaa", 20)
@@ -53,7 +55,7 @@ def test_populate_topoaa_molecules():
     topoaa = {
         "molecules": ["file1.pdb", "file2.pdb"],
         "mol1": {"cyclicpept": True},
-        }
+    }
     populate_topology_molecule_params(topoaa)
     assert "mol2" in topoaa
     assert topoaa["mol2"]["cyclicpept"] is False
@@ -73,7 +75,7 @@ def test_populate_topoaa_molecules_2():
     topoaa = {
         "molecules": ["file1.pdb", "file2.pdb"],
         "mol2": {"cyclicpept": True},
-        }
+    }
     populate_topology_molecule_params(topoaa)
     assert "mol1" in topoaa
 
@@ -96,7 +98,7 @@ def test_populate_topoaa_molecules_3():
     topoaa = {
         "molecules": ["file1.pdb", "file2.pdb", "file3.pdb"],
         "mol2": {"cyclicpept": True},
-        }
+    }
     populate_topology_molecule_params(topoaa)
     assert "mol1" in topoaa
 
@@ -106,7 +108,7 @@ def test_populate_topoaa_molecules_4():
     topoaa = {
         "molecules": ["file1.pdb", "file2.pdb", "file3.pdb", "file4.pdb"],
         "mol3": {"cyclicpept": True},
-        }
+    }
     populate_topology_molecule_params(topoaa)
     assert "mol1" in topoaa
 
@@ -117,7 +119,7 @@ def test_populate_mol_params():
         "topoaa.1": {"molecules": ["file1.pdb", "file2.pdb", "file3.pdb"]},
         "flexref.1": {"mol_fix_origin_2": True},
         "caprieval.1": {},
-        }
+    }
 
     populate_mol_parameters(params)
     assert "mol_fix_origin_1" in params["flexref.1"]
@@ -140,8 +142,10 @@ def test_check_if_path_exists():
 
     with pytest.raises(ValueError) as err:
         check_if_path_exists("file-01.txt")
-        end = ("the following \'file_01.txt\' is the closest match to the "
-               "supplied \'file-01.txt\', did you mean to open this?")
+        end = (
+            "the following 'file_01.txt' is the closest match to the "
+            "supplied 'file-01.txt', did you mean to open this?"
+        )
         assert str(err).endswith(end)
 
     Path("file_01.txt").unlink()
@@ -152,12 +156,14 @@ def test_check_if_path_exists():
     "user_input,expected",
     [
         ("long-fromat", [("long-fromat", "long-format")]),
-        (["loong-format", "verboese"],
-            [("loong-format", "long-format"), ("verboese", "verbose")]),
+        (
+            ["loong-format", "verboese"],
+            [("loong-format", "long-format"), ("verboese", "verbose")],
+        ),
         ("middle-format", [("middle-format", "long-format")]),
         ("out", [("out", "output-dir")]),
-        ]
-    )
+    ],
+)
 def test_fuzzy_match(user_input, expected):
     possibilities = ["long-format", "short-format", "verbose", "output-dir"]
     assert fuzzy_match(user_input, possibilities) == expected
@@ -168,8 +174,8 @@ def test_fuzzy_match(user_input, expected):
     [
         ("mol1.pdb", 1),
         (["mol1.pdb", "mol2.pdb"], 2),
-        ],
-    )
+    ],
+)
 def test_copy_mols_to_topo_dir(molecules, expected):
     d = {}
     copy_molecules_to_topology(molecules, d)
@@ -181,15 +187,15 @@ def test_copy_mols_to_topo_dir(molecules, expected):
 def test_validate_step_names_are_not_misspelled():
     params = {
         "par1": None,
-        }
+    }
 
     for i, module in enumerate(modules_names):
         # the key and value for this function do not matter
         if i % 2 == 0:
-            params[module] = {None: None}
+            params[module] = {None: None}  # type: ignore
         else:
             # add index
-            params[module + ".1"] = {None: None}
+            params[module + ".1"] = {None: None}  # type: ignore
 
     validate_module_names_are_not_misspelled(params)
 
@@ -197,9 +203,9 @@ def test_validate_step_names_are_not_misspelled():
 def test_validate_step_names_are_not_misspelled_error():
     params = {
         "par1": None,
-        }
+    }
 
-    params["r1g1dbod1"] = {None: None}
+    params["r1g1dbod1"] = {None: None}  # type: ignore
 
     with pytest.raises(ValueError):
         validate_module_names_are_not_misspelled(params)
@@ -221,17 +227,17 @@ def test_validate_params_error():
 def test_update_step_folders_from_restart():
     output_tmp = Path(data_folder, "1_dummystep")
     shutil.copytree(steptmp, output_tmp)
-    prev_names = ['0_dummystep']
-    next_names = ['1_dummystep']
+    prev_names = ["0_dummystep"]
+    next_names = ["1_dummystep"]
     update_step_contents_to_step_names(prev_names, next_names, data_folder)
 
     file1 = Path(output_tmp, "file1.in").read_text()
-    assert '0_dummystep' not in file1
-    assert '1_dummystep' in file1
+    assert "0_dummystep" not in file1
+    assert "1_dummystep" in file1
 
     file2 = Path(output_tmp, "folder", "file2.in").read_text()
-    assert '0_dummystep' not in file2
-    assert '1_dummystep' in file2
+    assert "0_dummystep" not in file2
+    assert "1_dummystep" in file2
 
     shutil.rmtree(output_tmp)
 
@@ -239,14 +245,14 @@ def test_update_step_folders_from_restart():
 @pytest.mark.parametrize(
     "defaultparam,inputvalue",
     [
-        ({'type': 'integer'}, 1),
-        ({'type': 'float'}, 0.99),
-        ({'type': 'list'}, [1, 2]),
-        ({'type': 'boolean'}, False),
-        ({'type': 'boolean'}, True),
-        ({'type': 'string'}, 'Hello world'),
-        ]
-    )
+        ({"type": "integer"}, 1),
+        ({"type": "float"}, 0.99),
+        ({"type": "list"}, [1, 2]),
+        ({"type": "boolean"}, False),
+        ({"type": "boolean"}, True),
+        ({"type": "string"}, "Hello world"),
+    ],
+)
 def test_accepted_value_type(defaultparam, inputvalue):
     """Test if the provided value type is correct.
 
@@ -258,33 +264,33 @@ def test_accepted_value_type(defaultparam, inputvalue):
 @pytest.mark.parametrize(
     "defaultparam,inputvalue",
     [
-        ({'type': 'integer', 'default': 0}, False),
-        ({'type': 'float', 'default': 1.1}, 'Hello world'),
-        ({'type': 'list', 'default': [1, 2]}, {1: 1, 2: 2}),
-        ({'type': 'boolean', 'default': True}, 1),
-        ({'type': 'boolean', 'default': False}, 0),
-        ({'type': 'str', 'default': 'test'}, 2.1),
-        ]
-    )
+        ({"type": "integer", "default": 0}, False),
+        ({"type": "float", "default": 1.1}, "Hello world"),
+        ({"type": "list", "default": [1, 2]}, {1: 1, 2: 2}),
+        ({"type": "boolean", "default": True}, 1),
+        ({"type": "boolean", "default": False}, 0),
+        ({"type": "str", "default": "test"}, 2.1),
+    ],
+)
 def test_value_type_error(defaultparam, inputvalue):
     """Test if the provided value type is wrong.
 
     Should return a formated string describing the error.
     """
     assert validate_param_type(defaultparam, inputvalue) is not None
-    
+
 
 @pytest.mark.parametrize(
     "defaultparam,inputvalue",
     [
-        ({'min': 0, 'max': 1}, 0.5),
-        ({'min': 1, 'max': 1000}, 1),
-        ({'min': 0, 'max': 1000}, 1000),
-        ({'min': 0, 'max': 1000}, -0),
-        ({'choices': ['ok', 'fine']}, 'fine'),
-        ({'choices': ['super']}, 'super'),
-        ]
-    )
+        ({"min": 0, "max": 1}, 0.5),
+        ({"min": 1, "max": 1000}, 1),
+        ({"min": 0, "max": 1000}, 1000),
+        ({"min": 0, "max": 1000}, -0),
+        ({"choices": ["ok", "fine"]}, "fine"),
+        ({"choices": ["super"]}, "super"),
+    ],
+)
 def test_accepted_value_range(defaultparam, inputvalue):
     """Test if the provided value range/choices is correct.
 
@@ -296,13 +302,13 @@ def test_accepted_value_range(defaultparam, inputvalue):
 @pytest.mark.parametrize(
     "defaultparam,inputvalue",
     [
-        ({'min': 0, 'max': 1, 'default': 0}, 2),
-        ({'min': 1.1, 'max': 1.3, 'default': 1.2}, 1.4),
-        ({'min': 0.1, 'max': 1.0, 'default': 0.5}, -0.1),
-        ({'choices': ['not', 'good'], 'default': 'good'}, ['not', 'good']),
-        ({'choices': ['super'], 'default': 'super'}, 'wrong'),
-        ]
-    )
+        ({"min": 0, "max": 1, "default": 0}, 2),
+        ({"min": 1.1, "max": 1.3, "default": 1.2}, 1.4),
+        ({"min": 0.1, "max": 1.0, "default": 0.5}, -0.1),
+        ({"choices": ["not", "good"], "default": "good"}, ["not", "good"]),
+        ({"choices": ["super"], "default": "super"}, "wrong"),
+    ],
+)
 def test_value_range_error(defaultparam, inputvalue):
     """Test if the provided value range/choices is erronnated.
 
@@ -314,19 +320,17 @@ def test_value_range_error(defaultparam, inputvalue):
 @pytest.mark.parametrize(
     "defaultparams,key,value",
     [
-        ({'key': {'min': 0, 'max': 1, 'type': 'integer'}}, 'key', 1),
-        ({'key': {'min': 0.5, 'max': 2.2, 'type': 'float'}}, 'key', 1.1),
-        ({'key': {'min': 0, 'max': 1, 'type': 'integer'}}, 'key', 0),
-        ({'key': {'choices': ['ok', 'fine'], 'type': 'string'}},
-         'key', 'ok'),
-        ({'key': {'choices': ['ok', 'fine'], 'type': 'string'}},
-         'key', 'fine'),
-        ({'key': {'type': 'boolean'}}, 'key', True),
-        ({'key': {'type': 'list'}}, 'key', ['mol1', 'mol2']),
-        ({'mol': {'group': 'molecules', 'type': 'list'}}, 'mol', ['pdb']),
-        ({'molecule': {'type': 'list'}}, 'molecules', ['mol1', 'pdb']),
-        ]
-    )
+        ({"key": {"min": 0, "max": 1, "type": "integer"}}, "key", 1),
+        ({"key": {"min": 0.5, "max": 2.2, "type": "float"}}, "key", 1.1),
+        ({"key": {"min": 0, "max": 1, "type": "integer"}}, "key", 0),
+        ({"key": {"choices": ["ok", "fine"], "type": "string"}}, "key", "ok"),
+        ({"key": {"choices": ["ok", "fine"], "type": "string"}}, "key", "fine"),
+        ({"key": {"type": "boolean"}}, "key", True),
+        ({"key": {"type": "list"}}, "key", ["mol1", "mol2"]),
+        ({"mol": {"group": "molecules", "type": "list"}}, "mol", ["pdb"]),
+        ({"molecule": {"type": "list"}}, "molecules", ["mol1", "pdb"]),
+    ],
+)
 def test_accepted_param_value(defaultparams, key, value):
     """Test if the provided parameter = value is correct.
 
@@ -338,31 +342,44 @@ def test_accepted_param_value(defaultparams, key, value):
 @pytest.mark.parametrize(
     "defaultparams,key,value",
     [
-        ({'key': {'min': 0, 'max': 1, 'type': 'integer',
-                  'default': 0}}, 'key', 1.1),
-        ({'key': {'min': 0.5, 'max': 2.2,
-                  'type': 'float', 'default': 1.1}}, 'key', 0),
-        ({'key': {'choices': ['not', 'good'],
-                  'type': 'string',
-                  'default': 'good'}},
-         'key', 'ok'),
-        ({'key': {'choices': ['False', 'True'],
-                  'type': 'string',
-                  'default': 'True'}},
-         'key', True),
-        ({'key': {'choices': ['False', 'True'], 'type': 'string',
-                  'default': 'False'}},
-         'key', False),
-        ({'key': {'type': 'boolean', 'default': False}}, 'key', 0),
-        ({'key': {'type': 'boolean', 'default': True}}, 'key', 1),
-        ({'key': {'type': 'boolean', 'default': False}}, 'key', []),
-        ({'key': {'type': 'boolean', 'default': False}}, 'key', ''),
-        ({'key': {'type': 'list', 'default': ['m1', 'm2']}}, 'key', 1),
-        ({'key': {'type': 'list', 'default': ['m1', 'm2']}}, 'key', 'list'),
-        ({'key': {'type': 'list', 'default': ['m1', 'm2']}},
-         'key', {'hello': 'world'}),
-        ]
-    )
+        ({"key": {"min": 0, "max": 1, "type": "integer", "default": 0}}, "key", 1.1),
+        ({"key": {"min": 0.5, "max": 2.2, "type": "float", "default": 1.1}}, "key", 0),
+        (
+            {"key": {"choices": ["not", "good"], "type": "string", "default": "good"}},
+            "key",
+            "ok",
+        ),
+        (
+            {
+                "key": {
+                    "choices": ["False", "True"],
+                    "type": "string",
+                    "default": "True",
+                }
+            },
+            "key",
+            True,
+        ),
+        (
+            {
+                "key": {
+                    "choices": ["False", "True"],
+                    "type": "string",
+                    "default": "False",
+                }
+            },
+            "key",
+            False,
+        ),
+        ({"key": {"type": "boolean", "default": False}}, "key", 0),
+        ({"key": {"type": "boolean", "default": True}}, "key", 1),
+        ({"key": {"type": "boolean", "default": False}}, "key", []),
+        ({"key": {"type": "boolean", "default": False}}, "key", ""),
+        ({"key": {"type": "list", "default": ["m1", "m2"]}}, "key", 1),
+        ({"key": {"type": "list", "default": ["m1", "m2"]}}, "key", "list"),
+        ({"key": {"type": "list", "default": ["m1", "m2"]}}, "key", {"hello": "world"}),
+    ],
+)
 def test_param_value_error(defaultparams, key, value):
     """Test if the provided parameter = value is not correct.
 
@@ -370,3 +387,25 @@ def test_param_value_error(defaultparams, key, value):
     """
     with pytest.raises(ConfigurationError):
         validate_value(defaultparams, key, value)
+
+
+def test_validate_parameters_are_not_incompatible(mocker):
+    mocker.patch(
+        "haddock.gear.prepare_run.incompatible_params",
+        {"limiting_parameter": {"incompatible_parameter": "incompatible_value"}},
+    )
+
+    params = {
+        "limiting_parameter": "",
+        "incompatible_parameter": "incompatible_value",
+    }
+
+    with pytest.raises(ValueError):
+        validate_parameters_are_not_incompatible(params)
+
+    params = {
+        "limiting_parameter": "limiting_value",
+        "ok_parameter": "ok_value",
+    }
+
+    assert validate_parameters_are_not_incompatible(params) is None

--- a/tests/test_gear_prepare_run.py
+++ b/tests/test_gear_prepare_run.py
@@ -391,7 +391,7 @@ def test_param_value_error(defaultparams, key, value):
 
 def test_validate_parameters_are_not_incompatible(mocker):
     mocker.patch(
-        "haddock.gear.prepare_run.incompatible_params",
+        "haddock.gear.prepare_run.incompatible_defaults_params",
         {"limiting_parameter": {"incompatible_parameter": "incompatible_value"}},
     )
 


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and that you comply with the following criteria:

- [x] You have sticked to Python. Please talk to us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [x] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [x] You structured the code into small functions as much as possible. You can use classes if there is a (state) purpose
- [x] Your code follows our coding style
- [x] You wrote tests for the new code
- [x] `tox` tests pass. *Run `tox` command inside the repository folder*
- [ ] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [x] PR does not add any dependencies, unless permission granted by the HADDOCK team
- [x] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---

This PR adds a logic to check for parameter incompatibilities. 

For example; with #918 I added a new parameter called `less_io` however you cannot use this parameter together with `mode=batch`.

So now you can define a new `incompatible` property of a given parameter in the `haddock.modules.defaults.yaml`;

```yaml
less_io:
  # ...
  incompatible:
    mode: batch
```

Which will then be validated when the run is being setup.

