### PR TITLE
Clean intermediate files in batch mode

### DIFF
--- a/src/haddock/gear/clean_steps.py
+++ b/src/haddock/gear/clean_steps.py
@@ -65,6 +65,8 @@ def clean_output(path: FilePath, ncores: int = 1) -> None:
         '.inp.gz',
         '.out',
         '.out.gz',
+        '.job',
+        '.err',
         ]
 
     for extension in files_to_delete:


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and that you comply with the following criteria:

- [ ] You have sticked to Python. Please talk to us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [ ] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [ ] You structured the code into small functions as much as possible. You can use classes if there is a (state) purpose
- [ ] Your code follows our coding style
- [ ] You wrote tests for the new code
- [ ] `tox` tests pass. *Run `tox` command inside the repository folder*
- [ ] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [ ] PR does not add any dependencies, unless permission granted by the HADDOCK team
- [ ] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---

Close #936 

In batch mode, more files are created (e.g: `.job` and `.err`).
They were not part of the file extensions to be removed during the cleaning process.
This is now fixed !