### PR TITLE
Add MPI execution tests

### DIFF
--- a/integration_tests/test_mpi.py
+++ b/integration_tests/test_mpi.py
@@ -1,0 +1,77 @@
+import tempfile
+from pathlib import Path
+from typing import Generator
+
+import pytest
+
+from haddock.clis.cli_mpi import main as cli_mpi_main
+from haddock.libs.libmpi import MPIScheduler
+from haddock.libs.libsubprocess import CNSJob
+
+from . import CNS_EXEC
+
+
+class Task:
+    """A task to be executed by the MPIScheduler."""
+
+    def __init__(self, output_fname: Path):
+        self.output_fname = output_fname
+
+    def run(self):
+        self.output_fname.touch()
+
+
+@pytest.fixture
+def cnsjob() -> Generator[CNSJob, None, None]:
+    """A simple CNSJob that writes a message to a file."""
+    with tempfile.NamedTemporaryFile(suffix=".out") as out_f:
+        cns_inp = f"""
+set display={out_f.name} end
+display hello_from_test_mpi
+close {out_f.name} end
+stop"""
+
+        yield CNSJob(
+            input_file=cns_inp,
+            output_file=Path(out_f.name),
+            cns_exec=CNS_EXEC,
+        )
+
+
+@pytest.fixture
+def task() -> Generator[Task, None, None]:
+    """A simple task that creates a file."""
+    with tempfile.NamedTemporaryFile(suffix=".out") as out_f:
+        yield Task(output_fname=Path(out_f.name))
+
+
+def test_run_cli_mpi_main_cnsjob(cnsjob):
+    """Test the cli_mpi_main function with a CNSJob."""
+    with tempfile.TemporaryDirectory() as tempdir:
+        scheduler = MPIScheduler(tasks=[cnsjob], ncores=1)
+        scheduler.cwd = Path(tempdir)
+        scheduler._pickle_tasks()
+
+        pickled_tasks = Path(scheduler.cwd, "mpi.pkl")
+        assert pickled_tasks.exists()
+        assert pickled_tasks.stat().st_size > 0
+
+        cli_mpi_main(pickled_tasks)
+
+        scheduler.tasks[0].output_file.exists()
+
+
+def test_run_cli_mpi_main_task(task):
+    """Test the cli_mpi_main function with a Task."""
+    with tempfile.TemporaryDirectory() as tempdir:
+        scheduler = MPIScheduler(tasks=[task], ncores=1)
+        scheduler.cwd = Path(tempdir)
+        scheduler._pickle_tasks()
+
+        pickled_tasks = Path(scheduler.cwd, "mpi.pkl")
+        assert pickled_tasks.exists()
+        assert pickled_tasks.stat().st_size > 0
+
+        cli_mpi_main(pickled_tasks)
+
+        assert scheduler.tasks[0].output_fname.exists()

--- a/tests/test_cli_mpi.py
+++ b/tests/test_cli_mpi.py
@@ -1,0 +1,31 @@
+from mpi4py import MPI
+
+from haddock.clis import cli_mpi
+from haddock.clis.cli_mpi import split_tasks
+
+
+def test_cli_has_maincli():
+    """
+    Test maincli func in CLI.
+
+    maincli is used in setup.py.
+    """
+    assert cli_mpi.maincli
+
+
+def test_cli_has_comm():
+    """
+    Test COMM object in CLI.
+
+    COMM is used in main function.
+    """
+    assert cli_mpi.COMM
+
+    assert isinstance(cli_mpi.COMM, MPI.Intracomm)
+
+
+def test_split_tasks():
+
+    t = split_tasks([1, 2, 3, 4, 5, 6, 7, 8, 9], 3)
+
+    assert t == [[1, 4, 7], [2, 5, 8], [3, 6, 9]]

--- a/tests/test_libmpi.py
+++ b/tests/test_libmpi.py
@@ -1,0 +1,82 @@
+import pickle
+import random
+import subprocess
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from haddock.libs.libmpi import MPIScheduler
+
+
+@pytest.fixture
+def mpischeduler():
+    with tempfile.TemporaryDirectory() as tempdir:
+
+        scheduler = MPIScheduler(tasks=[1, 2, 3], ncores=4)
+        scheduler.cwd = Path(tempdir)
+
+        yield scheduler
+
+
+def test_mpischeduler_init():
+
+    cores = random.randint(1, 99)
+    mpi = MPIScheduler(tasks=[1, 2, 3], ncores=cores)
+
+    assert mpi.tasks == [1, 2, 3]
+    assert mpi.cwd == Path.cwd()
+    assert mpi.ncores == cores
+
+
+def test_mpischduler_run(mocker, mpischeduler):
+    # Mock the necessary methods and objects
+    mock_pickle_tasks = mocker.patch.object(
+        mpischeduler, "_pickle_tasks", return_value="mocked_pkl_tasks"
+    )
+    mock_subprocess_run = mocker.patch("subprocess.run")
+    mock_sys_exit = mocker.patch("sys.exit")
+
+    # Set up the mock subprocess.run return value
+    mock_process = MagicMock()
+    mock_process.stderr.decode.return_value = ""
+    mock_subprocess_run.return_value = mock_process
+
+    # Call the run method
+    mpischeduler.run()
+
+    # Assertions
+    mock_pickle_tasks.assert_called_once()
+
+    mock_subprocess_run.assert_called_once_with(
+        [
+            "mpirun",
+            "-np",
+            str(mpischeduler.ncores),
+            "haddock3-mpitask",
+            "mocked_pkl_tasks",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    mock_sys_exit.assert_not_called()
+
+    # Test error case
+    mock_process.stderr.decode.return_value = "Error occurred"
+    mpischeduler.run()
+    mock_sys_exit.assert_called_once()
+
+
+def test__pickle_tasks(mpischeduler):
+
+    result = mpischeduler._pickle_tasks()
+
+    expected_path = Path(mpischeduler.cwd, "mpi.pkl")
+    assert result == expected_path
+    assert expected_path.exists()
+
+    # Verify the content of the pickled file
+    with open(expected_path, "rb") as f:
+        unpickled_tasks = pickle.load(f)
+    assert unpickled_tasks == mpischeduler.tasks


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and that you comply with the following criteria:

- [ ] You have sticked to Python. Please talk to us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [ ] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [ ] You structured the code into small functions as much as possible. You can use classes if there is a (state) purpose
- [ ] Your code follows our coding style
- [ ] You wrote tests for the new code
- [ ] `tox` tests pass. *Run `tox` command inside the repository folder*
- [ ] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [ ] PR does not add any dependencies, unless permission granted by the HADDOCK team
- [ ] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---

*Delete this line and explain your PR here*
