### PR TITLE
Use `prepare_cns_input_sequential` when `mode` is not local

### DIFF
--- a/integration_tests/test_rigidbody.py
+++ b/integration_tests/test_rigidbody.py
@@ -75,7 +75,7 @@ class MockPreviousIO:
         return None
 
 
-def test_rigidbody(rigidbody_module):
+def test_rigidbody_local(rigidbody_module):
 
     sampling = 5
     rigidbody_module.previous_io = MockPreviousIO(path=rigidbody_module.path)
@@ -83,6 +83,7 @@ def test_rigidbody(rigidbody_module):
     rigidbody_module.params["cmrest"] = True
     rigidbody_module.params["mol_fix_origin_1"] = True
     rigidbody_module.params["mol_fix_origin_2"] = False
+    rigidbody_module.params["mode"] = "local"
 
     rigidbody_module.run()
 
@@ -95,6 +96,34 @@ def test_rigidbody(rigidbody_module):
         assert Path(rigidbody_module.path, f"rigidbody_{i}.pdb").stat().st_size > 0
         assert Path(rigidbody_module.path, f"rigidbody_{i}.out.gz").stat().st_size > 0
         assert Path(rigidbody_module.path, f"rigidbody_{i}.inp").stat().st_size > 0
+
+
+def test_rigidbody_mpi(rigidbody_module):
+
+    sampling = 5
+    rigidbody_module.previous_io = MockPreviousIO(path=rigidbody_module.path)
+    rigidbody_module.params["sampling"] = sampling
+    rigidbody_module.params["cmrest"] = True
+    rigidbody_module.params["mol_fix_origin_1"] = True
+    rigidbody_module.params["mol_fix_origin_2"] = False
+    rigidbody_module.params["mode"] = "mpi"
+
+    rigidbody_module.run()
+
+    for i in range(1, sampling + 1):
+        assert Path(rigidbody_module.path, f"rigidbody_{i}.pdb").exists()
+        assert Path(rigidbody_module.path, f"rigidbody_{i}.out.gz").exists()
+        assert Path(rigidbody_module.path, f"rigidbody_{i}.inp").exists()
+        assert not Path(rigidbody_module.path, f"rigidbody_{i}.seed").exists()
+
+        assert Path(rigidbody_module.path, f"rigidbody_{i}.pdb").stat().st_size > 0
+        assert Path(rigidbody_module.path, f"rigidbody_{i}.out.gz").stat().st_size > 0
+        assert Path(rigidbody_module.path, f"rigidbody_{i}.inp").stat().st_size > 0
+
+
+@pytest.mark.skip("Not implemented yet")
+def test_rigidbody_batch(rigidbody_module):
+    pass
 
 
 def test_rigidbody_less_io(rigidbody_module):

--- a/integration_tests/test_rigidbody.py
+++ b/integration_tests/test_rigidbody.py
@@ -107,6 +107,7 @@ def test_rigidbody_mpi(rigidbody_module):
     rigidbody_module.params["mol_fix_origin_1"] = True
     rigidbody_module.params["mol_fix_origin_2"] = False
     rigidbody_module.params["mode"] = "mpi"
+    rigidbody_module.params["ncores"] = 1
 
     rigidbody_module.run()
 

--- a/src/haddock/modules/sampling/rigidbody/__init__.py
+++ b/src/haddock/modules/sampling/rigidbody/__init__.py
@@ -161,7 +161,6 @@ class HaddockModule(BaseCNSModule):
 
         # Replace the task with the result of the task
         l = []
-        assert isinstance(prepare_engine, Scheduler)
         for element, task_result in zip(_l, prepare_engine.results):
             l.append((element[0], task_result, element[2], element[3]))
 
@@ -208,7 +207,8 @@ class HaddockModule(BaseCNSModule):
         start = datetime.now()
         self.output_models: list[PDBFile] = []
         self.log("Preparing jobs...")
-        if self.params["mode"] == "batch":
+        if self.params["mode"] != "local":
+            # Note: `batch` and (pseudo)-`mpi` mode uses files to communicate and cannot extract the information from the task object.
             cns_input = self.prepare_cns_input_sequential(
                 models_to_dock, sampling_factor, ambig_fnames  # type: ignore
             )


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and that you comply with the following criteria:

- [x] You have sticked to Python. Please talk to us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [x] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [x] You structured the code into small functions as much as possible. You can use classes if there is a (state) purpose
- [x] Your code follows our coding style
- [x] You wrote tests for the new code
- [x] `tox` tests pass. *Run `tox` command inside the repository folder*
- [ ] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [x] PR does not add any dependencies, unless permission granted by the HADDOCK team
- [x] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [x] Your PR is about writing tests for already existing code :godmode:

---

This PR changes the rigidbody module to use `prepare_cns_input_sequential` if the execution mode is different than `local` - it also adds more tests
