### PR TITLE
removed duplicated w_air parameter

### DIFF
--- a/src/haddock/modules/scoring/mdscoring/defaults.yaml
+++ b/src/haddock/modules/scoring/mdscoring/defaults.yaml
@@ -20,18 +20,6 @@ w_air:
   long: Weight of the distance restraints energy in the scoring function.
     Note that this is different from the force constants used during the calculations.
   group: 'scoring'
-  explevel: expert
-w_air:
-  default: 0.0
-  type: float
-  min: 0
-  max: 9999
-  precision: 3
-  title: Weight of the distance restraint energy
-  short: Weight of the distance restraints energy in the scoring function
-  long: Weight of the distance restraints energy in the scoring function.
-    Note that this is different from the force constants used during the calculations.
-  group: 'scoring'
   explevel: hidden
 w_bsa:
   default: 0.0


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and that you comply with the following criteria:

- [ ] You have sticked to Python. Please talk to us before adding other programming languages to HADDOCK3
- [X] Your PR is about CNS
- [ ] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [ ] You structured the code into small functions as much as possible. You can use classes if there is a (state) purpose
- [ ] Your code follows our coding style
- [ ] You wrote tests for the new code
- [ ] `tox` tests pass. *Run `tox` command inside the repository folder*
- [ ] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [X] PR does not add any dependencies, unless permission granted by the HADDOCK team
- [X] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---

The haddock-runner detected duplicated parameters in the `default.yaml` file of the `mdscoring` module. This pull request removes the duplication of the w_air parameter.