### PR TITLE
Refactor `capri.extract_data_from_capri_class` to propagate the model's energy terms

### DIFF
--- a/integration_tests/test_caprieval.py
+++ b/integration_tests/test_caprieval.py
@@ -6,8 +6,9 @@ from pathlib import Path
 import pytest
 
 from haddock.libs.libontology import PDBFile
-from haddock.modules.analysis.caprieval import \
-    DEFAULT_CONFIG as DEFAULT_CAPRIEVAL_CONFIG
+from haddock.modules.analysis.caprieval import (
+    DEFAULT_CONFIG as DEFAULT_CAPRIEVAL_CONFIG,
+)
 from haddock.modules.analysis.caprieval import HaddockModule as CaprievalModule
 from tests import golden_data
 
@@ -25,8 +26,16 @@ def caprieval_module():
 @pytest.fixture
 def model_list():
     return [
-        PDBFile(file_name="protprot_complex_1.pdb", path="."),
-        PDBFile(file_name="protprot_complex_2.pdb", path="."),
+        PDBFile(
+            file_name="protprot_complex_1.pdb",
+            path=".",
+            unw_energies={"energy_term": 0.0},
+        ),
+        PDBFile(
+            file_name="protprot_complex_2.pdb",
+            path=".",
+            unw_energies={"energy_term": 0.0},
+        ),
     ]
 
 
@@ -44,8 +53,16 @@ class MockPreviousIO:
             Path(".", "protprot_complex_2.pdb"),
         )
         model_list = [
-            PDBFile(file_name="protprot_complex_1.pdb", path="."),
-            PDBFile(file_name="protprot_complex_2.pdb", path="."),
+            PDBFile(
+                file_name="protprot_complex_1.pdb",
+                path=".",
+                unw_energies={"energy_term": 0.0},
+            ),
+            PDBFile(
+                file_name="protprot_complex_2.pdb",
+                path=".",
+                unw_energies={"energy_term": 0.0},
+            ),
         ]
 
         return model_list
@@ -96,6 +113,7 @@ def evaluate_caprieval_execution(module: CaprievalModule, model_list):
         "dockq",
         "cluster_ranking",
         "model-cluster_ranking",
+        "energy_term",
     ]
     header = lines[0].strip().split("\t")
     for col_name in expected_colnames:
@@ -117,6 +135,7 @@ def evaluate_caprieval_execution(module: CaprievalModule, model_list):
             "cluster_id": "-",
             "cluster_ranking": "-",
             "model-cluster_ranking": "-",
+            "energy_term": 0.000,
         },
         {
             "model": "",
@@ -131,6 +150,7 @@ def evaluate_caprieval_execution(module: CaprievalModule, model_list):
             "cluster_id": "-",
             "cluster_ranking": "-",
             "model-cluster_ranking": "-",
+            "energy_term": 0.000,
         },
     ]
     oberseved_data = []
@@ -149,6 +169,7 @@ def evaluate_caprieval_execution(module: CaprievalModule, model_list):
             "cluster_id": str(values[9]),
             "cluster_ranking": str(values[10]),
             "model-cluster_ranking": str(values[11]),
+            "energy_term": float(values[12]),
         }
         oberseved_data.append(data_dict)
 

--- a/src/haddock/modules/analysis/caprieval/capri.py
+++ b/src/haddock/modules/analysis/caprieval/capri.py
@@ -946,6 +946,8 @@ def extract_data_from_capri_class(
             "cluster_ranking": None,
             "model-cluster_ranking": None,
         }
+        if c.model.unw_energies is not None:
+            data[i].update(c.model.unw_energies)
 
     ranked_data = rank_according_to_score(
         data, sort_key=sort_key, sort_ascending=sort_ascending

--- a/tests/test_module_caprieval.py
+++ b/tests/test_module_caprieval.py
@@ -20,7 +20,7 @@ from haddock.modules.analysis.caprieval.capri import (
     load_contacts,
     rank_according_to_score,
     rearrange_ss_capri_output,
-    )
+)
 
 from . import golden_data
 
@@ -438,6 +438,7 @@ def test_make_output(protprot_caprimodule):
     protprot_caprimodule.model.clt_id = 1
     protprot_caprimodule.model.clt_rank = 1
     protprot_caprimodule.model.clt_model_rank = 10
+    protprot_caprimodule.model.unw_energies = {"something": 0.0}
 
     protprot_caprimodule.make_output()
 
@@ -463,8 +464,9 @@ def test_make_output(protprot_caprimodule):
             "cluster_id",
             "cluster_ranking",
             "model-cluster_ranking",
+            "something",
         ],
-        ["-", "-", "nan", "nan", "nan", "nan", "nan", "nan", "1", "1", "10"],
+        ["-", "-", "nan", "nan", "nan", "nan", "nan", "nan", "1", "1", "10", "0.000"],
     ]
 
     assert observed_outf_l == expected_outf_l

--- a/tests/test_module_caprieval.py
+++ b/tests/test_module_caprieval.py
@@ -982,7 +982,10 @@ def test_extract_data_from_capri_class(mocker):
     )
 
     # Create random entries
-    random_model = PDBFile(file_name=str(uuid.uuid4()), score=42)
+    random_energy = random.random()
+    random_model = PDBFile(
+        file_name=str(uuid.uuid4()), score=42, unw_energies={"energy": random_energy}
+    )
     random_md5 = str(uuid.uuid4())
     random_score = random.random()
     random_irmsd = random.random()
@@ -1014,3 +1017,4 @@ def test_extract_data_from_capri_class(mocker):
     assert observed_data[1]["lrmsd"] == random_lrmsd
     assert observed_data[1]["ilrmsd"] == random_ilrmsd
     assert observed_data[1]["dockq"] == random_dockq
+    assert observed_data[1]["energy"] == random_energy


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and that you comply with the following criteria:

- [x] You have sticked to Python. Please talk to us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [x] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [x] You structured the code into small functions as much as possible. You can use classes if there is a (state) purpose
- [x] Your code follows our coding style
- [x] You wrote tests for the new code
- [x] `tox` tests pass. *Run `tox` command inside the repository folder*
- [ ] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [x] PR does not add any dependencies, unless permission granted by the HADDOCK team
- [x] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [x] Your PR is about writing tests for already existing code :godmode:

---

This PR refactors `capri.extract_data_from_capri_class` to mimic the behaviour of the `make_output` method that retrieves the `PDBFile.unw_energies` property that will later be used when writing the output.

