### PR TITLE
lazy load MPI module and COMM variable

### DIFF
--- a/tests/test_cli_mpi.py
+++ b/tests/test_cli_mpi.py
@@ -1,7 +1,9 @@
-from mpi4py import MPI
+from unittest import mock
+
+import pytest
 
 from haddock.clis import cli_mpi
-from haddock.clis.cli_mpi import split_tasks
+from haddock.clis.cli_mpi import get_mpi, split_tasks
 
 
 def test_cli_has_maincli():
@@ -19,9 +21,7 @@ def test_cli_has_comm():
 
     COMM is used in main function.
     """
-    assert cli_mpi.COMM
-
-    assert isinstance(cli_mpi.COMM, MPI.Intracomm)
+    assert cli_mpi.COMM is None
 
 
 def test_split_tasks():
@@ -29,3 +29,33 @@ def test_split_tasks():
     t = split_tasks([1, 2, 3, 4, 5, 6, 7, 8, 9], 3)
 
     assert t == [[1, 4, 7], [2, 5, 8], [3, 6, 9]]
+
+
+def test_get_mpi_success():
+    # Mock the import of mpi4py.MPI
+    with mock.patch.dict(
+        "sys.modules", {"mpi4py": mock.Mock(), "mpi4py.MPI": mock.Mock()}
+    ):
+        from mpi4py import MPI as _MPI
+
+        MPI, COMM = get_mpi()
+        assert MPI == _MPI
+        assert COMM == _MPI.COMM_WORLD
+
+
+def test_get_mpi_import_error():
+    # Mock the absence of mpi4py.MPI to simulate ImportError
+    with mock.patch.dict("sys.modules", {"mpi4py": None}):
+        with mock.patch("sys.exit") as mock_exit:
+            get_mpi()
+            mock_exit.assert_called_once()
+
+
+# Cleanup fixture to reset global state after each test
+@pytest.fixture(autouse=True)
+def cleanup():
+    yield
+    import haddock.clis.cli_mpi
+
+    haddock.clis.cli_mpi.MPI = None
+    haddock.clis.cli_mpi.COMM = None


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and that you comply with the following criteria:

- [x] You have sticked to Python. Please talk to us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [x] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [x] You structured the code into small functions as much as possible. You can use classes if there is a (state) purpose
- [x] Your code follows our coding style
- [x] You wrote tests for the new code
- [ ] `tox` tests pass. *Run `tox` command inside the repository folder*
- [ ] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [x] PR does not add any dependencies, unless permission granted by the HADDOCK team
- [x] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---

<!-- Carefully explain what changed you made to the code, make sure the title reflects the changes -->

This PR adds lazy-loading of the `mpi4py` module, avoiding issues during testing
