### PR TITLE
Handle exceptions in `Worker.run`

### DIFF
--- a/src/haddock/libs/libparallel.py
+++ b/src/haddock/libs/libparallel.py
@@ -85,7 +85,12 @@ class Worker(Process):
         """Execute tasks."""
         results = []
         for task in self.tasks:
-            r = task.run()
+            r = None
+            try:
+                r = task.run()
+            except Exception as e:
+                log.exception(f"Exception in task {task}: {e}")
+
             results.append(r)
 
         # Put results into the queue


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and that you comply with the following criteria:

- [ ] You have sticked to Python. Please talk to us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [ ] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [ ] You structured the code into small functions as much as possible. You can use classes if there is a (state) purpose
- [ ] Your code follows our coding style
- [ ] You wrote tests for the new code
- [ ] `tox` tests pass. *Run `tox` command inside the repository folder*
- [ ] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [ ] PR does not add any dependencies, unless permission granted by the HADDOCK team
- [ ] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---

<!-- Carefully explain what changed you made to the code, make sure the title reflects the changes -->

This PR fixes the `libparallel.Worker.run` method to properly handle exception raised by the tasks 
