### PR TITLE
Update `caprieval` integration tests with new score values

### DIFF
--- a/integration_tests/test_caprieval.py
+++ b/integration_tests/test_caprieval.py
@@ -31,11 +31,13 @@ def model_list():
             file_name="protprot_complex_1.pdb",
             path=".",
             unw_energies={"energy_term": 0.0},
+            score=0.0,
         ),
         PDBFile(
             file_name="protprot_complex_2.pdb",
             path=".",
             unw_energies={"energy_term": 0.0},
+            score=100.0,
         ),
     ]
 
@@ -48,8 +50,8 @@ def expected_clt_data() -> list[dict[str, Union[int, str, float]]]:
             "cluster_id": "-",
             "n": 2,
             "under_eval": "yes",
-            "score": float("nan"),
-            "score_std": float("nan"),
+            "score": 50.0,
+            "score_std": 50.0,
             "irmsd": 4.163,
             "irmsd_std": 4.163,
             "fnat": 0.525,
@@ -84,7 +86,7 @@ def expected_ss_data() -> list[dict[str, Union[int, str, float]]]:
             "model": "",
             "md5": "-",
             "caprieval_rank": 1,
-            "score": float("nan"),
+            "score": 0.0,
             "irmsd": 0.000,
             "fnat": 1.000,
             "lrmsd": 0.000,
@@ -99,7 +101,7 @@ def expected_ss_data() -> list[dict[str, Union[int, str, float]]]:
             "model": "",
             "md5": "-",
             "caprieval_rank": 2,
-            "score": float("nan"),
+            "score": 100.0,
             "irmsd": 8.327,
             "fnat": 0.050,
             "lrmsd": 20.937,
@@ -131,11 +133,13 @@ class MockPreviousIO:
                 file_name="protprot_complex_1.pdb",
                 path=".",
                 unw_energies={"energy_term": 0.0},
+                score=0.0,
             ),
             PDBFile(
                 file_name="protprot_complex_2.pdb",
                 path=".",
                 unw_energies={"energy_term": 0.0},
+                score=100.0,
             ),
         ]
 


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and that you comply with the following criteria:

- [ ] You have sticked to Python. Please talk to us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [ ] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [ ] You structured the code into small functions as much as possible. You can use classes if there is a (state) purpose
- [ ] Your code follows our coding style
- [ ] You wrote tests for the new code
- [ ] `tox` tests pass. *Run `tox` command inside the repository folder*
- [ ] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [ ] PR does not add any dependencies, unless permission granted by the HADDOCK team
- [ ] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---

<!-- Carefully explain what changed you made to the code, make sure the title reflects the changes -->

Before the tests had `float(nan)` as scores, which does not produce a constant sorting when sorting by scores. This PR adds scores to the test data to produce reproducible results.
