### PR TITLE
change log level of exceptions in the Worker's run method

### DIFF
--- a/src/haddock/libs/libparallel.py
+++ b/src/haddock/libs/libparallel.py
@@ -89,7 +89,7 @@ class Worker(Process):
             try:
                 r = task.run()
             except Exception as e:
-                log.exception(f"Exception in task {task}: {e}")
+                log.warning(f"Exception in task execution: {e}")
 
             results.append(r)
 


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and that you comply with the following criteria:

- [x] You have sticked to Python. Please talk to us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [ ] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [ ] You structured the code into small functions as much as possible. You can use classes if there is a (state) purpose
- [x] Your code follows our coding style
- [ ] You wrote tests for the new code
- [ ] `tox` tests pass. *Run `tox` command inside the repository folder*
- [ ] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [x] PR does not add any dependencies, unless permission granted by the HADDOCK team
- [x] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---

<!-- Carefully explain what changed you made to the code, make sure the title reflects the changes -->

This PR changes the log level when reporting exceptions in the task execution. `exception` will log it with ERROR level - which is wrong since the execution can move forward. This PR changes it so its logged as WARNING 
