### PR TITLE
Propagate cluster related properties in `caprieval`

### DIFF
--- a/src/haddock/modules/analysis/caprieval/__init__.py
+++ b/src/haddock/modules/analysis/caprieval/__init__.py
@@ -144,6 +144,10 @@ class HaddockModule(BaseHaddockModule):
             )
 
         else:
+            self.log(
+                msg="DEPRECATION NOTICE: This execution mode (less_io=False) will no longer be supported in the next version.",
+                level="warning",
+            )
             jobs = merge_data(jobs)
 
             # Each job created one .tsv, unify them:

--- a/src/haddock/modules/analysis/caprieval/capri.py
+++ b/src/haddock/modules/analysis/caprieval/capri.py
@@ -224,9 +224,6 @@ class CAPRI:
         self.identificator = identificator
         self.core_model_idx = identificator
         self.less_io = less_io
-        self.cluster_id = None
-        self.cluster_ranking = None
-        self.model_cluster_ranking = None
 
     def calc_irmsd(self, cutoff: float = 5.0) -> None:
         """Calculate the I-RMSD.

--- a/src/haddock/modules/analysis/caprieval/capri.py
+++ b/src/haddock/modules/analysis/caprieval/capri.py
@@ -224,6 +224,9 @@ class CAPRI:
         self.identificator = identificator
         self.core_model_idx = identificator
         self.less_io = less_io
+        self.cluster_id = None
+        self.cluster_ranking = None
+        self.model_cluster_ranking = None
 
     def calc_irmsd(self, cutoff: float = 5.0) -> None:
         """Calculate the I-RMSD.
@@ -942,9 +945,11 @@ def extract_data_from_capri_class(
             "lrmsd": c.lrmsd,
             "ilrmsd": c.ilrmsd,
             "dockq": c.dockq,
-            "cluster_id": None,
-            "cluster_ranking": None,
-            "model-cluster_ranking": None,
+            "cluster_id": c.model.clt_id if c.model.clt_id else None,
+            "cluster_ranking": c.model.clt_rank if c.model.clt_rank else None,
+            "model-cluster_ranking": (
+                c.model.clt_model_rank if c.model.clt_model_rank else None
+            ),
         }
         if c.model.unw_energies is not None:
             data[i].update(c.model.unw_energies)

--- a/tests/test_module_caprieval.py
+++ b/tests/test_module_caprieval.py
@@ -992,6 +992,10 @@ def test_extract_data_from_capri_class(mocker):
     random_model = PDBFile(
         file_name=str(uuid.uuid4()), score=42, unw_energies={"energy": random_energy}
     )
+
+    random_clt_id = random.randint(0, 100)
+    random_clt_rank = random.randint(0, 100)
+    random_clt_model_rank = random.randint(0, 100)
     random_md5 = str(uuid.uuid4())
     random_score = random.random()
     random_irmsd = random.random()
@@ -1001,6 +1005,9 @@ def test_extract_data_from_capri_class(mocker):
     random_dockq = random.random()
 
     c.model = random_model
+    c.model.clt_id = random_clt_id
+    c.model.clt_rank = random_clt_rank
+    c.model.clt_model_rank = random_clt_model_rank
     c.md5 = random_md5
     c.score = random_score
     c.irmsd = random_irmsd
@@ -1024,3 +1031,6 @@ def test_extract_data_from_capri_class(mocker):
     assert observed_data[1]["ilrmsd"] == random_ilrmsd
     assert observed_data[1]["dockq"] == random_dockq
     assert observed_data[1]["energy"] == random_energy
+    assert observed_data[1]["cluster_id"] == random_clt_id
+    assert observed_data[1]["cluster_ranking"] == random_clt_rank
+    assert observed_data[1]["model-cluster_ranking"] == random_clt_model_rank


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and that you comply with the following criteria:

- [x] You have sticked to Python. Please talk to us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [x] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [x] You structured the code into small functions as much as possible. You can use classes if there is a (state) purpose
- [x] Your code follows our coding style
- [x] You wrote tests for the new code
- [x] `tox` tests pass. *Run `tox` command inside the repository folder*
- [ ] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [x] PR does not add any dependencies, unless permission granted by the HADDOCK team
- [x] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [x] Your PR is about writing tests for already existing code :godmode:

---

<!-- Carefully explain what changed you made to the code, make sure the title reflects the changes -->

This PR adds the extraction and combination of cluster-related information from the models into the `extract_data_from_capri_class` method. I've also updated the test to cover this behaviour and added a deprecation notice to the soon-to-be-removed branch with `less_io=false` - see #970 

Also keep in mind that this retrieval of clustering information should not be done via the model object - by doing this we are breaking the modular design by using the PDBFile object as means to transport information instead of the ontology object. Should be addressed in a separate PR tho