### PR TITLE
Refactor `validate_parameters_are_not_incompatible` to check for the incompatible value

### DIFF
--- a/src/haddock/gear/prepare_run.py
+++ b/src/haddock/gear/prepare_run.py
@@ -962,9 +962,15 @@ def validate_parameters_are_not_incompatible(params: ParamMap) -> None:
         # Check if the limiting parameter is present in the parameters
         if limiting_param in params:
             # Check each incompatibility for the limiting parameter
+            incompatible_value_of_limiting_param = incompatibilities["value"]
             for incompatible_param, incompatible_value in incompatibilities.items():
+                if incompatible_param == "value":
+                    continue
                 # Check if the incompatible parameter is present and has the incompatible value
-                if params.get(incompatible_param) == incompatible_value:
+                if (
+                    params.get(incompatible_param) == incompatible_value
+                    and params[limiting_param] == incompatible_value_of_limiting_param
+                ):
                     raise ValueError(
                         f"Parameter `{limiting_param}` is incompatible with `{incompatible_param}={incompatible_value}`."
                     )

--- a/src/haddock/modules/defaults.yaml
+++ b/src/haddock/modules/defaults.yaml
@@ -149,4 +149,5 @@ less_io:
   group: "execution"
   explevel: easy
   incompatible:
+    value: true
     mode: batch

--- a/tests/test_gear_prepare_run.py
+++ b/tests/test_gear_prepare_run.py
@@ -392,19 +392,26 @@ def test_param_value_error(defaultparams, key, value):
 def test_validate_parameters_are_not_incompatible(mocker):
     mocker.patch(
         "haddock.gear.prepare_run.incompatible_defaults_params",
-        {"limiting_parameter": {"incompatible_parameter": "incompatible_value"}},
+        {
+            "limiting_parameter": {
+                "value": True,
+                "incompatible_parameter": "incompatible_value",
+            }
+        },
     )
 
+    # Test 1 successfully fail
     params = {
-        "limiting_parameter": "",
+        "limiting_parameter": True,
         "incompatible_parameter": "incompatible_value",
     }
 
     with pytest.raises(ValueError):
         validate_parameters_are_not_incompatible(params)
 
+    # Test 2 - successfully pass
     params = {
-        "limiting_parameter": "limiting_value",
+        "limiting_parameter": False,
         "ok_parameter": "ok_value",
     }
 


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and that you comply with the following criteria:

- [x] You have sticked to Python. Please talk to us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [x] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [x] You structured the code into small functions as much as possible. You can use classes if there is a (state) purpose
- [x] Your code follows our coding style
- [x] You wrote tests for the new code
- [x] `tox` tests pass. *Run `tox` command inside the repository folder*
- [ ] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [x] PR does not add any dependencies, unless permission granted by the HADDOCK team
- [x] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [x] Your PR is about writing tests for already existing code :godmode:

---

<!-- Carefully explain what changed you made to the code, make sure the title reflects the changes -->

This PR updates `validate_parameters_are_not_incompatible` that was not checking which value should trigger the incompatibility. Effectively it would break any workflow using the parameters mark as incompatible.
