### PR TITLE
Single chain caprieval

### DIFF
--- a/integration_tests/test_caprieval.py
+++ b/integration_tests/test_caprieval.py
@@ -62,6 +62,8 @@ def expected_clt_data() -> list[dict[str, Union[int, str, float]]]:
             "dockq_std": 0.463,
             "ilrmsd": 9.124,
             "ilrmsd_std": 9.124,
+            "rmsd": 4.311,
+            "rmsd_std": 4.311,
             "air": float("nan"),
             "air_std": float("nan"),
             "bsa": float("nan"),
@@ -92,6 +94,7 @@ def expected_ss_data() -> list[dict[str, Union[int, str, float]]]:
             "lrmsd": 0.000,
             "ilrmsd": 0.000,
             "dockq": 1.000,
+            "rmsd": 0.000,
             "cluster_id": "-",
             "cluster_ranking": "-",
             "model-cluster_ranking": "-",
@@ -107,6 +110,7 @@ def expected_ss_data() -> list[dict[str, Union[int, str, float]]]:
             "lrmsd": 20.937,
             "ilrmsd": 18.248,
             "dockq": 0.074,
+            "rmsd": 8.622,
             "cluster_id": "-",
             "cluster_ranking": "-",
             "model-cluster_ranking": "-",
@@ -209,9 +213,9 @@ def _check_capri_ss_tsv(
     expected_header_cols = list(expected_data[0].keys())
     observed_header_cols = lines[0].strip().split("\t")
 
-    # Check if all they have the same lenght
+    # Check if all of them have the same lenght
     assert len(observed_header_cols) == len(expected_header_cols), "Header mismatch"
-
+    # Make sure column names are the same
     for col_name in expected_header_cols:
         assert col_name in observed_header_cols, f"{col_name} not found in the header"
 

--- a/integration_tests/test_caprieval.py
+++ b/integration_tests/test_caprieval.py
@@ -110,7 +110,7 @@ def expected_ss_data() -> list[dict[str, Union[int, str, float]]]:
             "lrmsd": 20.937,
             "ilrmsd": 18.248,
             "dockq": 0.074,
-            "rmsd": 8.622,
+            "rmsd": 8.623,
             "cluster_id": "-",
             "cluster_ranking": "-",
             "model-cluster_ranking": "-",
@@ -169,33 +169,35 @@ def _compare_polymorphic_data(
     oberseved_data: list[dict[str, Union[int, str, float]]],
 ):
     """Helper function to compare a list of dictionaries with polymorphic values."""
-    for k, v in zip(expected_data, oberseved_data):
-        for key in k:
-            v1 = k[key]
-            v2 = v[key]
+    for expected, observed in zip(expected_data, oberseved_data):
+        # Loop over keys
+        for key in expected.keys():
+            # Point corresponding values
+            exp_val = expected[key]
+            obs_val = observed[key]
 
             # Check the type match
-            assert type(v1) == type(v2), f"Type mismatch for {key}"
+            assert type(exp_val) == type(obs_val), f"Type mismatch for {key}"
 
             # Check float
-            if isinstance(v1, float):
-                if math.isnan(v1):
-                    assert isinstance(v2, float) and math.isnan(
-                        v2
+            if isinstance(exp_val, float):
+                if math.isnan(exp_val):
+                    assert isinstance(obs_val, float) and math.isnan(
+                        obs_val
                     ), f"Value mismatch for {key}"
                 else:
                     assert (
-                        isinstance(v2, (int, float))
-                        and pytest.approx(v1, rel=1e-3) == v2
+                        isinstance(obs_val, (int, float))
+                        and pytest.approx(exp_val, rel=1e-3) == obs_val
                     ), f"Value mismatch for {key}"
 
             # Check int
-            elif isinstance(v1, int):
-                assert v1 == v2, f"Value mismatch for {key}"
+            elif isinstance(exp_val, int):
+                assert exp_val == obs_val, f"Value mismatch for {key}"
 
             # Check str
-            elif isinstance(v1, str):
-                assert v1 == v2, f"Value mismatch for {key}"
+            elif isinstance(exp_val, str):
+                assert exp_val == obs_val, f"Value mismatch for {key}"
 
             # Value is not float, int or str
             else:
@@ -207,11 +209,15 @@ def _check_capri_ss_tsv(
 ):
     """Helper function to check the content of the capri_ss.tsv file."""
     with open(capri_file) as f:
-        lines = f.readlines()
+        lines = [
+            _.strip().split("\t")
+            for _ in f.readlines()
+            if not _.startswith("#")
+            ]
 
     # Check the header
     expected_header_cols = list(expected_data[0].keys())
-    observed_header_cols = lines[0].strip().split("\t")
+    observed_header_cols = lines[0]
 
     # Check if all of them have the same lenght
     assert len(observed_header_cols) == len(expected_header_cols), "Header mismatch"
@@ -222,13 +228,12 @@ def _check_capri_ss_tsv(
     oberseved_data: list[dict[str, Union[int, str, float]]] = []
     data = lines[1:]
     for line in data:
-        values = line.strip().split("\t")
 
         # Check there is one value for each column
-        assert len(values) == len(expected_header_cols), "Values mismatch"
+        assert len(line) == len(expected_header_cols), "Values mismatch"
 
         data_dict = {}
-        for h, v in zip(expected_header_cols, values):
+        for h, v in zip(expected_header_cols, line):
             data_dict[h] = _cast_float_str_int(v)
 
         oberseved_data.append(data_dict)
@@ -244,14 +249,16 @@ def _check_capri_clt_tsv(
 ):
     """Helper function to check the content of the capri_clt.tsv file."""
     with open(capri_file) as f:
-        lines = f.readlines()
-
-    # There are several `#` lines in the file, these are comments and can be ignored
-    lines = [line for line in lines if not line.startswith("#")]
+        # There are several `#` lines in the file, these are comments and can be ignored
+        lines = [
+            _.strip().split("\t")
+            for _ in f.readlines()
+            if not _.startswith("#")
+            ]
 
     # Check header
     expected_header_cols = list(expected_data[0].keys())
-    observed_header_cols = lines[0].strip().split("\t")
+    observed_header_cols = lines[0]
 
     # Check if all the columns are present
     assert len(observed_header_cols) == len(expected_header_cols), "Header mismatch"
@@ -262,13 +269,12 @@ def _check_capri_clt_tsv(
     data = lines[1:]
     oberseved_data: list[dict[str, Union[int, str, float]]] = []
     for line in data:
-        values = line.strip().split("\t")
 
         # Check if there is one value for each column
-        assert len(values) == len(expected_header_cols), "Values mismatch"
+        assert len(line) == len(expected_header_cols), "Values mismatch"
 
         data_dic = {}
-        for h, v in zip(expected_header_cols, values):
+        for h, v in zip(expected_header_cols, line):
             data_dic[h] = _cast_float_str_int(v)
 
         oberseved_data.append(data_dic)

--- a/src/haddock/modules/analysis/caprieval/__init__.py
+++ b/src/haddock/modules/analysis/caprieval/__init__.py
@@ -17,6 +17,7 @@ By default the following metrics are calculated:
 - ILRMSD (interface ligand root mean square deviation), the RMSD of the
     ligand of the docked complex with respect to the reference complex
     upon superposition of the interface of the receptor.
+- GLOBAL_RMSD, the full RMSD between the reference and the model.
 
 The following files are generated:
 

--- a/src/haddock/modules/analysis/caprieval/capri.py
+++ b/src/haddock/modules/analysis/caprieval/capri.py
@@ -784,6 +784,7 @@ def merge_data(capri_jobs: list[CAPRI]) -> list[CAPRI]:
             if m == file_name:
                 # add the data
                 for target_key in target_keys:
+                   # Set a new target_key attribute to object with capri_dic[m][target_key] value
                     j.__setattr__(target_key, capri_dic[m][target_key])
 
     return capri_jobs

--- a/src/haddock/modules/analysis/caprieval/capri.py
+++ b/src/haddock/modules/analysis/caprieval/capri.py
@@ -949,6 +949,7 @@ def extract_data_from_capri_class(
             "lrmsd": c.lrmsd,
             "ilrmsd": c.ilrmsd,
             "dockq": c.dockq,
+            "rmsd": c.rmsd,
             "cluster_id": c.model.clt_id if c.model.clt_id else None,
             "cluster_ranking": c.model.clt_rank if c.model.clt_rank else None,
             "model-cluster_ranking": (

--- a/src/haddock/modules/analysis/caprieval/capri.py
+++ b/src/haddock/modules/analysis/caprieval/capri.py
@@ -776,7 +776,7 @@ def merge_data(capri_jobs: list[CAPRI]) -> list[CAPRI]:
             key: float(content_data[header_data.index(key)])
             for key in target_keys
             }
-    
+
     for j in capri_jobs:
         for m in capri_dic:
             jm = j.model
@@ -1045,12 +1045,7 @@ def capri_cluster_analysis(
         # capri keys
         for key in capri_keys:
             std_key = f"{key}_std"
-            print(key)
-            print(clt_data[element])
             try:
-                if key == "rmsd":
-                    for e in clt_data[element][:clt_threshold]:
-                        print(vars(e[0]))
                 key_array = [vars(e[0])[key] for e in clt_data[element][:clt_threshold]]
                 data[key], data[std_key] = calc_stats(key_array)
             except KeyError:

--- a/src/haddock/modules/analysis/caprieval/defaults.yaml
+++ b/src/haddock/modules/analysis/caprieval/defaults.yaml
@@ -62,6 +62,19 @@ dockq:
   group: analysis
   explevel: easy
 
+global_rmsd:
+  default: true
+  type: boolean
+  title: Calculate global RMSD
+  short: Calculate full structure RMSD.
+  long: Compute full structure RMSD between reference structure and the model
+        after superimposition. Note that a sequence alignment is performed to
+        obtain the mapping between the reference and the model. If the one of
+        the structure contain a 'small-molecule', we assume that the compared
+        structure atoms are in the same order.
+  group: analysis
+  explevel: easy
+
 irmsd_cutoff:
   default: 10.0
   type: float

--- a/src/haddock/modules/analysis/caprieval/defaults.yaml
+++ b/src/haddock/modules/analysis/caprieval/defaults.yaml
@@ -71,7 +71,8 @@ global_rmsd:
         after superimposition. Note that a sequence alignment is performed to
         obtain the mapping between the reference and the model. If the one of
         the structure contain a 'small-molecule', we assume that the compared
-        structure atoms are in the same order.
+        structure atoms are in the same order. With default parameters `allatoms = false`, only
+        backbone RMSD will be computed.
   group: analysis
   explevel: easy
 

--- a/tests/test_module_caprieval.py
+++ b/tests/test_module_caprieval.py
@@ -636,6 +636,7 @@ def test_capri_cluster_analysis(protprot_caprimodule, protprot_input_list):
     protprot_caprimodule.fnat = 1.0
     protprot_caprimodule.lrmsd = 1.2
     protprot_caprimodule.ilrmsd = 4.3
+    protprot_caprimodule.rmsd = 0.01,
     capri_cluster_analysis(
         capri_list=[protprot_caprimodule, protprot_caprimodule],
         model_list=[model1, model2],
@@ -666,6 +667,8 @@ def test_capri_cluster_analysis(protprot_caprimodule, protprot_input_list):
             "dockq_std",
             "ilrmsd",
             "ilrmsd_std",
+            "rmsd",
+            "rmsd_std",
             "caprieval_rank",
         ],
         [
@@ -684,6 +687,8 @@ def test_capri_cluster_analysis(protprot_caprimodule, protprot_input_list):
             "nan",
             "4.300",
             "0.000",
+            "0.010",
+            "0.000",
             "1",
         ],
         [
@@ -701,6 +706,8 @@ def test_capri_cluster_analysis(protprot_caprimodule, protprot_input_list):
             "nan",
             "nan",
             "4.300",
+            "0.000",
+            "0.010",
             "0.000",
             "2",
         ],
@@ -734,6 +741,8 @@ def test_capri_cluster_analysis(protprot_caprimodule, protprot_input_list):
             "lrmsd_std",
             "dockq",
             "dockq_std",
+            "rmsd",
+            "rmsd_std",
             "caprieval_rank",
         ],
         [
@@ -750,6 +759,8 @@ def test_capri_cluster_analysis(protprot_caprimodule, protprot_input_list):
             "0.000",
             "nan",
             "nan",
+            "0.010",
+            "0.000",
             "2",
         ],
         [
@@ -766,6 +777,8 @@ def test_capri_cluster_analysis(protprot_caprimodule, protprot_input_list):
             "0.000",
             "nan",
             "nan",
+            "0.010",
+            "0.000",
             "1",
         ],
     ]

--- a/tests/test_module_caprieval.py
+++ b/tests/test_module_caprieval.py
@@ -1019,6 +1019,7 @@ def test_extract_data_from_capri_class(mocker):
     random_lrmsd = random.random()
     random_ilrmsd = random.random()
     random_dockq = random.random()
+    random_rmsd = random.random()
 
     c.model = random_model
     c.model.clt_id = random_clt_id
@@ -1031,6 +1032,7 @@ def test_extract_data_from_capri_class(mocker):
     c.lrmsd = random_lrmsd
     c.ilrmsd = random_ilrmsd
     c.dockq = random_dockq
+    c.rmsd = random_rmsd
 
     observed_data = extract_data_from_capri_class(
         capri_objects=[c], sort_key="score", sort_ascending=True, output_fname=Path("")
@@ -1046,6 +1048,7 @@ def test_extract_data_from_capri_class(mocker):
     assert observed_data[1]["lrmsd"] == random_lrmsd
     assert observed_data[1]["ilrmsd"] == random_ilrmsd
     assert observed_data[1]["dockq"] == random_dockq
+    assert observed_data[1]["rmsd"] == random_rmsd
     assert observed_data[1]["energy"] == random_energy
     assert observed_data[1]["cluster_id"] == random_clt_id
     assert observed_data[1]["cluster_ranking"] == random_clt_rank


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and that you comply with the following criteria:

- [ ] You have sticked to Python. Please talk to us before adding other programming languages to HADDOCK3
- [ ] Your PR is about CNS
- [ ] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [ ] You structured the code into small functions as much as possible. You can use classes if there is a (state) purpose
- [ ] Your code follows our coding style
- [ ] You wrote tests for the new code
- [ ] `tox` tests pass. *Run `tox` command inside the repository folder*
- [ ] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [ ] PR does not add any dependencies, unless permission granted by the HADDOCK team
- [ ] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---

Closes #989 by adding a new parameter `global_rmsd` in `[caprieval]`, where the full structure RMSD is now computed, regardless of any reference/ligands chains.
Still a sequence alignment is performed.

Additionally, few modifications were made on the uni/integration tests for code optimization and readability.
