### PR TITLE
make sure `hbond` restraints are read under a separate class

### DIFF
--- a/integration_tests/golden_data/ambig.tbl
+++ b/integration_tests/golden_data/ambig.tbl
@@ -1,0 +1,386 @@
+! ambig restraints set
+!
+assign ( resid 38  and segid A)
+       (
+        ( resid 15  and segid B)
+     or
+        ( resid 16  and segid B)
+     or
+        ( resid 17  and segid B)
+     or
+        ( resid 20  and segid B)
+     or
+        ( resid 48  and segid B)
+     or
+        ( resid 51  and segid B)
+     or
+        ( resid 52  and segid B)
+     or
+        ( resid 54  and segid B)
+     or
+        ( resid 56  and segid B)
+     or
+        ( resid 12  and segid B)
+     or
+        ( resid 21  and segid B)
+     or
+        ( resid 24  and segid B)
+     or
+        ( resid 47  and segid B)
+     or
+        ( resid 49  and segid B)
+     or
+        ( resid 57  and segid B)
+     or
+        ( resid 85  and segid B)
+       )  2.0 2.0 0.0
+!
+assign ( resid 40  and segid A)
+       (
+        ( resid 15  and segid B)
+     or
+        ( resid 16  and segid B)
+     or
+        ( resid 17  and segid B)
+     or
+        ( resid 20  and segid B)
+     or
+        ( resid 48  and segid B)
+     or
+        ( resid 51  and segid B)
+     or
+        ( resid 52  and segid B)
+     or
+        ( resid 54  and segid B)
+     or
+        ( resid 56  and segid B)
+     or
+        ( resid 12  and segid B)
+     or
+        ( resid 21  and segid B)
+     or
+        ( resid 24  and segid B)
+     or
+        ( resid 47  and segid B)
+     or
+        ( resid 49  and segid B)
+     or
+        ( resid 57  and segid B)
+     or
+        ( resid 85  and segid B)
+       )  2.0 2.0 0.0
+!
+assign ( resid 45  and segid A)
+       (
+        ( resid 15  and segid B)
+     or
+        ( resid 16  and segid B)
+     or
+        ( resid 17  and segid B)
+     or
+        ( resid 20  and segid B)
+     or
+        ( resid 48  and segid B)
+     or
+        ( resid 51  and segid B)
+     or
+        ( resid 52  and segid B)
+     or
+        ( resid 54  and segid B)
+     or
+        ( resid 56  and segid B)
+     or
+        ( resid 12  and segid B)
+     or
+        ( resid 21  and segid B)
+     or
+        ( resid 24  and segid B)
+     or
+        ( resid 47  and segid B)
+     or
+        ( resid 49  and segid B)
+     or
+        ( resid 57  and segid B)
+     or
+        ( resid 85  and segid B)
+       )  2.0 2.0 0.0
+!
+assign ( resid 46  and segid A)
+       (
+        ( resid 15  and segid B)
+     or
+        ( resid 16  and segid B)
+     or
+        ( resid 17  and segid B)
+     or
+        ( resid 20  and segid B)
+     or
+        ( resid 48  and segid B)
+     or
+        ( resid 51  and segid B)
+     or
+        ( resid 52  and segid B)
+     or
+        ( resid 54  and segid B)
+     or
+        ( resid 56  and segid B)
+     or
+        ( resid 12  and segid B)
+     or
+        ( resid 21  and segid B)
+     or
+        ( resid 24  and segid B)
+     or
+        ( resid 47  and segid B)
+     or
+        ( resid 49  and segid B)
+     or
+        ( resid 57  and segid B)
+     or
+        ( resid 85  and segid B)
+       )  2.0 2.0 0.0
+!
+assign ( resid 69  and segid A)
+       (
+        ( resid 15  and segid B)
+     or
+        ( resid 16  and segid B)
+     or
+        ( resid 17  and segid B)
+     or
+        ( resid 20  and segid B)
+     or
+        ( resid 48  and segid B)
+     or
+        ( resid 51  and segid B)
+     or
+        ( resid 52  and segid B)
+     or
+        ( resid 54  and segid B)
+     or
+        ( resid 56  and segid B)
+     or
+        ( resid 12  and segid B)
+     or
+        ( resid 21  and segid B)
+     or
+        ( resid 24  and segid B)
+     or
+        ( resid 47  and segid B)
+     or
+        ( resid 49  and segid B)
+     or
+        ( resid 57  and segid B)
+     or
+        ( resid 85  and segid B)
+       )  2.0 2.0 0.0
+!
+assign ( resid 71  and segid A)
+       (
+        ( resid 15  and segid B)
+     or
+        ( resid 16  and segid B)
+     or
+        ( resid 17  and segid B)
+     or
+        ( resid 20  and segid B)
+     or
+        ( resid 48  and segid B)
+     or
+        ( resid 51  and segid B)
+     or
+        ( resid 52  and segid B)
+     or
+        ( resid 54  and segid B)
+     or
+        ( resid 56  and segid B)
+     or
+        ( resid 12  and segid B)
+     or
+        ( resid 21  and segid B)
+     or
+        ( resid 24  and segid B)
+     or
+        ( resid 47  and segid B)
+     or
+        ( resid 49  and segid B)
+     or
+        ( resid 57  and segid B)
+     or
+        ( resid 85  and segid B)
+       )  2.0 2.0 0.0
+!
+assign ( resid 78  and segid A)
+       (
+        ( resid 15  and segid B)
+     or
+        ( resid 16  and segid B)
+     or
+        ( resid 17  and segid B)
+     or
+        ( resid 20  and segid B)
+     or
+        ( resid 48  and segid B)
+     or
+        ( resid 51  and segid B)
+     or
+        ( resid 52  and segid B)
+     or
+        ( resid 54  and segid B)
+     or
+        ( resid 56  and segid B)
+     or
+        ( resid 12  and segid B)
+     or
+        ( resid 21  and segid B)
+     or
+        ( resid 24  and segid B)
+     or
+        ( resid 47  and segid B)
+     or
+        ( resid 49  and segid B)
+     or
+        ( resid 57  and segid B)
+     or
+        ( resid 85  and segid B)
+       )  2.0 2.0 0.0
+!
+assign ( resid 80  and segid A)
+       (
+        ( resid 15  and segid B)
+     or
+        ( resid 16  and segid B)
+     or
+        ( resid 17  and segid B)
+     or
+        ( resid 20  and segid B)
+     or
+        ( resid 48  and segid B)
+     or
+        ( resid 51  and segid B)
+     or
+        ( resid 52  and segid B)
+     or
+        ( resid 54  and segid B)
+     or
+        ( resid 56  and segid B)
+     or
+        ( resid 12  and segid B)
+     or
+        ( resid 21  and segid B)
+     or
+        ( resid 24  and segid B)
+     or
+        ( resid 47  and segid B)
+     or
+        ( resid 49  and segid B)
+     or
+        ( resid 57  and segid B)
+     or
+        ( resid 85  and segid B)
+       )  2.0 2.0 0.0
+!
+assign ( resid 94  and segid A)
+       (
+        ( resid 15  and segid B)
+     or
+        ( resid 16  and segid B)
+     or
+        ( resid 17  and segid B)
+     or
+        ( resid 20  and segid B)
+     or
+        ( resid 48  and segid B)
+     or
+        ( resid 51  and segid B)
+     or
+        ( resid 52  and segid B)
+     or
+        ( resid 54  and segid B)
+     or
+        ( resid 56  and segid B)
+     or
+        ( resid 12  and segid B)
+     or
+        ( resid 21  and segid B)
+     or
+        ( resid 24  and segid B)
+     or
+        ( resid 47  and segid B)
+     or
+        ( resid 49  and segid B)
+     or
+        ( resid 57  and segid B)
+     or
+        ( resid 85  and segid B)
+       )  2.0 2.0 0.0
+!
+assign ( resid 96  and segid A)
+       (
+        ( resid 15  and segid B)
+     or
+        ( resid 16  and segid B)
+     or
+        ( resid 17  and segid B)
+     or
+        ( resid 20  and segid B)
+     or
+        ( resid 48  and segid B)
+     or
+        ( resid 51  and segid B)
+     or
+        ( resid 52  and segid B)
+     or
+        ( resid 54  and segid B)
+     or
+        ( resid 56  and segid B)
+     or
+        ( resid 12  and segid B)
+     or
+        ( resid 21  and segid B)
+     or
+        ( resid 24  and segid B)
+     or
+        ( resid 47  and segid B)
+     or
+        ( resid 49  and segid B)
+     or
+        ( resid 57  and segid B)
+     or
+        ( resid 85  and segid B)
+       )  2.0 2.0 0.0
+!
+assign ( resid 141  and segid A)
+       (
+        ( resid 15  and segid B)
+     or
+        ( resid 16  and segid B)
+     or
+        ( resid 17  and segid B)
+     or
+        ( resid 20  and segid B)
+     or
+        ( resid 48  and segid B)
+     or
+        ( resid 51  and segid B)
+     or
+        ( resid 52  and segid B)
+     or
+        ( resid 54  and segid B)
+     or
+        ( resid 56  and segid B)
+     or
+        ( resid 12  and segid B)
+     or
+        ( resid 21  and segid B)
+     or
+        ( resid 24  and segid B)
+     or
+        ( resid 47  and segid B)
+     or
+        ( resid 49  and segid B)
+     or
+        ( resid 57  and segid B)
+     or
+        ( resid 85  and segid B)
+       )  2.0 2.0 0.0

--- a/integration_tests/golden_data/hbond.tbl
+++ b/integration_tests/golden_data/hbond.tbl
@@ -1,0 +1,124 @@
+! hbond restraint set
+!
+assign ( resid 52  and segid B)
+       (
+        ( resid 38  and segid A)
+     or
+        ( resid 40  and segid A)
+     or
+        ( resid 45  and segid A)
+     or
+        ( resid 46  and segid A)
+     or
+        ( resid 69  and segid A)
+     or
+        ( resid 71  and segid A)
+     or
+        ( resid 78  and segid A)
+     or
+        ( resid 80  and segid A)
+     or
+        ( resid 94  and segid A)
+     or
+        ( resid 96  and segid A)
+     or
+        ( resid 141  and segid A)
+     or
+        ( resid 37  and segid A)
+     or
+        ( resid 39  and segid A)
+     or
+        ( resid 43  and segid A)
+     or
+        ( resid 68  and segid A)
+     or
+        ( resid 72  and segid A)
+     or
+        ( resid 97  and segid A)
+     or
+        ( resid 109  and segid A)
+     or
+        ( resid 132  and segid A)
+       )  2.0 2.0 0.0
+!
+assign ( resid 54  and segid B)
+       (
+        ( resid 38  and segid A)
+     or
+        ( resid 40  and segid A)
+     or
+        ( resid 45  and segid A)
+     or
+        ( resid 46  and segid A)
+     or
+        ( resid 69  and segid A)
+     or
+        ( resid 71  and segid A)
+     or
+        ( resid 78  and segid A)
+     or
+        ( resid 80  and segid A)
+     or
+        ( resid 94  and segid A)
+     or
+        ( resid 96  and segid A)
+     or
+        ( resid 141  and segid A)
+     or
+        ( resid 37  and segid A)
+     or
+        ( resid 39  and segid A)
+     or
+        ( resid 43  and segid A)
+     or
+        ( resid 68  and segid A)
+     or
+        ( resid 72  and segid A)
+     or
+        ( resid 97  and segid A)
+     or
+        ( resid 109  and segid A)
+     or
+        ( resid 132  and segid A)
+       )  2.0 2.0 0.0
+!
+assign ( resid 56  and segid B)
+       (
+        ( resid 38  and segid A)
+     or
+        ( resid 40  and segid A)
+     or
+        ( resid 45  and segid A)
+     or
+        ( resid 46  and segid A)
+     or
+        ( resid 69  and segid A)
+     or
+        ( resid 71  and segid A)
+     or
+        ( resid 78  and segid A)
+     or
+        ( resid 80  and segid A)
+     or
+        ( resid 94  and segid A)
+     or
+        ( resid 96  and segid A)
+     or
+        ( resid 141  and segid A)
+     or
+        ( resid 37  and segid A)
+     or
+        ( resid 39  and segid A)
+     or
+        ( resid 43  and segid A)
+     or
+        ( resid 68  and segid A)
+     or
+        ( resid 72  and segid A)
+     or
+        ( resid 97  and segid A)
+     or
+        ( resid 109  and segid A)
+     or
+        ( resid 132  and segid A)
+       )  2.0 2.0 0.0

--- a/integration_tests/golden_data/unambig.tbl
+++ b/integration_tests/golden_data/unambig.tbl
@@ -1,0 +1,248 @@
+!
+! unambig restraint set
+!
+assign ( resid 15  and segid B)
+       (
+        ( resid 38  and segid A)
+     or
+        ( resid 40  and segid A)
+     or
+        ( resid 45  and segid A)
+     or
+        ( resid 46  and segid A)
+     or
+        ( resid 69  and segid A)
+     or
+        ( resid 71  and segid A)
+     or
+        ( resid 78  and segid A)
+     or
+        ( resid 80  and segid A)
+     or
+        ( resid 94  and segid A)
+     or
+        ( resid 96  and segid A)
+     or
+        ( resid 141  and segid A)
+     or
+        ( resid 37  and segid A)
+     or
+        ( resid 39  and segid A)
+     or
+        ( resid 43  and segid A)
+     or
+        ( resid 68  and segid A)
+     or
+        ( resid 72  and segid A)
+     or
+        ( resid 97  and segid A)
+     or
+        ( resid 109  and segid A)
+     or
+        ( resid 132  and segid A)
+       )  2.0 2.0 0.0
+!
+assign ( resid 16  and segid B)
+       (
+        ( resid 38  and segid A)
+     or
+        ( resid 40  and segid A)
+     or
+        ( resid 45  and segid A)
+     or
+        ( resid 46  and segid A)
+     or
+        ( resid 69  and segid A)
+     or
+        ( resid 71  and segid A)
+     or
+        ( resid 78  and segid A)
+     or
+        ( resid 80  and segid A)
+     or
+        ( resid 94  and segid A)
+     or
+        ( resid 96  and segid A)
+     or
+        ( resid 141  and segid A)
+     or
+        ( resid 37  and segid A)
+     or
+        ( resid 39  and segid A)
+     or
+        ( resid 43  and segid A)
+     or
+        ( resid 68  and segid A)
+     or
+        ( resid 72  and segid A)
+     or
+        ( resid 97  and segid A)
+     or
+        ( resid 109  and segid A)
+     or
+        ( resid 132  and segid A)
+       )  2.0 2.0 0.0
+!
+assign ( resid 17  and segid B)
+       (
+        ( resid 38  and segid A)
+     or
+        ( resid 40  and segid A)
+     or
+        ( resid 45  and segid A)
+     or
+        ( resid 46  and segid A)
+     or
+        ( resid 69  and segid A)
+     or
+        ( resid 71  and segid A)
+     or
+        ( resid 78  and segid A)
+     or
+        ( resid 80  and segid A)
+     or
+        ( resid 94  and segid A)
+     or
+        ( resid 96  and segid A)
+     or
+        ( resid 141  and segid A)
+     or
+        ( resid 37  and segid A)
+     or
+        ( resid 39  and segid A)
+     or
+        ( resid 43  and segid A)
+     or
+        ( resid 68  and segid A)
+     or
+        ( resid 72  and segid A)
+     or
+        ( resid 97  and segid A)
+     or
+        ( resid 109  and segid A)
+     or
+        ( resid 132  and segid A)
+       )  2.0 2.0 0.0
+!
+assign ( resid 20  and segid B)
+       (
+        ( resid 38  and segid A)
+     or
+        ( resid 40  and segid A)
+     or
+        ( resid 45  and segid A)
+     or
+        ( resid 46  and segid A)
+     or
+        ( resid 69  and segid A)
+     or
+        ( resid 71  and segid A)
+     or
+        ( resid 78  and segid A)
+     or
+        ( resid 80  and segid A)
+     or
+        ( resid 94  and segid A)
+     or
+        ( resid 96  and segid A)
+     or
+        ( resid 141  and segid A)
+     or
+        ( resid 37  and segid A)
+     or
+        ( resid 39  and segid A)
+     or
+        ( resid 43  and segid A)
+     or
+        ( resid 68  and segid A)
+     or
+        ( resid 72  and segid A)
+     or
+        ( resid 97  and segid A)
+     or
+        ( resid 109  and segid A)
+     or
+        ( resid 132  and segid A)
+       )  2.0 2.0 0.0
+!
+assign ( resid 48  and segid B)
+       (
+        ( resid 38  and segid A)
+     or
+        ( resid 40  and segid A)
+     or
+        ( resid 45  and segid A)
+     or
+        ( resid 46  and segid A)
+     or
+        ( resid 69  and segid A)
+     or
+        ( resid 71  and segid A)
+     or
+        ( resid 78  and segid A)
+     or
+        ( resid 80  and segid A)
+     or
+        ( resid 94  and segid A)
+     or
+        ( resid 96  and segid A)
+     or
+        ( resid 141  and segid A)
+     or
+        ( resid 37  and segid A)
+     or
+        ( resid 39  and segid A)
+     or
+        ( resid 43  and segid A)
+     or
+        ( resid 68  and segid A)
+     or
+        ( resid 72  and segid A)
+     or
+        ( resid 97  and segid A)
+     or
+        ( resid 109  and segid A)
+     or
+        ( resid 132  and segid A)
+       )  2.0 2.0 0.0
+!
+assign ( resid 51  and segid B)
+       (
+        ( resid 38  and segid A)
+     or
+        ( resid 40  and segid A)
+     or
+        ( resid 45  and segid A)
+     or
+        ( resid 46  and segid A)
+     or
+        ( resid 69  and segid A)
+     or
+        ( resid 71  and segid A)
+     or
+        ( resid 78  and segid A)
+     or
+        ( resid 80  and segid A)
+     or
+        ( resid 94  and segid A)
+     or
+        ( resid 96  and segid A)
+     or
+        ( resid 141  and segid A)
+     or
+        ( resid 37  and segid A)
+     or
+        ( resid 39  and segid A)
+     or
+        ( resid 43  and segid A)
+     or
+        ( resid 68  and segid A)
+     or
+        ( resid 72  and segid A)
+     or
+        ( resid 97  and segid A)
+     or
+        ( resid 109  and segid A)
+     or
+        ( resid 132  and segid A)
+       )  2.0 2.0 0.0

--- a/integration_tests/test_restraints.py
+++ b/integration_tests/test_restraints.py
@@ -59,7 +59,7 @@ class MockPreviousIO:
                 ),
                 PDBFile(
                     file_name="hpr_ensemble_1_haddock.pdb",
-                    path=".",
+                    path=self.path,
                     topology=[
                         Persistent(
                             file_name="hpr_ensemble_1_haddock.psf",

--- a/integration_tests/test_restraints.py
+++ b/integration_tests/test_restraints.py
@@ -52,7 +52,7 @@ class MockPreviousIO:
                     topology=[
                         Persistent(
                             file_name="e2aP_1F3G_haddock.psf",
-                            path=".",
+                            path=self.path,
                             file_type=Format.TOPOLOGY,
                         )
                     ],

--- a/integration_tests/test_restraints.py
+++ b/integration_tests/test_restraints.py
@@ -38,7 +38,7 @@ class MockPreviousIO:
         )
         shutil.copy(
             Path(golden_data, "hpr_ensemble_1_haddock.pdb"),
-            Path(".", "hpr_ensemble_1_haddock.pdb"),
+            Path(self.path, "hpr_ensemble_1_haddock.pdb"),
         )
         shutil.copy(
             Path(golden_data, "hpr_ensemble_1_haddock.psf"),

--- a/integration_tests/test_restraints.py
+++ b/integration_tests/test_restraints.py
@@ -48,7 +48,7 @@ class MockPreviousIO:
             [
                 PDBFile(
                     file_name="e2aP_1F3G_haddock.pdb",
-                    path=".",
+                    path=self.path,
                     topology=[
                         Persistent(
                             file_name="e2aP_1F3G_haddock.psf",

--- a/integration_tests/test_restraints.py
+++ b/integration_tests/test_restraints.py
@@ -90,13 +90,13 @@ def test_restraints_rigidbody(rigidbody_module):
 
     rigidbody_module.run()
 
-    assert Path(rigidbody_module.path, f'{"rigidbody_1.pdb"}').exists()
-    assert Path(rigidbody_module.path, f'{"rigidbody_1.out.gz"}').exists()
-    assert Path(rigidbody_module.path, f'{"rigidbody_1.inp"}').exists()
+    assert Path(rigidbody_module.path, "rigidbody_1.pdb").exists()
+    assert Path(rigidbody_module.path, "rigidbody_1.out.gz").exists()
+    assert Path(rigidbody_module.path, "rigidbody_1.inp").exists()
 
-    assert Path(rigidbody_module.path, f'{"rigidbody_1.pdb"}').stat().st_size > 0
-    assert Path(rigidbody_module.path, f'{"rigidbody_1.out.gz"}').stat().st_size > 0
-    assert Path(rigidbody_module.path, f'{"rigidbody_1.inp"}').stat().st_size > 0
+    assert Path(rigidbody_module.path, "rigidbody_1.pdb").stat().st_size > 0
+    assert Path(rigidbody_module.path, "rigidbody_1.out.gz").stat().st_size > 0
+    assert Path(rigidbody_module.path, "rigidbody_1.inp").stat().st_size > 0
 
     file_content = gzip.open(Path(rigidbody_module.path, "rigidbody_1.out.gz"), 'rt').read()
     assert 'NOEPRI: RMS diff. class AMBI' in file_content

--- a/integration_tests/test_restraints.py
+++ b/integration_tests/test_restraints.py
@@ -1,0 +1,105 @@
+import shutil
+import tempfile
+import gzip
+from pathlib import Path
+
+import pytest
+
+from haddock.libs.libontology import Format, PDBFile, Persistent
+from haddock.modules.sampling.rigidbody import (
+    DEFAULT_CONFIG as DEFAULT_RIGIDBODY_CONFIG,
+)
+from haddock.modules.sampling.rigidbody import HaddockModule as RigidbodyModule
+from tests import golden_data
+from integration_tests import golden_data as GOLDEN_DATA
+
+
+@pytest.fixture
+def rigidbody_module():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        rigidbody = RigidbodyModule(
+            order=0, path=Path(tmpdir), initial_params=DEFAULT_RIGIDBODY_CONFIG
+        )
+        yield rigidbody
+
+
+class MockPreviousIO:
+    def __init__(self, path):
+        self.path = path
+
+    def retrieve_models(self, crossdock: bool = False):
+        shutil.copy(
+            Path(golden_data, "e2aP_1F3G_haddock.pdb"),
+            Path(".", "e2aP_1F3G_haddock.pdb"),
+        )
+        shutil.copy(
+            Path(golden_data, "e2aP_1F3G_haddock.psf"),
+            Path(".", "e2aP_1F3G_haddock.psf"),
+        )
+        shutil.copy(
+            Path(golden_data, "hpr_ensemble_1_haddock.pdb"),
+            Path(".", "hpr_ensemble_1_haddock.pdb"),
+        )
+        shutil.copy(
+            Path(golden_data, "hpr_ensemble_1_haddock.psf"),
+            Path(".", "hpr_ensemble_1_haddock.psf"),
+        )
+        model_list = [
+            [
+                PDBFile(
+                    file_name="e2aP_1F3G_haddock.pdb",
+                    path=".",
+                    topology=[
+                        Persistent(
+                            file_name="e2aP_1F3G_haddock.psf",
+                            path=".",
+                            file_type=Format.TOPOLOGY,
+                        )
+                    ],
+                ),
+                PDBFile(
+                    file_name="hpr_ensemble_1_haddock.pdb",
+                    path=".",
+                    topology=[
+                        Persistent(
+                            file_name="hpr_ensemble_1_haddock.psf",
+                            path=".",
+                            file_type=Format.TOPOLOGY,
+                        )
+                    ],
+                ),
+            ]
+        ]
+
+        return model_list
+
+    def output(self):
+        return None
+
+
+def test_restraints_rigidbody(rigidbody_module):
+
+    rigidbody_module.previous_io = MockPreviousIO(path=rigidbody_module.path)
+    rigidbody_module.params["sampling"] = 1
+    rigidbody_module.params["mol_fix_origin_1"] = False
+    rigidbody_module.params["mol_fix_origin_2"] = False
+    rigidbody_module.params["ambig_fname"] = Path(GOLDEN_DATA, "ambig.tbl")
+    rigidbody_module.params["unambig_fname"] = Path(GOLDEN_DATA, "unambig.tbl")
+    rigidbody_module.params["hbond_fname"] = Path(GOLDEN_DATA, "hbond.tbl")
+    rigidbody_module.params["mode"] = "local"
+    
+    rigidbody_module.run()
+
+    assert Path(rigidbody_module.path, f"rigidbody_1.pdb").exists()
+    assert Path(rigidbody_module.path, f"rigidbody_1.out.gz").exists()
+    assert Path(rigidbody_module.path, f"rigidbody_1.inp").exists()
+
+    assert Path(rigidbody_module.path, f"rigidbody_1.pdb").stat().st_size > 0
+    assert Path(rigidbody_module.path, f"rigidbody_1.out.gz").stat().st_size > 0
+    assert Path(rigidbody_module.path, f"rigidbody_1.inp").stat().st_size > 0
+
+    file_content = gzip.open(Path(rigidbody_module.path, "rigidbody_1.out.gz"), 'rt').read()
+    assert 'NOEPRI: RMS diff. class AMBI' in file_content
+    assert 'NOEPRI: RMS diff. class DIST' in file_content
+    assert 'NOEPRI: RMS diff. class HBON' in file_content
+

--- a/integration_tests/test_restraints.py
+++ b/integration_tests/test_restraints.py
@@ -87,16 +87,16 @@ def test_restraints_rigidbody(rigidbody_module):
     rigidbody_module.params["unambig_fname"] = Path(GOLDEN_DATA, "unambig.tbl")
     rigidbody_module.params["hbond_fname"] = Path(GOLDEN_DATA, "hbond.tbl")
     rigidbody_module.params["mode"] = "local"
-    
+
     rigidbody_module.run()
 
-    assert Path(rigidbody_module.path, f"rigidbody_1.pdb").exists()
-    assert Path(rigidbody_module.path, f"rigidbody_1.out.gz").exists()
-    assert Path(rigidbody_module.path, f"rigidbody_1.inp").exists()
+    assert Path(rigidbody_module.path, f'{"rigidbody_1.pdb"}').exists()
+    assert Path(rigidbody_module.path, f'{"rigidbody_1.out.gz"}').exists()
+    assert Path(rigidbody_module.path, f'{"rigidbody_1.inp"}').exists()
 
-    assert Path(rigidbody_module.path, f"rigidbody_1.pdb").stat().st_size > 0
-    assert Path(rigidbody_module.path, f"rigidbody_1.out.gz").stat().st_size > 0
-    assert Path(rigidbody_module.path, f"rigidbody_1.inp").stat().st_size > 0
+    assert Path(rigidbody_module.path, f'{"rigidbody_1.pdb"}').stat().st_size > 0
+    assert Path(rigidbody_module.path, f'{"rigidbody_1.out.gz"}').stat().st_size > 0
+    assert Path(rigidbody_module.path, f'{"rigidbody_1.inp"}').stat().st_size > 0
 
     file_content = gzip.open(Path(rigidbody_module.path, "rigidbody_1.out.gz"), 'rt').read()
     assert 'NOEPRI: RMS diff. class AMBI' in file_content

--- a/integration_tests/test_restraints.py
+++ b/integration_tests/test_restraints.py
@@ -63,7 +63,7 @@ class MockPreviousIO:
                     topology=[
                         Persistent(
                             file_name="hpr_ensemble_1_haddock.psf",
-                            path=".",
+                            path=self.path,
                             file_type=Format.TOPOLOGY,
                         )
                     ],

--- a/integration_tests/test_restraints.py
+++ b/integration_tests/test_restraints.py
@@ -42,7 +42,7 @@ class MockPreviousIO:
         )
         shutil.copy(
             Path(golden_data, "hpr_ensemble_1_haddock.psf"),
-            Path(".", "hpr_ensemble_1_haddock.psf"),
+            Path(self.path, "hpr_ensemble_1_haddock.psf"),
         )
         model_list = [
             [

--- a/integration_tests/test_restraints.py
+++ b/integration_tests/test_restraints.py
@@ -34,7 +34,7 @@ class MockPreviousIO:
         )
         shutil.copy(
             Path(golden_data, "e2aP_1F3G_haddock.psf"),
-            Path(".", "e2aP_1F3G_haddock.psf"),
+            Path(self.path, "e2aP_1F3G_haddock.psf"),
         )
         shutil.copy(
             Path(golden_data, "hpr_ensemble_1_haddock.pdb"),

--- a/src/haddock/modules/refinement/emref/cns/emref.cns
+++ b/src/haddock/modules/refinement/emref/cns/emref.cns
@@ -198,7 +198,6 @@ noe
     msoexponent * 1
     masymptote  * -0.1
     mrswitch    * 0.5
-    avexpo hbond 20
 end
 
 {* set the energy flags ======================================================== *}

--- a/src/haddock/modules/refinement/emref/cns/read_data.cns
+++ b/src/haddock/modules/refinement/emref/cns/read_data.cns
@@ -44,7 +44,7 @@ end if
 if ($hbond_fname # "") then
     fileexist $hbond_fname end
     if ($result eq true) then
-        noe @@$hbond_fname end
+        noe class hbon @@$hbond_fname end
     end if
 end if
 
@@ -61,7 +61,6 @@ noe
     msoexponent * 1
     masymptote  * -0.1
     mrswitch    * 1.0
-    avexpo hbond 20
 end
 
 

--- a/src/haddock/modules/refinement/emref/cns/read_noes.cns
+++ b/src/haddock/modules/refinement/emref/cns/read_noes.cns
@@ -45,7 +45,7 @@ end if
 if ($hbond_fname # "") then
     fileexist $hbond_fname end
     if ($result eq true) then
-        noe @@$hbond_fname end
+        noe class hbon @@$hbond_fname end
     end if
 end if
 
@@ -62,5 +62,4 @@ noe
     msoexponent * 1
     masymptote  * -0.1
     mrswitch    * 1.0
-    avexpo hbond 20
 end

--- a/src/haddock/modules/refinement/flexref/cns/read_data.cns
+++ b/src/haddock/modules/refinement/flexref/cns/read_data.cns
@@ -44,7 +44,7 @@ end if
 if ($hbond_fname # "") then
     fileexist $hbond_fname end
     if ($result eq true) then
-        noe @@$hbond_fname end
+        noe class hbon @@$hbond_fname end
     end if
 end if
 
@@ -61,7 +61,6 @@ noe
     msoexponent * 1
     masymptote  * -0.1
     mrswitch    * 1.0
-    avexpo hbond 20
 end
 
 

--- a/src/haddock/modules/refinement/flexref/cns/read_noes.cns
+++ b/src/haddock/modules/refinement/flexref/cns/read_noes.cns
@@ -45,7 +45,7 @@ end if
 if ($hbond_fname # "") then
     fileexist $hbond_fname end
     if ($result eq true) then
-        noe @@$hbond_fname end
+        noe class hbon @@$hbond_fname end
     end if
 end if
 
@@ -62,5 +62,4 @@ noe
     msoexponent * 1
     masymptote  * -0.1
     mrswitch    * 1.0
-    avexpo hbond 20
 end

--- a/src/haddock/modules/refinement/mdref/cns/mdref.cns
+++ b/src/haddock/modules/refinement/mdref/cns/mdref.cns
@@ -227,7 +227,6 @@ noe
     msoexponent * 1
     masymptote  * -0.1
     mrswitch    * 0.5
-    avexpo hbond 20
 end
 
 {* set the energy flags ======================================================== *}

--- a/src/haddock/modules/refinement/mdref/cns/read_data.cns
+++ b/src/haddock/modules/refinement/mdref/cns/read_data.cns
@@ -44,7 +44,7 @@ end if
 if ($hbond_fname # "") then
     fileexist $hbond_fname end
     if ($result eq true) then
-        noe @@$hbond_fname end
+        noe class hbon @@$hbond_fname end
     end if
 end if
 
@@ -61,7 +61,6 @@ noe
     msoexponent * 1
     masymptote  * -0.1
     mrswitch    * 1.0
-    avexpo hbond 20
 end
 
 

--- a/src/haddock/modules/refinement/mdref/cns/read_noes.cns
+++ b/src/haddock/modules/refinement/mdref/cns/read_noes.cns
@@ -45,7 +45,7 @@ end if
 if ($hbond_fname # "") then
     fileexist $hbond_fname end
     if ($result eq true) then
-        noe @@$hbond_fname end
+        noe class hbon @@$hbond_fname end
     end if
 end if
 
@@ -62,5 +62,4 @@ noe
     msoexponent * 1
     masymptote  * -0.1
     mrswitch    * 1.0
-    avexpo hbond 20
 end

--- a/src/haddock/modules/sampling/rigidbody/cns/read_noes.cns
+++ b/src/haddock/modules/sampling/rigidbody/cns/read_noes.cns
@@ -45,7 +45,7 @@ end if
 if ($hbond_fname # "") then
     fileexist $hbond_fname end
     if ($result eq true) then
-        noe @@$hbond_fname end
+        noe class hbon @@$hbond_fname end
     end if
 end if
 
@@ -62,5 +62,4 @@ noe
     msoexponent * 1
     masymptote  * -0.1
     mrswitch    * 1.0
-    avexpo hbond 20
 end

--- a/src/haddock/modules/sampling/rigidbody/cns/rigidbody.cns
+++ b/src/haddock/modules/sampling/rigidbody/cns/rigidbody.cns
@@ -559,7 +559,7 @@ evaluate ($hbond_scale = $Data.hbond_scale)
 noe
     scale dist $unambig_scale
     scale ambi $ambig_scale
-    scale hbon 0.0
+    scale hbon $hbond_scale
     scale cont 0.0
 end
 


### PR DESCRIPTION
You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md) and that you comply with the following criteria:

- [ ] You have sticked to Python. Please talk to us before adding other programming languages to HADDOCK3
- [X] Your PR is about CNS
- [ ] Your code is well documented: proper docstrings and explanatory comments for those tricky parts
- [ ] You structured the code into small functions as much as possible. You can use classes if there is a (state) purpose
- [X] Your code follows our coding style
- [X] You wrote tests for the new code
- [X] `purest` tests pass. *Run `pytest` command inside the repository folder*
- [ ] `-test.cfg` examples execute without errors. *Inside `examples/` run `python run_tests.py -b`*
- [X] PR does not add any dependencies, unless permission granted by the HADDOCK team
- [X] PR does not break licensing
- [ ] Your PR is about writing documentation for already existing code :fire:
- [ ] Your PR is about writing tests for already existing code :godmode:

---

hbond restraints provide a separate class of restraints that can be used as various stages with their own force constants.  In the current code these were read under the `dist` class if unambiguous restraints were read and otherwise in the `ambig` class, meaning they would be subjected to random removal.

This pull request corrects this behaviour by changing the relevant CNS scripts to make sure hbond restraints are read under a separate `hbon` class.

As hbonds restraints can be used for any type of distance restraints in principle, their contribution is now also added to the distance restraint energy of HADDOCK.

An integration test was added in which the three types of restraints are read in the rigidbody module and the resulting output checked for the presence of those classes.