### PR TITLE
Automatically reduce the tadfactor to 4 when fully flexible segments are defined

### DIFF
--- a/src/haddock/modules/refinement/flexref/cns/flexref.cns
+++ b/src/haddock/modules/refinement/flexref/cns/flexref.cns
@@ -366,6 +366,10 @@ if ($failure eq false) then
 
     {* Stage 1 ======================================= rigid body high temperature search*}
 
+    if ($nfle > 0) then
+        ! reduce timestep in case of fully flexible segments
+        evaluate ($SaProtocol.tadfactor = 4)
+    end if
     if ($SaProtocol.initiosteps > 0) then
         inline @MODULE:flex_segment.cns
         @MODULE:torsiontop.cns

--- a/src/haddock/modules/refinement/flexref/cns/flexref.cns
+++ b/src/haddock/modules/refinement/flexref/cns/flexref.cns
@@ -385,7 +385,10 @@ if ($failure eq false) then
             @MODULE:torsiontop.cns
             eval ($torsiondone = true)
         end if
-        evaluate ($SaProtocol.tadfactor = 4)
+        if ($nfle > 0) then
+            ! reduce timestep in case of fully flexible segments
+            evaluate ($SaProtocol.tadfactor = min(4,$SaProtocol.tadfactor))
+        end if
         @MODULE:sa_ltad_cool1.cns
     end if
 

--- a/src/haddock/modules/refinement/flexref/cns/flexref.cns
+++ b/src/haddock/modules/refinement/flexref/cns/flexref.cns
@@ -368,7 +368,7 @@ if ($failure eq false) then
 
     if ($nfle > 0) then
         ! reduce timestep in case of fully flexible segments
-        evaluate ($SaProtocol.tadfactor = 4)
+        evaluate ($SaProtocol.tadfactor = min(4,$SaProtocol.tadfactor))
     end if
     if ($SaProtocol.initiosteps > 0) then
         inline @MODULE:flex_segment.cns


### PR DESCRIPTION
- [ ] Tests added for the new code
- [ ] Documentation added for the code changes
- [X] Does not break licensing
- [X] Does not add any dependencies, if it does please add a thorough explanation

## Summary of the Pull Request  

Solves issue #1000.
In the `flexref` module, the tad factor defining the time step for an MD integrations step is now automatically reduced from the default of 8 to 4 for the high temperature initial stage of the simulated annealing protocol. This will reduce possible job failures (models crashing) in the flexref module.

Integration test will be added once the `integration-tests` branch is merged.