### PR TITLE
Refactor `tempfile` usage in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
       fail-fast: false
 
     steps:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,125 @@
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Any, Generator
+
+import pytest
+
+from haddock.libs.libontology import PDBFile
+
+from . import golden_data
+
+
+@pytest.fixture(name="protprot_input_list")
+def fixture_protprot_input_list():
+    """Prot-prot input."""
+
+    with (
+        tempfile.NamedTemporaryFile(delete=False, suffix=".pdb") as tmp_1,
+        tempfile.NamedTemporaryFile(delete=False, suffix=".pdb") as tmp_2,
+    ):
+        dst_prot_1 = tmp_1.name
+        dst_prot_2 = tmp_2.name
+
+        src_prot_1 = Path(golden_data, "protprot_complex_1.pdb")
+        src_prot_2 = Path(golden_data, "protprot_complex_2.pdb")
+
+        shutil.copy(src_prot_1, dst_prot_1)
+        shutil.copy(src_prot_2, dst_prot_2)
+
+        pdb_obj_1 = PDBFile(file_name=dst_prot_1, path=Path(dst_prot_1).parent)
+        pdb_obj_2 = PDBFile(file_name=dst_prot_2, path=Path(dst_prot_2).parent)
+
+        yield [pdb_obj_1, pdb_obj_2]
+
+
+@pytest.fixture(name="protprot_1bkd_input_list")
+def fixture_protprot_1bkd_input_list():
+    """
+    Prot-prot input for target 1bkd.
+
+    Heterogeneous ensemble and big protein.
+    """
+    with (
+        tempfile.NamedTemporaryFile(delete=False, suffix=".pdb") as tmp_1,
+        tempfile.NamedTemporaryFile(delete=False, suffix=".pdb") as tmp_2,
+    ):
+        dst_prot_1 = tmp_1.name
+        dst_prot_2 = tmp_2.name
+
+        src_prot_1 = Path(golden_data, "protprot_1bkd_1.pdb")
+        src_prot_2 = Path(golden_data, "protprot_1bkd_2.pdb")
+
+        shutil.copy(src_prot_1, dst_prot_1)
+        shutil.copy(src_prot_2, dst_prot_2)
+
+        pdb_obj_1 = PDBFile(file_name=dst_prot_1, path=Path(dst_prot_1).parent)
+        pdb_obj_2 = PDBFile(file_name=dst_prot_2, path=Path(dst_prot_2).parent)
+
+        yield [pdb_obj_1, pdb_obj_2]
+
+
+@pytest.fixture(name="protdna_input_list")
+def fixture_protdna_input_list():
+    """Prot-DNA input."""
+    with (
+        tempfile.NamedTemporaryFile(delete=False, suffix=".pdb") as tmp_1,
+        tempfile.NamedTemporaryFile(delete=False, suffix=".pdb") as tmp_2,
+    ):
+        dst_prot_1 = tmp_1.name
+        dst_prot_2 = tmp_2.name
+
+        src_prot_1 = Path(golden_data, "protdna_complex_1.pdb")
+        src_prot_2 = Path(golden_data, "protdna_complex_2.pdb")
+
+        shutil.copy(src_prot_1, dst_prot_1)
+        shutil.copy(src_prot_2, dst_prot_2)
+
+        pdb_obj_1 = PDBFile(file_name=dst_prot_1, path=Path(dst_prot_1).parent)
+        pdb_obj_2 = PDBFile(file_name=dst_prot_2, path=Path(dst_prot_2).parent)
+
+        yield [pdb_obj_1, pdb_obj_2]
+
+
+@pytest.fixture(name="protlig_input_list")
+def fixture_protlig_input_list():
+    """Protein-Ligand input."""
+    with (
+        tempfile.NamedTemporaryFile(delete=False, suffix=".pdb") as tmp_1,
+        tempfile.NamedTemporaryFile(delete=False, suffix=".pdb") as tmp_2,
+    ):
+        dst_prot_1 = tmp_1.name
+        dst_prot_2 = tmp_2.name
+
+        src_prot_1 = Path(golden_data, "protlig_complex_1.pdb")
+        src_prot_2 = Path(golden_data, "protlig_complex_2.pdb")
+
+        shutil.copy(src_prot_1, dst_prot_1)
+        shutil.copy(src_prot_2, dst_prot_2)
+
+        pdb_obj_1 = PDBFile(file_name=dst_prot_1, path=Path(dst_prot_1).parent)
+        pdb_obj_2 = PDBFile(file_name=dst_prot_2, path=Path(dst_prot_2).parent)
+
+        yield [pdb_obj_1, pdb_obj_2]
+
+
+@pytest.fixture(name="protprot_onechain_list")
+def fixture_protprot_onechain_list() -> Generator[list[PDBFile], Any, Any]:
+    """Protein-Protein complex with a single chain ID."""
+    with (
+        tempfile.NamedTemporaryFile(delete=False, suffix=".pdb") as tmp_1,
+        tempfile.NamedTemporaryFile(delete=False, suffix=".pdb") as tmp_2,
+    ):
+        dst_prot_1 = tmp_1.name
+        dst_prot_2 = tmp_2.name
+
+        src_prot_1 = Path(golden_data, "protprot_complex_1.pdb")
+        src_prot_2 = Path(golden_data, "protprot_onechain.pdb")
+
+        shutil.copy(src_prot_1, dst_prot_1)
+        shutil.copy(src_prot_2, dst_prot_2)
+
+        pdb_obj_1 = PDBFile(file_name=dst_prot_1, path=Path(dst_prot_1).parent)
+        pdb_obj_2 = PDBFile(file_name=dst_prot_2, path=Path(dst_prot_2).parent)
+
+        yield [pdb_obj_1, pdb_obj_2]

--- a/tests/test_cli_restraints.py
+++ b/tests/test_cli_restraints.py
@@ -1,23 +1,34 @@
 """Test the haddock3-restraints CLI."""
-from pathlib import Path
-import pytest
-import tempfile
+
 import logging
+import tempfile
+from pathlib import Path
+
+import pytest
 
 from haddock.clis.restraints.active_passive_to_ambig import (
     actpass_to_ambig,
     parse_actpass_file,
     )
-from haddock.clis.restraints.validate_tbl import validate_tbl
+from haddock.clis.restraints.calc_accessibility import (
+    REL_ASA,
+    calc_accessibility,
+    )
 from haddock.clis.restraints.passive_from_active import passive_from_active
 from haddock.clis.restraints.restrain_bodies import restrain_bodies
-from haddock.clis.restraints.calc_accessibility import (
-    calc_accessibility,
-    REL_ASA,
-    )
+from haddock.clis.restraints.validate_tbl import validate_tbl
+from haddock.libs.libontology import PDBFile
 
 from . import golden_data
-from tests.test_module_caprieval import protdna_input_list  # noqa : F401
+
+
+@pytest.fixture
+def protdna_input_list():
+    """Prot-DNA input."""
+    return [
+        PDBFile(Path(golden_data, "protdna_complex_1.pdb"), path=golden_data),
+        PDBFile(Path(golden_data, "protdna_complex_2.pdb"), path=golden_data),
+    ]
 
 
 @pytest.fixture
@@ -54,7 +65,7 @@ def test_actpass_to_ambig(capsys):
         tmp.write(b"1\n2")
         # close it
         tmp.flush()
-        
+
         # capture stdout and stderr
         actpass_to_ambig(tmp.name, tmp.name, "A", "B")
         captured = capsys.readouterr()
@@ -87,10 +98,7 @@ def test_validate_tbl_error(example_tbl_file, capsys):
         for ln in lines[3:]:
             tmp.write(ln.encode())
         tmp.flush()
-        with pytest.raises(
-                Exception,
-                match=r"Invalid TBL file: Unknown statement *"
-                ):
+        with pytest.raises(Exception, match=r"Invalid TBL file: Unknown statement *"):
             validate_tbl(tmp.name, pcs=False, quick=True, silent=True)
 
 
@@ -107,7 +115,10 @@ def test_restrain_bodies(protdna_input_list, capsys):  # noqa : F811
     restrain_bodies(protdna_input_list[0].rel_path)
     captured = capsys.readouterr()
     out_lines = captured.out.split("\n")
-    assert out_lines[0] == "assign (segid A and resi 10 and name CA) (segid B and resi 7 and name P) 26.542 0.0 0.0"  # noqa : E501
+    assert (
+        out_lines[0]
+        == "assign (segid A and resi 10 and name CA) (segid B and resi 7 and name P) 26.542 0.0 0.0"
+    )  # noqa : E501
 
 
 def test_restrain_bodies_empty(example_pdb_file, capsys):
@@ -122,7 +133,10 @@ def test_restrain_bodies_exclude(protdna_input_list, capsys):  # noqa : F811
     restrain_bodies(protdna_input_list[0].rel_path, exclude="A")
     captured = capsys.readouterr()
     out_lines = captured.out.split("\n")
-    assert out_lines[0] == "assign (segid B and resi 6 and name P) (segid B and resi 35 and name P) 15.187 0.0 0.0"  # noqa : E501
+    assert (
+        out_lines[0]
+        == "assign (segid B and resi 6 and name P) (segid B and resi 35 and name P) 15.187 0.0 0.0"
+    )  # noqa : E501
 
 
 def test_calc_accessibility_rel_asa_data():
@@ -136,11 +150,18 @@ def test_calc_accessibility(protdna_input_list, caplog):  # noqa : F811
     """Test calc_accessibility function."""
     caplog.set_level(logging.INFO)
     calc_accessibility(str(protdna_input_list[0].rel_path))
-    assert caplog.messages[-2].endswith("Chain A - -1,0,1,7,8,11,12,13,14,16,18,19,22,23,25,27,36,37,38,40,41,43,46,47,50,53,55,57,61")  # noqa : E501
-    assert caplog.messages[-1].endswith("Chain B - 2,3,4,5,6,7,8,9,10,11,28,29,30,31,32,33,34,35,36,37,38")  # noqa : E501
+    assert caplog.messages[-2].endswith(
+        "Chain A - -1,0,1,7,8,11,12,13,14,16,18,19,22,23,25,27,36,37,38,40,41,43,46,47,50,53,55,57,61"
+    )  # noqa : E501
+    assert caplog.messages[-1].endswith(
+        "Chain B - 2,3,4,5,6,7,8,9,10,11,28,29,30,31,32,33,34,35,36,37,38"
+    )  # noqa : E501
     # now let's change the cutoff
     caplog.clear()
     calc_accessibility(str(protdna_input_list[0].rel_path), cutoff=0.9)
     assert caplog.messages[-2].endswith("Chain A - 14,25,53")
     # DNA accessibility does not change with a higher cutoff!
-    assert caplog.messages[-1].endswith("Chain B - 2,3,4,5,6,7,8,9,10,11,28,29,30,31,32,33,34,35,36,37,38")  # noqa : E501
+    assert caplog.messages[-1].endswith(
+        "Chain B - 2,3,4,5,6,7,8,9,10,11,28,29,30,31,32,33,34,35,36,37,38"
+    )  # noqa : E501
+

--- a/tests/test_gear_haddockmodel.py
+++ b/tests/test_gear_haddockmodel.py
@@ -1,10 +1,35 @@
 """Test HaddockModel gear."""
-from haddock.gear.haddockmodel import HaddockModel
 
-from tests.test_module_caprieval import (
-    protprot_input_list,
-    protprot_1bkd_input_list
-    )
+from pathlib import Path
+
+import pytest
+
+from haddock.gear.haddockmodel import HaddockModel
+from haddock.libs.libontology import PDBFile
+
+from . import golden_data
+
+
+@pytest.fixture
+def protprot_input_list():
+    """Prot-prot input."""
+    return [
+        PDBFile(Path(golden_data, "protprot_complex_1.pdb"), path=golden_data),
+        PDBFile(Path(golden_data, "protprot_complex_2.pdb"), path=golden_data),
+    ]
+
+
+@pytest.fixture
+def protprot_1bkd_input_list():
+    """
+    Prot-prot input for target 1bkd.
+
+    Heterogeneous ensemble and big protein.
+    """
+    return [
+        PDBFile(Path(golden_data, "protprot_1bkd_1.pdb"), path=golden_data),
+        PDBFile(Path(golden_data, "protprot_1bkd_2.pdb"), path=golden_data),
+    ]
 
 
 def test_haddockmodel_energies(protprot_input_list):
@@ -13,25 +38,25 @@ def test_haddockmodel_energies(protprot_input_list):
     assert isinstance(haddock_mod.energies, dict)
 
     exp_energies = {
-        'vdw': 1.85709,
-        'elec': -9.41558,
-        'desolv': 3.25569,
-        'air': 482.494,
-        'coup': 0.0,
-        'sym': 0.0,
-        'rdcs': 0.0,
-        'vean': 0.0,
-        'dani': 0.0,
-        'xpcs': 0.0,
-        'rg': 0.0,
-        'bsa': 846.821,
-        'total': 474.936,
-        'bonds': 0.0,
-        'angles': 0.0,
-        'improper': 0.0,
-        'dihe': 0.0,
-        'cdih': 0.0
-        }
+        "vdw": 1.85709,
+        "elec": -9.41558,
+        "desolv": 3.25569,
+        "air": 482.494,
+        "coup": 0.0,
+        "sym": 0.0,
+        "rdcs": 0.0,
+        "vean": 0.0,
+        "dani": 0.0,
+        "xpcs": 0.0,
+        "rg": 0.0,
+        "bsa": 846.821,
+        "total": 474.936,
+        "bonds": 0.0,
+        "angles": 0.0,
+        "improper": 0.0,
+        "dihe": 0.0,
+        "cdih": 0.0,
+    }
 
     assert haddock_mod.energies == exp_energies
 
@@ -47,14 +72,14 @@ def test_haddockmodel_score(protprot_input_list):
     haddock_mod = HaddockModel(protprot_input_list[1].rel_path)
 
     weights = {
-        'w_vdw': 1.0,
-        'w_elec': 1.0,
-        'w_desolv': 1.0,
-        'w_air': 1.0,
-        }
+        "w_vdw": 1.0,
+        "w_elec": 1.0,
+        "w_desolv": 1.0,
+        "w_air": 1.0,
+    }
 
     assert haddock_mod.calc_haddock_score(**weights) == 84.9855
-    
+
     weights["w_air"] = 0.1
     weights["w_bsa"] = -0.01
 

--- a/tests/test_module_alascan.py
+++ b/tests/test_module_alascan.py
@@ -1,20 +1,17 @@
 """Test the Alascan module."""
+
 import os
+import shutil
+import tempfile
 from pathlib import Path
 
 import numpy as np
 import pandas as pd
 import pytest
-import pytest_mock
-import tempfile
-import shutil
-from subprocess import CompletedProcess
-
-from haddock.modules.analysis.alascan import HaddockModule as AlascanModule
-from haddock.modules.analysis.alascan import DEFAULT_CONFIG
-from .test_module_caprieval import protprot_input_list
 
 from haddock.libs.libontology import PDBFile
+from haddock.modules.analysis.alascan import DEFAULT_CONFIG
+from haddock.modules.analysis.alascan import HaddockModule as AlascanModule
 from haddock.modules.analysis.alascan.scan import (
     Scan,
     ScanJob,
@@ -24,64 +21,80 @@ from haddock.modules.analysis.alascan.scan import (
     calc_score,
     create_alascan_plots,
     generate_alascan_output,
-    mutate
-)
+    mutate,
+    )
 
 from . import golden_data
 
 
-@pytest.fixture
-def complex_pdb():
+@pytest.fixture(name="protprot_input_list")
+def fixture_protprot_input_list():
+    """Prot-prot input."""
+    return [
+        PDBFile(Path(golden_data, "protprot_complex_1.pdb"), path=golden_data),
+        PDBFile(Path(golden_data, "protprot_complex_2.pdb"), path=golden_data),
+    ]
+
+
+@pytest.fixture(name="complex_pdb")
+def fixture_complex_pdb():
     """Return example complex pdb."""
     return Path(golden_data, "protprot_complex_1.pdb")
 
 
-@pytest.fixture
-def protprot_model_list(complex_pdb):
+@pytest.fixture(name="protprot_model_list")
+def fixture_protprot_model_list(complex_pdb):
     """Prot-prot input."""
     return [
         PDBFile(file_name=complex_pdb, path=str(golden_data)),
     ]
 
 
-@pytest.fixture
-def params():
-    return {"int_cutoff": 3.0, "plot": False, "scan_residue": "ALA", "resdic_A": [19, 20]}
+@pytest.fixture(name="params")
+def fixture_params():
+    """Parameter fixture to be used in the tests"""
+    return {
+        "int_cutoff": 3.0,
+        "plot": False,
+        "scan_residue": "ALA",
+        "resdic_A": [19, 20],
+    }
 
 
-@pytest.fixture
-def scan_obj(protprot_model_list, params):
+@pytest.fixture(name="scan_obj")
+def fixture_scan_obj(protprot_model_list, params):
     """Return example alascan module."""
-    with tempfile.TemporaryDirectory(dir=".") as tmpdir:
-        scan_obj = Scan(
+    with tempfile.TemporaryDirectory() as tmpdir:
+        os.chdir(tmpdir)
+        yield Scan(
             model_list=protprot_model_list,
             output_name="alascan",
-            path=Path(tmpdir),
+            path=Path("."),
             core=0,
             params=params,
         )
 
-        yield scan_obj
 
-
-@pytest.fixture
-def scanjob_obj(scan_obj):
+@pytest.fixture(name="scanjob_obj")
+def fixture_scanjob_obj(scan_obj, params):
     """Return example alascan module."""
-    with tempfile.TemporaryDirectory(dir=".") as tmpdir:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        os.chdir(tmpdir)
         yield ScanJob(
-        scan_obj=scan_obj,
-        output=Path(tmpdir),
-        params=params,
+            scan_obj=scan_obj,
+            output=Path("."),
+            params=params,
         )
 
 
-@pytest.fixture
-def alascan():
+@pytest.fixture(name="alascan")
+def fixture_alascan():
     """Return alascan module."""
-    with tempfile.TemporaryDirectory(dir=".") as tmpdir:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        os.chdir(tmpdir)
         yield AlascanModule(
             order=1,
-            path=Path(tmpdir),
+            path=Path("."),
             initial_params=DEFAULT_CONFIG,
         )
 
@@ -172,10 +185,10 @@ def example_df_scan_clt():
     yield example_df_scan_clt
 
 
-@pytest.fixture
-def scan_file():
+@pytest.fixture(name="scan_file")
+def fixture_scan_file():
     """Return example alascan file."""
-    yield(Path(golden_data, "scan_protprot_complex_1.csv"))
+    yield Path(golden_data, "scan_protprot_complex_1.csv")
 
 
 def test_scan_obj(scan_obj, protprot_model_list):
@@ -186,17 +199,16 @@ def test_scan_obj(scan_obj, protprot_model_list):
 
 def test_mutate(protprot_model_list):
     """Test the mutate function."""
-    with tempfile.TemporaryDirectory(dir=".") as tmpdir:
+    with tempfile.TemporaryDirectory() as tmpdir:
         mut_fname = Path(golden_data, protprot_model_list[0].file_name)
         os.chdir(path=tmpdir)
         mut_pdb_fname = mutate(mut_fname, "A", 19, "ALA")
-        
+
         assert mut_pdb_fname == Path("protprot_complex_1-A_T19A.pdb")
         assert os.path.exists(mut_pdb_fname)
 
         first_line = open(mut_pdb_fname).readline()
         assert first_line[17:20] == "ALA"
-   
 
         with pytest.raises(KeyError):
             mutate(mut_fname, "A", 19, "HOH")
@@ -204,7 +216,7 @@ def test_mutate(protprot_model_list):
 
 def test_add_delta_to_bfactor(protprot_model_list, example_df_scan):
     """Test the add_delta_to_bfactor function."""
-    with tempfile.TemporaryDirectory(dir=".") as tmpdir:
+    with tempfile.TemporaryDirectory() as tmpdir:
         mut_fname = Path(golden_data, protprot_model_list[0].file_name)
         os.chdir(path=tmpdir)
         mut_pdb_fname = mutate(mut_fname, "A", 19, "ALA")
@@ -247,12 +259,14 @@ def test_run(
     Path(alascan.path, "alascan_0.scan").touch()
     ala_path = Path(golden_data, "scan_protprot_complex_1.csv")
     shutil.copy(ala_path, Path(alascan.path, "scan_protprot_complex_1.csv"))
-    
+
     alascan.params["plot"] = True
 
     alascan.previous_io = MockPreviousIO()
-    mocker.patch("haddock.libs.libparallel.Scheduler.run", return_value = None)
-    mocker.patch("haddock.modules.BaseHaddockModule.export_io_models", return_value = None)
+    mocker.patch("haddock.libs.libparallel.Scheduler.run", return_value=None)
+    mocker.patch(
+        "haddock.modules.BaseHaddockModule.export_io_models", return_value=None
+    )
 
     alascan.run()
     assert Path(alascan.path, "scan_clt_-.csv").exists()
@@ -263,16 +277,17 @@ def test_run(
 
 
 def test_scanjob_run(scanjob_obj, mocker):
-    mocker.patch("haddock.modules.analysis.alascan.scan.Scan.run", return_value = None)
-    mocker.patch("haddock.modules.analysis.alascan.scan.Scan.output", return_value = None)
+    mocker.patch("haddock.modules.analysis.alascan.scan.Scan.run", return_value=None)
+    mocker.patch("haddock.modules.analysis.alascan.scan.Scan.output", return_value=None)
     scanjob_obj.run()
 
 
-def test_scan_run_output(
-    mocker,
-    scan_obj):
+def test_scan_run_output(mocker, scan_obj):
     """Test Scan run and output method."""
-    mocker.patch("haddock.modules.analysis.alascan.scan.calc_score", return_value = (-106.7, -29, -316, -13, 1494))
+    mocker.patch(
+        "haddock.modules.analysis.alascan.scan.calc_score",
+        return_value=(-106.7, -29, -316, -13, 1494),
+    )
     scan_obj.run()
     assert Path(scan_obj.path, "scan_protprot_complex_1.csv").exists()
     assert scan_obj.df_scan.shape[0] == 2
@@ -283,50 +298,51 @@ def test_scan_run_output(
 
 def test_scan_run_interface(mocker, scan_obj):
     """Test Scan run with empty filter_resdic."""
-    scan_obj.filter_resdic = {'_': []}
+    scan_obj.filter_resdic = {"_": []}
     scan_obj.scan_res = "ASP"
-    mocker.patch("haddock.modules.analysis.alascan.scan.calc_score", return_value = (-106.7, -29, -316, -13, 1494))
+    mocker.patch(
+        "haddock.modules.analysis.alascan.scan.calc_score",
+        return_value=(-106.7, -29, -316, -13, 1494),
+    )
     scan_obj.run()
 
     assert Path(scan_obj.path, "scan_protprot_complex_1.csv").exists()
     assert scan_obj.df_scan.shape[0] == 5
-    
+
 
 def test_calc_score(mocker):
     """Test the run_scan method."""
     mocker.patch(
         "haddock.modules.analysis.alascan.scan.get_score_string",
-        return_value = [
-        "> starting calculations...",
-        "> HADDOCK-score = (1.0 * vdw) + (0.2 * elec) + (1.0 * desolv) + (0.0 * air) + (0.0 * bsa)",
-        "> HADDOCK-score (emscoring) = -106.7376",
-        "> vdw=-29.5808,elec=-316.542,desolv=-13.8484,air=0.0,bsa=1494.73",
-        ]
+        return_value=[
+            "> starting calculations...",
+            "> HADDOCK-score = (1.0 * vdw) + (0.2 * elec) + (1.0 * desolv) + (0.0 * air) + (0.0 * bsa)",
+            "> HADDOCK-score (emscoring) = -106.7376",
+            "> vdw=-29.5808,elec=-316.542,desolv=-13.8484,air=0.0,bsa=1494.73",
+        ],
     )
     # sub with tmpdir
-    scores = calc_score(Path(golden_data, "protprot_complex_1.pdb"), run_dir = "tmp")
-    
+    scores = calc_score(Path(golden_data, "protprot_complex_1.pdb"), run_dir="tmp")
+
     assert scores == (-106.7376, -29.5808, -316.542, -13.8484, 1494.73)
+
 
 def test_calc_score_wrong(mocker):
     mocker.patch(
         "haddock.modules.analysis.alascan.scan.get_score_string",
-        return_value = ['> could not calculate score']
+        return_value=["> could not calculate score"],
     )
     # now calc_score should raise an Exception
     with pytest.raises(Exception):
-        calc_score(Path(golden_data, "protprot_complex_1.pdb"), run_dir = "tmp")
+        calc_score(Path(golden_data, "protprot_complex_1.pdb"), run_dir="tmp")
 
 
 def test_generate_alascan_output(mocker, protprot_model_list, scan_file):
     """Test the generate_alascan_output method."""
-    with tempfile.TemporaryDirectory(dir=".") as tmpdir:
+    with tempfile.TemporaryDirectory() as tmpdir:
         shutil.copy(scan_file, Path(tmpdir, "scan_protprot_complex_1.csv"))
         os.chdir(tmpdir)
-        models_to_export = generate_alascan_output(
-            protprot_model_list,
-            path=tmpdir
-            )
+        models_to_export = generate_alascan_output(protprot_model_list, path=tmpdir)
         assert len(models_to_export) == 1
         assert models_to_export[0].ori_name == "protprot_complex_1.pdb"
         assert models_to_export[0].file_name == "protprot_complex_1_alascan.pdb"
@@ -334,12 +350,13 @@ def test_generate_alascan_output(mocker, protprot_model_list, scan_file):
 
 class MockPreviousIO:
     """Mock PreviousIO class."""
+
     # In the mocked method, add the arguments that are called by the original method
     #  that is being tested
     def retrieve_models(self, individualize: bool = False):
         return [
             PDBFile(file_name="protprot_complex_1.pdb", path=str(golden_data)),
-            ]
+        ]
 
 
 def mock_alascan_cluster_analysis():
@@ -354,17 +371,17 @@ def mock_alascan_cluster_analysis():
                 "delta_desolv": 0.0,
                 "delta_bsa": 0.0,
                 "frac_pr": 0.0,
-                }
-            },
-        }
+            }
+        },
+    }
 
 
 def test_alascan_cluster_analysis(protprot_input_list, scan_file):
     """Test alascan_cluster_analysis."""
-    with tempfile.TemporaryDirectory(dir=".") as tmpdir:
-        shutil.copy(scan_file, Path(tmpdir, "scan_protprot_complex_1.csv"))
-        shutil.copy(scan_file, Path(tmpdir, "scan_protprot_complex_2.csv"))
+    with tempfile.TemporaryDirectory() as tmpdir:
         os.chdir(tmpdir)
+        shutil.copy(scan_file, Path("scan_protprot_complex_1.csv"))
+        shutil.copy(scan_file, Path("scan_protprot_complex_2.csv"))
         alascan_cluster_analysis(protprot_input_list)
 
         assert Path("scan_clt_-.csv").exists()
@@ -378,7 +395,6 @@ def test_alascan_cluster_analysis(protprot_input_list, scan_file):
 
 def test_create_alascan_plots(mocker, caplog):
     """Test create_alascan_plots."""
-    os.remove("scan_clt_-.csv")
     mocker.patch("pandas.read_csv", return_value=pd.DataFrame())
     create_alascan_plots({"-": []}, scan_residue="ALA")
 

--- a/tests/test_module_caprieval.py
+++ b/tests/test_module_caprieval.py
@@ -20,7 +20,7 @@ from haddock.modules.analysis.caprieval.capri import (
     load_contacts,
     rank_according_to_score,
     rearrange_ss_capri_output,
-)
+    )
 
 from . import golden_data
 
@@ -38,60 +38,16 @@ def remove_aln_files(class_name):
 
 
 def read_capri_file(fname):
+    """???"""
     file_content = [
         e.split()[1:] for e in open(fname).readlines() if not e.startswith("#")
     ]
     return file_content
 
 
-@pytest.fixture
-def protprot_input_list():
-    """Prot-prot input."""
-    return [
-        PDBFile(Path(golden_data, "protprot_complex_1.pdb"), path=golden_data),
-        PDBFile(Path(golden_data, "protprot_complex_2.pdb"), path=golden_data),
-    ]
-
-
-@pytest.fixture
-def protprot_1bkd_input_list():
-    """
-    Prot-prot input for target 1bkd.
-
-    Heterogeneous ensemble and big protein.
-    """
-    return [
-        PDBFile(Path(golden_data, "protprot_1bkd_1.pdb"), path=golden_data),
-        PDBFile(Path(golden_data, "protprot_1bkd_2.pdb"), path=golden_data),
-    ]
-
-
-@pytest.fixture
-def protdna_input_list():
-    """Prot-DNA input."""
-    return [
-        PDBFile(Path(golden_data, "protdna_complex_1.pdb"), path=golden_data),
-        PDBFile(Path(golden_data, "protdna_complex_2.pdb"), path=golden_data),
-    ]
-
-
-@pytest.fixture
-def protlig_input_list():
-    """Protein-Ligand input."""
-    return [
-        PDBFile(Path(golden_data, "protlig_complex_1.pdb"), path=golden_data),
-        PDBFile(Path(golden_data, "protlig_complex_2.pdb"), path=golden_data),
-    ]
-
-
-@pytest.fixture
-def protprot_onechain_list():
-    """Protein-Protein complex with a single chain ID."""
-    return [PDBFile(Path(golden_data, "protprot_onechain.pdb"), path=golden_data)]
-
-
-@pytest.fixture
-def params():
+@pytest.fixture(name="params")
+def fixture_params():
+    """???"""
     return {
         "receptor_chain": "A",
         "ligand_chains": ["B"],
@@ -100,8 +56,9 @@ def params():
     }
 
 
-@pytest.fixture
-def params_all():
+@pytest.fixture(name="params_all")
+def fixture_params_all():
+    """???"""
     return {
         "receptor_chain": "A",
         "ligand_chains": ["B"],
@@ -110,16 +67,17 @@ def params_all():
     }
 
 
-@pytest.fixture
-def protdna_caprimodule(protdna_input_list, params):
+@pytest.fixture(name="protdna_caprimodule")
+def fixture_protdna_caprimodule(protdna_input_list, params):
     """Protein-DNA CAPRI module."""
-    reference = protdna_input_list[0].rel_path
-    model = protdna_input_list[1].rel_path
+    reference = protdna_input_list[0]
+    model = protdna_input_list[1]
+    _path = protdna_input_list[0].path
     capri = CAPRI(
         identificator=str(42),
         reference=reference,
         model=model,
-        path=golden_data,
+        path=_path,
         params=params,
     )
 
@@ -128,16 +86,17 @@ def protdna_caprimodule(protdna_input_list, params):
     remove_aln_files(capri)
 
 
-@pytest.fixture
-def protlig_caprimodule(protlig_input_list, params):
+@pytest.fixture(name="protlig_caprimodule")
+def fixture_protlig_caprimodule(protlig_input_list, params):
     """Protein-Ligand CAPRI module."""
-    reference = protlig_input_list[0].rel_path
-    model = protlig_input_list[1].rel_path
+    reference = protlig_input_list[0]
+    model = protlig_input_list[1]
+    _path = protlig_input_list[0].path
     capri = CAPRI(
         identificator=str(42),
         reference=reference,
         model=model,
-        path=golden_data,
+        path=_path,
         params=params,
     )
 
@@ -146,16 +105,17 @@ def protlig_caprimodule(protlig_input_list, params):
     remove_aln_files(capri)
 
 
-@pytest.fixture
-def protprot_caprimodule(protprot_input_list, params):
+@pytest.fixture(name="protprot_caprimodule")
+def fixture_protprot_caprimodule(protprot_input_list, params):
     """Protein-Protein CAPRI module."""
-    reference = protprot_input_list[0].rel_path
+    reference = protprot_input_list[0]
     model = protprot_input_list[1]
+    _path = protprot_input_list[0].path
     capri = CAPRI(
         identificator=str(42),
         reference=reference,
         model=model,
-        path=golden_data,
+        path=_path,
         params=params,
     )
 
@@ -164,16 +124,17 @@ def protprot_caprimodule(protprot_input_list, params):
     remove_aln_files(capri)
 
 
-@pytest.fixture
-def protprot_allatm_caprimodule(protprot_input_list, params_all):
+@pytest.fixture(name="protprot_allatm_caprimodule")
+def fixture_protprot_allatm_caprimodule(protprot_input_list, params_all):
     """Protein-Protein CAPRI module."""
-    reference = protprot_input_list[0].rel_path
+    reference = protprot_input_list[0]
     model = protprot_input_list[1]
+    _path = protprot_input_list[0].path
     capri = CAPRI(
         identificator=str(42),
         reference=reference,
         model=model,
-        path=golden_data,
+        path=_path,
         params=params_all,
     )
 
@@ -182,16 +143,58 @@ def protprot_allatm_caprimodule(protprot_input_list, params_all):
     remove_aln_files(capri)
 
 
-@pytest.fixture
-def protprot_1bkd_caprimodule(protprot_1bkd_input_list, params):
+@pytest.fixture(name="protprot_1bkd_caprimodule")
+def fixture_protprot_1bkd_caprimodule(protprot_1bkd_input_list, params):
     """Protein-Protein CAPRI module for target 1BKD."""
-    reference = protprot_1bkd_input_list[0].rel_path
+    reference = protprot_1bkd_input_list[0]
     model = protprot_1bkd_input_list[1]
+    _path = protprot_1bkd_input_list[0].path
     capri = CAPRI(
         identificator=str(42),
         reference=reference,
         model=model,
-        path=golden_data,
+        path=_path,
+        params=params,
+    )
+
+    yield capri
+
+    remove_aln_files(capri)
+
+
+@pytest.fixture(name="protprot_onechain_ref_caprimodule")
+def fixture_protprot_onechain_ref_caprimodule(protprot_onechain_list, params):
+    """Protein-Protein CAPRI module with a single chain structure as ref."""
+
+    # reference, model = protprot_onechain_list
+    model, reference = protprot_onechain_list
+    _path = reference.path
+
+    capri = CAPRI(
+        identificator=str(42),
+        reference=reference,
+        model=model,
+        path=_path,
+        params=params,
+    )
+
+    yield capri
+
+    remove_aln_files(capri)
+
+
+@pytest.fixture(name="protprot_onechain_mod_caprimodule")
+def fixture_protprot_onechain_mod_caprimodule(protprot_onechain_list, params):
+    """Protein-Protein CAPRI module with a single chain structure as model."""
+
+    reference, model = protprot_onechain_list
+    _path = reference.path
+
+    capri = CAPRI(
+        identificator=str(42),
+        reference=reference,
+        model=model,
+        path=_path,
         params=params,
     )
 
@@ -449,8 +452,7 @@ def test_make_output(protprot_caprimodule):
     protprot_caprimodule.make_output()
 
     ss_fname = Path(
-        protprot_caprimodule.path,
-        f"capri_ss_{protprot_caprimodule.identificator}.tsv"
+        protprot_caprimodule.path, f"capri_ss_{protprot_caprimodule.identificator}.tsv"
     )
     # Check that the file contains something
     assert ss_fname.stat().st_size != 0
@@ -475,8 +477,19 @@ def test_make_output(protprot_caprimodule):
             "something",
         ],
         [
-            "-", "-", "nan", "nan", "nan", "nan", "nan", "nan",
-            "nan", "1", "1", "10", "0.000",
+            "-",
+            "-",
+            "nan",
+            "nan",
+            "nan",
+            "nan",
+            "nan",
+            "nan",
+            "nan",
+            "1",
+            "1",
+            "10",
+            "0.000",
         ],
     ]
 
@@ -597,26 +610,27 @@ def test_add_chain_from_segid(protprot_caprimodule):
 
 def test_rearrange_ss_capri_output():
     """Test rearranging the capri output."""
-    with open(f"{golden_data}/capri_ss_1.tsv", "w") as fh:
-        fh.write(
-            "model	caprieval_rank	score	irmsd	fnat	lrmsd	ilrmsd	"
-            "dockq	cluster_id	cluster_ranking	"
-            "model-cluster_ranking" + os.linesep
+    with tempfile.TemporaryDirectory() as tempdir:
+        os.chdir(tempdir)
+        with open("capri_ss_1.tsv", "w", encoding="utf-8") as fh:
+            fh.write(
+                "model	caprieval_rank	score	irmsd	fnat	lrmsd	ilrmsd	"
+                "dockq	cluster_id	cluster_ranking	"
+                "model-cluster_ranking" + os.linesep
+            )
+            fh.write(
+                "../1_emscoring/emscoring_909.pdb	1	-424.751	0.000	"
+                "1.000	0.000	0.000	1.000	-	-	-" + os.linesep
+            )
+        rearrange_ss_capri_output(
+            "capri_ss.txt",
+            output_count=1,
+            sort_key="score",
+            sort_ascending=True,
+            path=Path("."),
         )
-        fh.write(
-            "../1_emscoring/emscoring_909.pdb	1	-424.751	0.000	"
-            "1.000	0.000	0.000	1.000	-	-	-" + os.linesep
-        )
-    rearrange_ss_capri_output(
-        "capri_ss.txt",
-        output_count=1,
-        sort_key="score",
-        sort_ascending=True,
-        path=golden_data,
-    )
 
-    assert Path("capri_ss.txt").stat().st_size != 0
-    Path("capri_ss.txt").unlink()
+        assert Path("capri_ss.txt").stat().st_size != 0
 
 
 def test_calc_stats():
@@ -636,194 +650,154 @@ def test_capri_cluster_analysis(protprot_caprimodule, protprot_input_list):
     protprot_caprimodule.fnat = 1.0
     protprot_caprimodule.lrmsd = 1.2
     protprot_caprimodule.ilrmsd = 4.3
-    protprot_caprimodule.rmsd = 0.01,
-    capri_cluster_analysis(
-        capri_list=[protprot_caprimodule, protprot_caprimodule],
-        model_list=[model1, model2],
-        output_fname="capri_clt.txt",
-        clt_threshold=5,
-        sort_key="score",
-        sort_ascending=True,
-        path=Path("."),
-    )
+    protprot_caprimodule.rmsd = (0.01,)
+    with tempfile.TemporaryDirectory() as tempdir:
+        os.chdir(tempdir)
+        capri_cluster_analysis(
+            capri_list=[protprot_caprimodule, protprot_caprimodule],
+            model_list=[model1, model2],
+            output_fname="capri_clt.txt",
+            clt_threshold=5,
+            sort_key="score",
+            sort_ascending=True,
+            path=Path("."),
+        )
 
-    assert Path("capri_clt.txt").stat().st_size != 0
+        assert Path("capri_clt.txt").stat().st_size != 0
 
-    observed_outf_l = read_capri_file("capri_clt.txt")
-    expected_outf_l = [
-        [
-            "cluster_id",
-            "n",
-            "under_eval",
-            "score",
-            "score_std",
-            "irmsd",
-            "irmsd_std",
-            "fnat",
-            "fnat_std",
-            "lrmsd",
-            "lrmsd_std",
-            "dockq",
-            "dockq_std",
-            "ilrmsd",
-            "ilrmsd_std",
-            "rmsd",
-            "rmsd_std",
-            "caprieval_rank",
-        ],
-        [
-            "1",
-            "1",
-            "yes",
-            "42.000",
-            "0.000",
-            "0.100",
-            "0.000",
-            "1.000",
-            "0.000",
-            "1.200",
-            "0.000",
-            "nan",
-            "nan",
-            "4.300",
-            "0.000",
-            "0.010",
-            "0.000",
-            "1",
-        ],
-        [
-            "2",
-            "1",
-            "yes",
-            "50.000",
-            "0.000",
-            "0.100",
-            "0.000",
-            "1.000",
-            "0.000",
-            "1.200",
-            "0.000",
-            "nan",
-            "nan",
-            "4.300",
-            "0.000",
-            "0.010",
-            "0.000",
-            "2",
-        ],
-    ]
-    assert observed_outf_l == expected_outf_l
+        observed_outf_l = read_capri_file("capri_clt.txt")
+        expected_outf_l = [
+            [
+                "cluster_id",
+                "n",
+                "under_eval",
+                "score",
+                "score_std",
+                "irmsd",
+                "irmsd_std",
+                "fnat",
+                "fnat_std",
+                "lrmsd",
+                "lrmsd_std",
+                "dockq",
+                "dockq_std",
+                "ilrmsd",
+                "ilrmsd_std",
+                "rmsd",
+                "rmsd_std",
+                "caprieval_rank",
+            ],
+            [
+                "1",
+                "1",
+                "yes",
+                "42.000",
+                "0.000",
+                "0.100",
+                "0.000",
+                "1.000",
+                "0.000",
+                "1.200",
+                "0.000",
+                "nan",
+                "nan",
+                "4.300",
+                "0.000",
+                "0.010",
+                "0.000",
+                "1",
+            ],
+            [
+                "2",
+                "1",
+                "yes",
+                "50.000",
+                "0.000",
+                "0.100",
+                "0.000",
+                "1.000",
+                "0.000",
+                "1.200",
+                "0.000",
+                "nan",
+                "nan",
+                "4.300",
+                "0.000",
+                "0.010",
+                "0.000",
+                "2",
+            ],
+        ]
+        assert observed_outf_l == expected_outf_l
 
-    # test sorting
-    capri_cluster_analysis(
-        capri_list=[protprot_caprimodule, protprot_caprimodule],
-        model_list=[model1, model2],
-        output_fname="capri_clt.txt",
-        clt_threshold=5,
-        sort_key="cluster_rank",
-        sort_ascending=False,
-        path=Path("."),
-    )
+        # test sorting
+        capri_cluster_analysis(
+            capri_list=[protprot_caprimodule, protprot_caprimodule],
+            model_list=[model1, model2],
+            output_fname="capri_clt.txt",
+            clt_threshold=5,
+            sort_key="cluster_rank",
+            sort_ascending=False,
+            path=Path("."),
+        )
 
-    observed_outf_l = read_capri_file("capri_clt.txt")
-    expected_outf_l = [
-        [
-            "cluster_id",
-            "n",
-            "under_eval",
-            "score",
-            "score_std",
-            "irmsd",
-            "irmsd_std",
-            "fnat",
-            "fnat_std",
-            "lrmsd",
-            "lrmsd_std",
-            "dockq",
-            "dockq_std",
-            "rmsd",
-            "rmsd_std",
-            "caprieval_rank",
-        ],
-        [
-            "2",
-            "1",
-            "yes",
-            "50.000",
-            "0.000",
-            "0.100",
-            "0.000",
-            "1.000",
-            "0.000",
-            "1.200",
-            "0.000",
-            "nan",
-            "nan",
-            "0.010",
-            "0.000",
-            "2",
-        ],
-        [
-            "1",
-            "1",
-            "yes",
-            "42.000",
-            "0.000",
-            "0.100",
-            "0.000",
-            "1.000",
-            "0.000",
-            "1.200",
-            "0.000",
-            "nan",
-            "nan",
-            "0.010",
-            "0.000",
-            "1",
-        ],
-    ]
-
-    Path("capri_clt.txt").unlink()
-
-
-@pytest.fixture
-def protprot_onechain_ref_caprimodule(
-    protprot_input_list, protprot_onechain_list, params
-):
-    """Protein-Protein CAPRI module with a single chain structure as ref."""
-    reference = protprot_onechain_list[0].rel_path
-    model = protprot_input_list[1].rel_path
-    capri = CAPRI(
-        identificator=str(42),
-        reference=reference,
-        model=model,
-        path=golden_data,
-        params=params,
-    )
-
-    yield capri
-
-    remove_aln_files(capri)
-
-
-@pytest.fixture
-def protprot_onechain_mod_caprimodule(
-    protprot_input_list, protprot_onechain_list, params
-):
-    """Protein-Protein CAPRI module with a single chain structure as model."""
-    reference = protprot_input_list[0].rel_path
-    model = protprot_onechain_list[0].rel_path
-    capri = CAPRI(
-        identificator=str(42),
-        reference=reference,
-        model=model,
-        path=golden_data,
-        params=params,
-    )
-
-    yield capri
-
-    remove_aln_files(capri)
+        observed_outf_l = read_capri_file("capri_clt.txt")
+        expected_outf_l = [
+            [
+                "cluster_id",
+                "n",
+                "under_eval",
+                "score",
+                "score_std",
+                "irmsd",
+                "irmsd_std",
+                "fnat",
+                "fnat_std",
+                "lrmsd",
+                "lrmsd_std",
+                "dockq",
+                "dockq_std",
+                "rmsd",
+                "rmsd_std",
+                "caprieval_rank",
+            ],
+            [
+                "2",
+                "1",
+                "yes",
+                "50.000",
+                "0.000",
+                "0.100",
+                "0.000",
+                "1.000",
+                "0.000",
+                "1.200",
+                "0.000",
+                "nan",
+                "nan",
+                "0.010",
+                "0.000",
+                "2",
+            ],
+            [
+                "1",
+                "1",
+                "yes",
+                "42.000",
+                "0.000",
+                "0.100",
+                "0.000",
+                "1.000",
+                "0.000",
+                "1.200",
+                "0.000",
+                "nan",
+                "nan",
+                "0.010",
+                "0.000",
+                "1",
+            ],
+        ]
 
 
 def test_single_chain_reference(protprot_onechain_ref_caprimodule, params):
@@ -893,8 +867,9 @@ def test_protdna_swapped_chains(protdna_caprimodule):
     protdna_caprimodule.calc_ilrmsd()
     assert np.isclose(protdna_caprimodule.ilrmsd, 4.91, atol=0.01)
 
-    
+
 def test_capri_run(mocker):
+    """???"""
 
     mock_get_align_func = mocker.Mock(
         return_value={"numbering": {1: 1, 2: 2}, "chain_dict": {1: 2}}
@@ -905,73 +880,79 @@ def test_capri_run(mocker):
     )
 
     mocker.patch.object(CAPRI, "_load_atoms", return_value=None)
-    capri = CAPRI(
-        identificator="test",
-        model=Path("some-file"),
-        path=Path("."),
-        reference=Path("some-file"),
-        params={
-            "fnat": True,
-            "irmsd": True,
-            "lrmsd": True,
-            "ilrmsd": True,
-            "dockq": True,
-            "global_rmsd": True,
-            "allatoms": True,
-            "receptor_chain": "A",
-            "ligand_chains": ["B"],
-            "alignment_method": None,
-            "lovoalign_exec": None,
-            "fnat_cutoff": 10,
-            "irmsd_cutoff": 10,
-        },
-    )
-    rand_fnat = random.random()
-    mocker.patch.object(
-        capri, "calc_fnat", side_effect=lambda cutoff: setattr(capri, "fnat", rand_fnat)
-    )
-    rand_irmsd = random.random()
-    mocker.patch.object(
-        capri,
-        "calc_irmsd",
-        side_effect=lambda cutoff: setattr(capri, "irmsd", rand_irmsd),
-    )
-    rand_lrmsd = random.random()
-    mocker.patch.object(
-        capri, "calc_lrmsd", side_effect=lambda: setattr(capri, "lrmsd", rand_lrmsd)
-    )
-    rand_ilrmsd = random.random()
-    mocker.patch.object(
-        capri,
-        "calc_ilrmsd",
-        side_effect=lambda cutoff: setattr(capri, "ilrmsd", rand_ilrmsd),
-    )
-    rand_dockq = random.random()
-    mocker.patch.object(
-        capri, "calc_dockq", side_effect=lambda: setattr(capri, "dockq", rand_dockq)
-    )
+    with tempfile.TemporaryDirectory() as tempdir:
+        os.chdir(tempdir)
+        capri = CAPRI(
+            identificator="test",
+            model=Path("some-file"),
+            path=Path("."),
+            reference=Path("some-file"),
+            params={
+                "fnat": True,
+                "irmsd": True,
+                "lrmsd": True,
+                "ilrmsd": True,
+                "dockq": True,
+                "global_rmsd": True,
+                "allatoms": True,
+                "receptor_chain": "A",
+                "ligand_chains": ["B"],
+                "alignment_method": None,
+                "lovoalign_exec": None,
+                "fnat_cutoff": 10,
+                "irmsd_cutoff": 10,
+            },
+        )
+        rand_fnat = random.random()
+        mocker.patch.object(
+            capri,
+            "calc_fnat",
+            side_effect=lambda cutoff: setattr(capri, "fnat", rand_fnat),
+        )
+        rand_irmsd = random.random()
+        mocker.patch.object(
+            capri,
+            "calc_irmsd",
+            side_effect=lambda cutoff: setattr(capri, "irmsd", rand_irmsd),
+        )
+        rand_lrmsd = random.random()
+        mocker.patch.object(
+            capri, "calc_lrmsd", side_effect=lambda: setattr(capri, "lrmsd", rand_lrmsd)
+        )
+        rand_ilrmsd = random.random()
+        mocker.patch.object(
+            capri,
+            "calc_ilrmsd",
+            side_effect=lambda cutoff: setattr(capri, "ilrmsd", rand_ilrmsd),
+        )
+        rand_dockq = random.random()
+        mocker.patch.object(
+            capri, "calc_dockq", side_effect=lambda: setattr(capri, "dockq", rand_dockq)
+        )
 
-    rand_global_rmsd = random.random()
-    mocker.patch.object(
-        capri,
-        "calc_global_rmsd",
-        side_effect=lambda: setattr(capri, "rmsd", rand_global_rmsd)
-    )
+        rand_global_rmsd = random.random()
+        mocker.patch.object(
+            capri,
+            "calc_global_rmsd",
+            side_effect=lambda: setattr(capri, "rmsd", rand_global_rmsd),
+        )
 
-    mocker.patch.object(capri, "make_output")
+        mocker.patch.object(capri, "make_output")
 
-    capri.run()
+        capri.run()
 
-    # The only logic to be tested is if the methods are called
-    assert capri.fnat == pytest.approx(rand_fnat)
-    assert capri.irmsd == pytest.approx(rand_irmsd)
-    assert capri.lrmsd == pytest.approx(rand_lrmsd)
-    assert capri.ilrmsd == pytest.approx(rand_ilrmsd)
-    assert capri.dockq == pytest.approx(rand_dockq)
-    assert capri.rmsd == pytest.approx(rand_global_rmsd)
+        # The only logic to be tested is if the methods are called
+        assert capri.fnat == pytest.approx(rand_fnat)
+        assert capri.irmsd == pytest.approx(rand_irmsd)
+        assert capri.lrmsd == pytest.approx(rand_lrmsd)
+        assert capri.ilrmsd == pytest.approx(rand_ilrmsd)
+        assert capri.dockq == pytest.approx(rand_dockq)
+        assert capri.rmsd == pytest.approx(rand_global_rmsd)
 
 
 def test_rank_according_to_score():
+    """???"""
+
     data = {
         1: {
             "score": 3.0,
@@ -997,6 +978,7 @@ def test_rank_according_to_score():
 
 
 def test_extract_data_from_capri_class(mocker):
+    """???"""
 
     mocker.patch(
         "haddock.modules.analysis.caprieval.capri.write_nested_dic_to_file",
@@ -1004,65 +986,73 @@ def test_extract_data_from_capri_class(mocker):
     )
     mocker.patch.object(CAPRI, "_load_atoms", return_value=None)
 
-    c = CAPRI(
-        path=Path("."),
-        identificator="42",
-        model=Path("anything"),
-        reference=Path("anything"),
-        params={
-            "allatoms": True,
-            "receptor_chain": "X",
-            "ligand_chains": ["X"],
-        },
-    )
+    with tempfile.TemporaryDirectory() as tempdir:
+        os.chdir(tempdir)
 
-    # Create random entries
-    random_energy = random.random()
-    random_model = PDBFile(
-        file_name=str(uuid.uuid4()), score=42, unw_energies={"energy": random_energy}
-    )
+        c = CAPRI(
+            path=Path("."),
+            identificator="42",
+            model=Path("anything"),
+            reference=Path("anything"),
+            params={
+                "allatoms": True,
+                "receptor_chain": "X",
+                "ligand_chains": ["X"],
+            },
+        )
 
-    random_clt_id = random.randint(0, 100)
-    random_clt_rank = random.randint(0, 100)
-    random_clt_model_rank = random.randint(0, 100)
-    random_md5 = str(uuid.uuid4())
-    random_score = random.random()
-    random_irmsd = random.random()
-    random_fnat = random.random()
-    random_lrmsd = random.random()
-    random_ilrmsd = random.random()
-    random_dockq = random.random()
-    random_rmsd = random.random()
+        # Create random entries
+        random_energy = random.random()
+        random_model = PDBFile(
+            file_name=str(uuid.uuid4()),
+            score=42,
+            unw_energies={"energy": random_energy},
+        )
 
-    c.model = random_model
-    c.model.clt_id = random_clt_id
-    c.model.clt_rank = random_clt_rank
-    c.model.clt_model_rank = random_clt_model_rank
-    c.md5 = random_md5
-    c.score = random_score
-    c.irmsd = random_irmsd
-    c.fnat = random_fnat
-    c.lrmsd = random_lrmsd
-    c.ilrmsd = random_ilrmsd
-    c.dockq = random_dockq
-    c.rmsd = random_rmsd
+        random_clt_id = random.randint(0, 100)
+        random_clt_rank = random.randint(0, 100)
+        random_clt_model_rank = random.randint(0, 100)
+        random_md5 = str(uuid.uuid4())
+        random_score = random.random()
+        random_irmsd = random.random()
+        random_fnat = random.random()
+        random_lrmsd = random.random()
+        random_ilrmsd = random.random()
+        random_dockq = random.random()
+        random_rmsd = random.random()
 
-    observed_data = extract_data_from_capri_class(
-        capri_objects=[c], sort_key="score", sort_ascending=True, output_fname=Path("")
-    )
+        c.model = random_model
+        c.model.clt_id = random_clt_id
+        c.model.clt_rank = random_clt_rank
+        c.model.clt_model_rank = random_clt_model_rank
+        c.md5 = random_md5
+        c.score = random_score
+        c.irmsd = random_irmsd
+        c.fnat = random_fnat
+        c.lrmsd = random_lrmsd
+        c.ilrmsd = random_ilrmsd
+        c.dockq = random_dockq
+        c.rmsd = random_rmsd
 
-    assert observed_data is not None
+        observed_data = extract_data_from_capri_class(
+            capri_objects=[c],
+            sort_key="score",
+            sort_ascending=True,
+            output_fname=Path(""),
+        )
 
-    assert observed_data[1]["model"] == random_model
-    assert observed_data[1]["md5"] == random_md5
-    assert observed_data[1]["score"] == random_score
-    assert observed_data[1]["irmsd"] == random_irmsd
-    assert observed_data[1]["fnat"] == random_fnat
-    assert observed_data[1]["lrmsd"] == random_lrmsd
-    assert observed_data[1]["ilrmsd"] == random_ilrmsd
-    assert observed_data[1]["dockq"] == random_dockq
-    assert observed_data[1]["rmsd"] == random_rmsd
-    assert observed_data[1]["energy"] == random_energy
-    assert observed_data[1]["cluster_id"] == random_clt_id
-    assert observed_data[1]["cluster_ranking"] == random_clt_rank
-    assert observed_data[1]["model-cluster_ranking"] == random_clt_model_rank
+        assert observed_data is not None
+
+        assert observed_data[1]["model"] == random_model
+        assert observed_data[1]["md5"] == random_md5
+        assert observed_data[1]["score"] == random_score
+        assert observed_data[1]["irmsd"] == random_irmsd
+        assert observed_data[1]["fnat"] == random_fnat
+        assert observed_data[1]["lrmsd"] == random_lrmsd
+        assert observed_data[1]["ilrmsd"] == random_ilrmsd
+        assert observed_data[1]["dockq"] == random_dockq
+        assert observed_data[1]["rmsd"] == random_rmsd
+        assert observed_data[1]["energy"] == random_energy
+        assert observed_data[1]["cluster_id"] == random_clt_id
+        assert observed_data[1]["cluster_ranking"] == random_clt_rank
+        assert observed_data[1]["model-cluster_ranking"] == random_clt_model_rank

--- a/tests/test_module_clustfcc.py
+++ b/tests/test_module_clustfcc.py
@@ -6,45 +6,33 @@ from pathlib import Path
 
 import pytest
 
-from haddock.libs.libontology import ModuleIO, PDBFile
+from haddock.libs.libontology import ModuleIO
 from haddock.modules.analysis.clustfcc import DEFAULT_CONFIG as clustfcc_pars
 from haddock.modules.analysis.clustfcc import HaddockModule as ClustFCCModule
 
-from . import golden_data
 
-
-@pytest.fixture
-def prot_input_list():
-    """Prot-prot input."""
-    return [
-        PDBFile(Path(golden_data, "protprot_complex_1.pdb"), path=golden_data),
-        PDBFile(Path(golden_data, "protprot_complex_2.pdb"), path=golden_data),
-    ]
-
-
-@pytest.fixture
-def fcc_module():
+@pytest.fixture(name="fcc_module")
+def fixture_fcc_module():
     """Clustfcc module."""
     with tempfile.TemporaryDirectory() as tempdir:
-        yield ClustFCCModule(order=1, path=Path(tempdir), initial_params=clustfcc_pars)
+        os.chdir(tempdir)
+        yield ClustFCCModule(order=1, path=Path("."), initial_params=clustfcc_pars)
 
 
-def test_io_json(fcc_module, prot_input_list):
+def test_io_json(fcc_module, protprot_input_list):
     """Test the correct creation of the io.json file."""
     # set the input and output models
-    fcc_module.previous_io.output = prot_input_list
-    fcc_module.output_models = prot_input_list
+    fcc_module.previous_io.output = protprot_input_list
+    fcc_module.output_models = protprot_input_list
 
     # export models
     fcc_module.export_io_models()
+    expected_io = Path(f"{fcc_module.path}/io.json")
 
-    assert Path("io.json").exists()
+    assert expected_io.exists()
 
     # check the content of io.json
     io = ModuleIO()
-    io.load("io.json")
-    assert io.input[0].file_name == prot_input_list[0].file_name
-    assert io.output[1].file_name == prot_input_list[1].file_name
-
-    # remove io.json file
-    os.unlink(Path("io.json"))
+    io.load(expected_io)
+    assert io.input[0].file_name == protprot_input_list[0].file_name
+    assert io.output[1].file_name == protprot_input_list[1].file_name

--- a/tests/test_module_contmap.py
+++ b/tests/test_module_contmap.py
@@ -425,7 +425,6 @@ def test_write_res_contacts(res_res_contacts):
         assert lines[0].strip().split("\t") == ["res1", "res2", "ca-ca-dist"]
         assert lines[1].strip().split("\t") == ["A-1-MET", "A-2-ALA", "3.0"]
         assert lines[2].strip().split("\t") == ["A-1-MET", "A-3-VAL", "4.0"]
-        res_contact_output_f.unlink(missing_ok=True)
 
 
 def test_topx_models(protprot_input_list):

--- a/tests/test_module_contmap.py
+++ b/tests/test_module_contmap.py
@@ -1,39 +1,40 @@
 """Test the CONTact MAP module."""
+
 import os
-import pytest
-import pytest_mock  # noqa : F401
 import tempfile
 from pathlib import Path
+from typing import Callable
 
 import numpy as np
+import pytest
 from scipy.spatial.distance import pdist, squareform
 
 from haddock.libs.libontology import PDBFile
-from haddock.modules.analysis.contactmap import HaddockModule as ContactMapModule  # noqa : E501
 from haddock.modules.analysis.contactmap import DEFAULT_CONFIG
+from haddock.modules.analysis.contactmap import \
+    HaddockModule as ContactMapModule
 from haddock.modules.analysis.contactmap.contmap import (
-    ContactsMap,
-    ClusteredContactMap,
-    datakey_to_colorscale,
-    write_res_contacts,
-    min_dist,
-    extract_submatrix,
-    compute_distance_matrix,
-    extract_pdb_coords,
-    topX_models,
-    gen_contact_dt,
-    # chord chart functions
-    moduloAB,
     PI,
-    within_2PI,
+    ClusteredContactMap,
+    ContactsMap,
     check_square_matrix,
+    compute_distance_matrix,
+    control_pts,
+    ctrl_rib_chords,
+    datakey_to_colorscale,
+    extract_pdb_coords,
+    extract_submatrix,
+    gen_contact_dt,
+    invPerm,
+    make_chordchart,
+    make_ideogram_arc,
     make_q_bezier,
     make_ribbon_arc,
-    make_chordchart,
-    invPerm,
-    ctrl_rib_chords,
-    control_pts,
-    make_ideogram_arc,
+    min_dist,
+    moduloAB,
+    topX_models,
+    within_2PI,
+    write_res_contacts,
     )
 
 from . import golden_data
@@ -42,75 +43,81 @@ from . import golden_data
 ##########################
 # Define pytest fixtures #
 ##########################
-@pytest.fixture
-def contactmap_output_ext():
+@pytest.fixture(name="contactmap_output_ext")
+def fixture_contactmap_output_ext():
     """List of generated files suffixes."""
     return (
-        'contacts.tsv',
-        'heatmap.html',
-        'chordchart.html',
-        'interchain_contacts.tsv',
-        'heavyatoms_interchain_contacts.tsv',
-        )
+        "contacts.tsv",
+        "heatmap.html",
+        "chordchart.html",
+        "interchain_contacts.tsv",
+        "heavyatoms_interchain_contacts.tsv",
+    )
 
 
-@pytest.fixture
-def pdbline():
+@pytest.fixture(name="pdbline")
+def fixture_pdbline():
+    """???"""
     return "ATOM     28  O   GLU A  21      11.097   3.208   5.136  1.00"
 
 
-@pytest.fixture
-def atoms_coordinates() -> list[list]:
+@pytest.fixture(name="atoms_coordinates")
+def fixture_atoms_coordinates() -> list[list]:
     """List of 3 atom coordinates."""
     return [
         [1, 2, 3],
         [1, 2, 2],
         [0, 2, 3],
-        ]
+    ]
 
 
-@pytest.fixture
-def ref_one_line_dist_half_matrix():
+@pytest.fixture(name="ref_one_line_dist_half_matrix")
+def fixture_ref_one_line_dist_half_matrix():
+    """???"""
     return [1, 1, np.sqrt(2)]
 
 
-@pytest.fixture
-def ref_dist_matrix():
-    return np.array([
-        [0, 1, 1],
-        [1, 0, np.sqrt(2)],
-        [1, np.sqrt(2), 0],
-        ])
+@pytest.fixture(name="ref_dist_matrix")
+def fixture_ref_dist_matrix():
+    """???"""
+    return np.array(
+        [
+            [0, 1, 1],
+            [1, 0, np.sqrt(2)],
+            [1, np.sqrt(2), 0],
+        ]
+    )
 
 
-@pytest.fixture
-def contactmap():
+@pytest.fixture(name="contactmap")
+def fixture_contactmap():
     """Return contmap module."""
-    with tempfile.TemporaryDirectory(dir=".") as tmpdir:
+    with tempfile.TemporaryDirectory() as tempdir:
+        os.chdir(tempdir)
         yield ContactMapModule(
             order=1,
-            path=Path(tmpdir),
+            path=Path("."),
             initial_params=DEFAULT_CONFIG,
-            )
+        )
 
 
-@pytest.fixture
-def cluster_input_list() -> list:
-    """Prot-prot input."""
-    return [
-        PDBFile(Path(golden_data, "protprot_complex_1.pdb"), path=golden_data),
-        PDBFile(Path(golden_data, "protprot_complex_2.pdb"), path=golden_data),
-        ]
+# @pytest.fixture
+# def protprot_input_list() -> list:
+#     """Prot-prot input."""
+#     return [
+#         PDBFile(Path(golden_data, "protprot_complex_1.pdb"), path=golden_data),
+#         PDBFile(Path(golden_data, "protprot_complex_2.pdb"), path=golden_data),
+#     ]
 
 
-@pytest.fixture
-def cluster_input_iter(cluster_input_list) -> iter:
+@pytest.fixture(name="cluster_input_iter")
+def fixture_cluster_input_iter(protprot_input_list) -> Callable:
     """Generate an iterable of files path."""
-    return iter(cluster_input_list)
+    return iter(protprot_input_list)
 
 
-@pytest.fixture
-def params() -> dict:
+@pytest.fixture(name="params")
+def fixture_params() -> dict:
     """Set of parameters."""
     return {
         "ca_ca_dist_threshold": 9.0,
@@ -119,93 +126,151 @@ def params() -> dict:
         "single_model_analysis": False,
         "topX": 10,
         "generate_heatmap": True,
-        "cluster_heatmap_datatype": 'shortest-cont-probability',
+        "cluster_heatmap_datatype": "shortest-cont-probability",
         "generate_chordchart": True,
-        "chordchart_datatype": 'shortest-dist',
+        "chordchart_datatype": "shortest-dist",
         "offline": False,
-        }
+    }
 
 
-@pytest.fixture
-def protprot_contactmap(cluster_input_list, params):
+@pytest.fixture(name="protprot_contactmap")
+def fixture_protprot_contactmap(protprot_input_list, params):
+    """???"""
     params["single_model_analysis"] = True
-    return ContactsMap(
-        Path(cluster_input_list[0].rel_path),
-        Path('./contmap_test'),
-        params,
+    with (
+        tempfile.TemporaryDirectory() as tempdir,
+        tempfile.NamedTemporaryFile() as temp_f,
+    ):
+        os.chdir(tempdir)
+        return ContactsMap(
+            model=Path(protprot_input_list[0].rel_path),
+            output=Path(temp_f.name),
+            params=params,
         )
 
 
-@pytest.fixture
-def clustercontactmap(cluster_input_list, params):
-    return ClusteredContactMap(
-        [Path(m.rel_path) for m in cluster_input_list],
-        Path('./clustcontmap_test'),
-        params,
+@pytest.fixture(name="clustercontactmap")
+def fixture_clustercontactmap(protprot_input_list, params):
+    """???"""
+    with (
+        tempfile.TemporaryDirectory() as tempdir,
+        tempfile.NamedTemporaryFile() as temp_f,
+    ):
+        os.chdir(tempdir)
+        return ClusteredContactMap(
+            models=[Path(m.rel_path) for m in protprot_input_list],
+            output=Path(temp_f.name),
+            params=params,
         )
 
 
-@pytest.fixture
-def res_res_contacts():
+@pytest.fixture(name="res_res_contacts")
+def fixture_res_res_contacts():
+    """???"""
     return [
-        {'res1': 'A-1-MET', 'res2': 'A-2-ALA', 'ca-ca-dist': 3.0},
-        {'res1': 'A-1-MET', 'res2': 'A-3-VAL', 'ca-ca-dist': 4.0},
+        {"res1": "A-1-MET", "res2": "A-2-ALA", "ca-ca-dist": 3.0},
+        {"res1": "A-1-MET", "res2": "A-3-VAL", "ca-ca-dist": 4.0},
+    ]
+
+
+@pytest.fixture(name="contact_matrix")
+def fixture_contact_matrix():
+    """???"""
+    return np.array(
+        [
+            [1, 0, 0, 1, 0, 0],
+            [0, 1, 0, 0, 0, 0],
+            [0, 0, 1, 0, 0, 0],
+            [1, 0, 0, 1, 1, 0],
+            [0, 0, 0, 1, 1, 1],
+            [0, 0, 0, 0, 1, 1],
         ]
+    )
 
 
-@pytest.fixture
-def contact_matrix():
-    return np.array([
-        [1, 0, 0, 1, 0, 0],
-        [0, 1, 0, 0, 0, 0],
-        [0, 0, 1, 0, 0, 0],
-        [1, 0, 0, 1, 1, 0],
-        [0, 0, 0, 1, 1, 1],
-        [0, 0, 0, 0, 1, 1],
-        ])
+@pytest.fixture(name="dist_matrix")
+def fixture_dist_matrix():
+    """???"""
+    return np.array(
+        [
+            [0.0, 18.4, 16.0, 5.1, 11.4, 14.7],
+            [18.4, 0.0, 18.0, 15.2, 11.7, 20.1],
+            [16.0, 18.0, 0.0, 9.2, 12.8, 10.0],
+            [5.1, 15.2, 9.2, 0.0, 6.2, 9.3],
+            [11.4, 11.7, 12.8, 6.2, 0.0, 6.9],
+            [14.7, 20.1, 10.0, 9.3, 6.9, 0.0],
+        ]
+    )
 
 
-@pytest.fixture
-def dist_matrix():
-    return np.array([
-        [0.0, 18.4, 16.0, 5.1, 11.4, 14.7],
-        [18.4, 0.0, 18.0, 15.2, 11.7, 20.1],
-        [16.0, 18.0, 0.0, 9.2, 12.8, 10.0],
-        [5.1, 15.2, 9.2, 0.0, 6.2, 9.3],
-        [11.4, 11.7, 12.8, 6.2, 0.0, 6.9],
-        [14.7, 20.1, 10.0, 9.3, 6.9, 0.0],
-        ])
+@pytest.fixture(name="intertype_matrix")
+def fixture_intertype_matrix():
+    """???"""
+    return np.array(
+        [
+            [
+                "self-self",
+                "polar-positive",
+                "polar-apolar",
+                "polar-apolar",
+                "polar-apolar",
+                "polar-negative",
+            ],
+            [
+                "polar-positive",
+                "self-self",
+                "positive-apolar",
+                "positive-apolar",
+                "positive-apolar",
+                "positive-negative",
+            ],
+            [
+                "polar-apolar",
+                "positive-apolar",
+                "self-self",
+                "apolar-apolar",
+                "apolar-apolar",
+                "apolar-negative",
+            ],
+            [
+                "polar-apolar",
+                "positive-apolar",
+                "apolar-apolar",
+                "self-self",
+                "apolar-apolar",
+                "apolar-negative",
+            ],
+            [
+                "polar-apolar",
+                "positive-apolar",
+                "apolar-apolar",
+                "apolar-apolar",
+                "self-self",
+                "apolar-negative",
+            ],
+            [
+                "polar-negative",
+                "positive-negative",
+                "apolar-negative",
+                "apolar-negative",
+                "apolar-negative",
+                "self-self",
+            ],
+        ]
+    )
 
 
-@pytest.fixture
-def intertype_matrix():
-    return np.array([
-        ['self-self', 'polar-positive', 'polar-apolar',
-         'polar-apolar', 'polar-apolar', 'polar-negative'],
-        ['polar-positive', 'self-self', 'positive-apolar',
-         'positive-apolar', 'positive-apolar',
-         'positive-negative'],
-        ['polar-apolar', 'positive-apolar', 'self-self',
-         'apolar-apolar', 'apolar-apolar', 'apolar-negative'],
-        ['polar-apolar', 'positive-apolar', 'apolar-apolar',
-         'self-self', 'apolar-apolar', 'apolar-negative'],
-        ['polar-apolar', 'positive-apolar', 'apolar-apolar',
-         'apolar-apolar', 'self-self', 'apolar-negative'],
-        ['polar-negative', 'positive-negative', 'apolar-negative',
-         'apolar-negative', 'apolar-negative', 'self-self'],
-        ])
-
-
-@pytest.fixture
-def protein_labels():
+@pytest.fixture(name="protein_labels")
+def fixture_protein_labels():
+    """???"""
     return [
-        'A-69-THR',
-        'A-255-LYS',
-        'A-296-ILE',
-        'A-323-LEU',
-        'B-44-GLY',
-        'B-70-GLU',
-        ]
+        "A-69-THR",
+        "A-255-LYS",
+        "A-296-ILE",
+        "A-323-LEU",
+        "B-44-GLY",
+        "B-70-GLU",
+    ]
 
 
 ########################
@@ -245,7 +310,7 @@ def test_init(contactmap):
         order=42,
         path=Path("0_anything"),
         initial_params=DEFAULT_CONFIG,
-        )
+    )
 
     # Once a module is initialized, it should have the following attributes
     assert contactmap.path == Path("0_anything")
@@ -262,11 +327,9 @@ class MockPreviousIO:
     def retrieve_models(self, individualize: bool = False):
         """Provide a set of models."""
         models = [
-            PDBFile(Path(golden_data, "protprot_complex_1.pdb"),
-                    path=golden_data),
-            PDBFile(Path(golden_data, "protprot_complex_2.pdb"),
-                    path=golden_data),
-            ]
+            PDBFile(Path(golden_data, "protprot_complex_1.pdb"), path=golden_data),
+            PDBFile(Path(golden_data, "protprot_complex_2.pdb"), path=golden_data),
+        ]
         models[0].clt_id = None
         models[1].clt_id = 1
         return models
@@ -280,7 +343,7 @@ def test_contactmap_run(contactmap, mocker):
     mocker.patch(
         "haddock.modules.BaseHaddockModule.export_io_models",
         return_value=None,
-        )
+    )
     # run main module _run() function
     module_sucess = contactmap.run()
     assert module_sucess is None
@@ -289,9 +352,9 @@ def test_contactmap_run(contactmap, mocker):
 #########################################
 # Testing of previous_io errors handles #
 #########################################
-def test_contactmap_run_errors(contactmap, cluster_input_list, mocker):
+def test_contactmap_run_errors(contactmap, protprot_input_list, mocker):
     """Test content of _run() function from __init__.py HaddockModule class."""
-    contactmap.previous_io = cluster_input_list
+    contactmap.previous_io = protprot_input_list
     # run main module _run() function
     with pytest.raises(RuntimeError):
         module_sucess = contactmap.run()
@@ -320,7 +383,7 @@ def test_single_model(protprot_contactmap, contactmap_output_ext):
     # check generated output files
     output_bp = protprot_contactmap.output
     for output_ext in contactmap_output_ext:
-        fpath = f'{output_bp}_{output_ext}'
+        fpath = f"{output_bp}_{output_ext}"
         assert os.path.exists(fpath) is True
         assert Path(fpath).stat().st_size != 0
         Path(fpath).unlink(missing_ok=False)
@@ -335,7 +398,7 @@ def test_clustercontactmap_run(clustercontactmap, contactmap_output_ext):
     # check outputs
     output_bp = clustercontactmap.output
     for output_ext in contactmap_output_ext:
-        fpath = f'{output_bp}_{output_ext}'
+        fpath = f"{output_bp}_{output_ext}"
         assert os.path.exists(fpath) is True
         assert Path(fpath).stat().st_size != 0
         Path(fpath).unlink(missing_ok=False)
@@ -343,36 +406,44 @@ def test_clustercontactmap_run(clustercontactmap, contactmap_output_ext):
 
 def test_write_res_contacts(res_res_contacts):
     """Test list of dict to tsv generation."""
-    fpath = write_res_contacts(
-        res_res_contacts,
-        ['res1', 'res2', 'ca-ca-dist'],
-        Path('./test-contacts.tsv'),
+
+    with (
+        tempfile.TemporaryDirectory() as tempdir,
+        tempfile.NamedTemporaryFile(suffix=".tsv") as temp_f,
+    ):
+        os.chdir(tempdir)
+        res_contact_output_f = write_res_contacts(
+            res_res_contacts=res_res_contacts,
+            header=["res1", "res2", "ca-ca-dist"],
+            path=Path(temp_f.name),
         )
-    assert os.path.exists(fpath) is True
-    with open(fpath, 'r') as filin:
-        flines = [_ for _ in filin.readlines() if not _.startswith('#')]
-    assert flines[0].strip().split('\t') == ['res1', 'res2', 'ca-ca-dist']
-    assert flines[1].strip().split('\t') == ['A-1-MET', 'A-2-ALA', '3.0']
-    assert flines[2].strip().split('\t') == ['A-1-MET', 'A-3-VAL', '4.0']
-    fpath.unlink(missing_ok=True)
+        assert os.path.exists(res_contact_output_f) is True
+
+        with open(res_contact_output_f, "r", encoding="utf-8") as fh:
+            lines = [_ for _ in fh.readlines() if not _.startswith("#")]
+
+        assert lines[0].strip().split("\t") == ["res1", "res2", "ca-ca-dist"]
+        assert lines[1].strip().split("\t") == ["A-1-MET", "A-2-ALA", "3.0"]
+        assert lines[2].strip().split("\t") == ["A-1-MET", "A-3-VAL", "4.0"]
+        res_contact_output_f.unlink(missing_ok=True)
 
 
-def test_topx_models(cluster_input_list):
+def test_topx_models(protprot_input_list):
     """Test sorting and X=1 topX function."""
     # set input PDBFiles scores
-    cluster_input_list[0].score = -20.0
-    cluster_input_list[1].score = -40.0  # `better` than -20.0
-    topxmodels = topX_models(cluster_input_list, topX=1)
+    protprot_input_list[0].score = -20.0
+    protprot_input_list[1].score = -40.0  # `better` than -20.0
+    topxmodels = topX_models(protprot_input_list, topX=1)
     assert len(topxmodels) == 1
-    assert topxmodels[0].file_name == cluster_input_list[1].file_name
+    assert topxmodels[0].file_name == protprot_input_list[1].file_name
 
 
 def test_topx_models_exception():
     """Test exception handling of non PDBFile type lists."""
-    topxmodels = topX_models(['pdbpath1.pdb', 'pdbpath2.pdb'], topX=1)
+    topxmodels = topX_models(["pdbpath1.pdb", "pdbpath2.pdb"], topX=1)
     assert len(topxmodels) == 1
-    assert topxmodels == ['pdbpath1.pdb']
-    assert topxmodels[0] == 'pdbpath1.pdb'
+    assert topxmodels == ["pdbpath1.pdb"]
+    assert topxmodels[0] == "pdbpath1.pdb"
 
 
 def test_compute_distance_matrix(atoms_coordinates, ref_dist_matrix):
@@ -406,20 +477,20 @@ def test_min_dist(ref_dist_matrix):
 
 def test_no_reverse_coloscale():
     """Test non reversed color scale."""
-    colorscale = 'color'
+    colorscale = "color"
     new_colorscale = datakey_to_colorscale(
-        'probability',
+        "probability",
         color_scale=colorscale,
-        )
+    )
     assert new_colorscale == colorscale
 
 
 def test_reverse_coloscale():
     """Test reversed color scale."""
-    colorscale = 'color'
-    new_colorscale = datakey_to_colorscale('anything', color_scale=colorscale)
-    assert new_colorscale == f'{colorscale}_r'
-    assert '_r' in new_colorscale
+    colorscale = "color"
+    new_colorscale = datakey_to_colorscale("anything", color_scale=colorscale)
+    assert new_colorscale == f"{colorscale}_r"
+    assert "_r" in new_colorscale
 
 
 def test_gen_contact_dt_ca_exception(ref_dist_matrix):
@@ -427,13 +498,13 @@ def test_gen_contact_dt_ca_exception(ref_dist_matrix):
     cont_dt = gen_contact_dt(
         ref_dist_matrix,
         {
-            'r1': {'atoms_indices': [0, 1], 'CA': 0, 'resname': 'ALA'},
-            'r2': {'atoms_indices': [2], 'resname': 'ALA'},
-            },
-        'r1',
-        'r2',
-        )
-    assert cont_dt['ca-ca-dist'] == 9999
+            "r1": {"atoms_indices": [0, 1], "CA": 0, "resname": "ALA"},
+            "r2": {"atoms_indices": [2], "resname": "ALA"},
+        },
+        "r1",
+        "r2",
+    )
+    assert cont_dt["ca-ca-dist"] == 9999
 
 
 #################################
@@ -486,16 +557,16 @@ def test_check_square_matrix(contact_matrix):
 def test_make_q_bezier_error():
     """Test error raising in make_q_bezier()."""
     with pytest.raises(ValueError):
-        noreturn = make_q_bezier([1., 2.])
+        noreturn = make_q_bezier([1.0, 2.0])
         assert noreturn is None
 
 
 def test_make_ribbon_arc_angle_error():
     """Test error raising in make_ribbon_arc()."""
     with pytest.raises(ValueError):
-        noreturn = make_ribbon_arc(-1., 1.)
+        noreturn = make_ribbon_arc(-1.0, 1.0)
         assert noreturn is None
-        noreturn2 = make_ribbon_arc(1., -1.)
+        noreturn2 = make_ribbon_arc(1.0, -1.0)
         assert noreturn2 is None
 
 
@@ -507,14 +578,15 @@ def test_make_ribbon_arc_angle_baddef_error():
 
 
 def test_make_chordchart(
-        contact_matrix,
-        dist_matrix,
-        intertype_matrix,
-        protein_labels,
-        ):
+    contact_matrix,
+    dist_matrix,
+    intertype_matrix,
+    protein_labels,
+):
     """Test main function."""
-    with tempfile.TemporaryDirectory(dir=".") as tmpdir:
-        outputpath = f"{tmpdir}chord.html"
+    with tempfile.TemporaryDirectory() as tmpdir:
+        os.chdir(tmpdir)
+        outputpath = "chord.html"
         graphpath = make_chordchart(
             contact_matrix,
             dist_matrix,
@@ -522,7 +594,7 @@ def test_make_chordchart(
             protein_labels,
             output_fpath=outputpath,
             title="test",
-            )
+        )
         assert graphpath == outputpath
         assert os.path.exists(outputpath)
         assert Path(outputpath).stat().st_size != 0
@@ -553,10 +625,12 @@ def test_make_ideogram_arc_moduloAB():
     """Test usage of moduloAB while providing outranged angle values."""
     nb_points = 2
     arc_positions = make_ideogram_arc(1.1, (1, -1), nb_points=nb_points)
-    excpected_output = np.array([
-        0.5943325364549538 + 0.9256180832886862j,
-        0.5943325364549535 - 0.9256180832886863j,
-        ])
+    excpected_output = np.array(
+        [
+            0.5943325364549538 + 0.9256180832886862j,
+            0.5943325364549535 - 0.9256180832886863j,
+        ]
+    )
     assert arc_positions.shape == excpected_output.shape
     for i in range(nb_points):
         assert np.isclose(arc_positions[i], excpected_output[i], atol=0.0001)

--- a/tests/test_module_emscoring.py
+++ b/tests/test_module_emscoring.py
@@ -1,55 +1,73 @@
 """Test the emscoring module."""
+
 import os
+import tempfile
 from pathlib import Path
 
 import pytest
 
-from haddock.libs.libontology import PDBFile
-from haddock.modules.scoring.emscoring import DEFAULT_CONFIG as emscoring_pars
-from haddock.modules.scoring.emscoring import HaddockModule
-
-from . import golden_data
+from haddock.modules.scoring.emscoring import \
+    DEFAULT_CONFIG as DEFAULT_EMSCORING_PARAMS
+from haddock.modules.scoring.emscoring import HaddockModule as EMScoring
 
 
-@pytest.fixture
-def output_models():
-    """Prot-DNA models using for emscoring output."""
-    return [
-        PDBFile(
-            Path(golden_data, "protdna_complex_1.pdb"),
-            path=golden_data,
-            score=42.0
-            ),
-        PDBFile(
-            Path(golden_data, "protdna_complex_2.pdb"),
-            path=golden_data,
-            score=-28.0
-            )]
+@pytest.fixture(name="emscoring")
+def fixture_emscoring():
+    """???"""
 
-
-def test_emscoring_output(output_models):
-    """Test emscoring expected output."""
-    ems_module = HaddockModule(
-        order=1,
-        path=Path("1_emscoring"),
-        initial_params=emscoring_pars
+    with tempfile.TemporaryDirectory() as tempdir:
+        os.chdir(tempdir)
+        yield EMScoring(
+            order=1, path=Path("."), initial_params=DEFAULT_EMSCORING_PARAMS
         )
-    # original names
-    ems_module.output_models = output_models
-    for mod in range(len(output_models)):
-        ori_name = "original_name_" + str(mod) + ".pdb"
-        ems_module.output_models[mod].ori_name = ori_name
-    # creating output
+
+
+@pytest.fixture(name="emscoring_dna")
+def fixture_emscoring_dna(emscoring, protdna_input_list):
+    """???"""
+
+    protdna_input_list[0].score = -28.0
+    protdna_input_list[0].ori_name = "original_name_1.pdb"
+
+    protdna_input_list[1].score = 42.0
+    protdna_input_list[1].ori_name = "original_name_2.pdb"
+
+    emscoring.output_models = protdna_input_list
+
+    yield emscoring
+
+
+def test_emscoring_output(emscoring_dna, protdna_input_list):
+    """Test emscoring expected output."""
+
     output_fname = Path("emscoring.tsv")
-    ems_module.output(output_fname)
-    observed_outf_l = [e.split() for e in open(
-        output_fname).readlines() if not e.startswith('#')]
+    emscoring_dna.output(output_fname)
+
+    with open(output_fname, "r", encoding="utf-8") as fh:
+        observed_outf_l = [l.split() for l in fh.readlines() if not l.startswith("#")]
+
     # expected output
     expected_outf_l = [
         ["structure", "original_name", "md5", "score"],
-        ["protdna_complex_2.pdb", "original_name_1.pdb", "None", "-28.0"],
-        ["protdna_complex_1.pdb", "original_name_0.pdb", "None", "42.0"]]
-        
+        [
+            Path(protdna_input_list[0].rel_path).name,
+            Path(protdna_input_list[0].ori_name).name,
+            "None",
+            str(protdna_input_list[0].score),
+        ],
+        [
+            Path(protdna_input_list[1].rel_path).name,
+            Path(protdna_input_list[1].ori_name).name,
+            "None",
+            str(protdna_input_list[1].score),
+        ],
+    ]
+
+    assert len(observed_outf_l) == len(expected_outf_l)
+
+    for i, j in zip(observed_outf_l, expected_outf_l):
+        assert i == j
+
     assert observed_outf_l == expected_outf_l
 
     os.unlink(output_fname)

--- a/tests/test_module_ilrmsdmatrix.py
+++ b/tests/test_module_ilrmsdmatrix.py
@@ -1,52 +1,62 @@
 """Test the rmsdmatrix module."""
+
+import os
+import tempfile
 from pathlib import Path
 
 import numpy as np
 import pytest
-import pytest_mock  # noqa : F401
-import tempfile
 
-from haddock.modules.analysis.ilrmsdmatrix import DEFAULT_CONFIG as ilrmsd_pars
-from haddock.modules.analysis.ilrmsdmatrix import (
-    HaddockModule as IlrmsdmatrixModule,
-    )
-from haddock.modules.analysis.ilrmsdmatrix.ilrmsd import (
-    ContactJob,
-    Contact,
-    )
-
-from .test_module_caprieval import protprot_input_list, protprot_onechain_list  # noqa : F401
+from haddock.modules.analysis.ilrmsdmatrix import \
+    DEFAULT_CONFIG as ILRMSD_DEFAULT_PARAMS
+from haddock.modules.analysis.ilrmsdmatrix import \
+    HaddockModule as IlrmsdmatrixModule
+from haddock.modules.analysis.ilrmsdmatrix.ilrmsd import Contact, ContactJob
 
 
-@pytest.fixture
-def params():
+@pytest.fixture(name="params")
+def fixture_params():
+    """???"""
     return {"receptor_chain": "A", "ligand_chains": ["B"]}
 
 
 @pytest.fixture
-def contact_obj(protprot_input_list, params):  # noqa : F811    
+def ilrmsdmatrix():
+    """Return ilrmsdmatrix module."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        os.chdir(tmpdir)
+        yield IlrmsdmatrixModule(
+            order=1,
+            path=Path("."),
+            initial_params=ILRMSD_DEFAULT_PARAMS,
+        )
+
+
+@pytest.fixture(name="contact_obj")
+def fixture_contact_obj(protprot_input_list, params):
     """Return example Contact object."""
-    contact_obj = Contact(
-        model_list=protprot_input_list,
-        output_name="contact",
-        path=Path("."),
-        core=0,
-        contact_distance_cutoff=5.0,
-        params=params,
+    with tempfile.TemporaryDirectory() as tempdir:
+        os.chdir(tempdir)
+        yield Contact(
+            model_list=protprot_input_list,
+            output_name="contact",
+            path=Path("."),
+            core=0,
+            contact_distance_cutoff=5.0,
+            params=params,
         )
 
-    yield contact_obj
 
-
-@pytest.fixture
-def contact_job_obj(contact_obj, params):
+@pytest.fixture(name="contact_job_obj")
+def fixture_contact_job_obj(contact_obj, params):
     """Return example ContactJob object."""
-    contact_job_obj = ContactJob(
-        Path("contact_output"),
-        params,
-        contact_obj,
+    with tempfile.TemporaryDirectory() as tempdir:
+        os.chdir(tempdir)
+        yield ContactJob(
+            Path("contact_output"),
+            params,
+            contact_obj,
         )
-    yield contact_job_obj
 
 
 def test_contact(contact_obj):
@@ -59,7 +69,8 @@ def test_contact(contact_obj):
     assert np.array_equal(contact_obj.unique_lig_res, exp_lig_res)
     # assert contact_obj.unique_lig_res == exp_lig_res
     exp_rec_res = np.array(
-        [37, 38, 39, 40, 43, 44, 45, 69, 71, 72, 75, 90, 93, 94, 96, 132])
+        [37, 38, 39, 40, 43, 44, 45, 69, 71, 72, 75, 90, 93, 94, 96, 132]
+    )
     assert np.array_equal(contact_obj.unique_rec_res, exp_rec_res)
 
 
@@ -85,26 +96,15 @@ def test_contact_job(contact_job_obj):
     assert Path(exp_output).exists()
 
 
-@pytest.fixture
-def ilrmsdmatrix():
-    """Return ilrmsdmatrix module."""
-    with tempfile.TemporaryDirectory(dir=".") as tmpdir:
-        yield IlrmsdmatrixModule(
-            order=1,
-            path=Path(tmpdir),
-            initial_params=ilrmsd_pars,
-            )
-
-
 def test_ilrmsdmatrix_init(ilrmsdmatrix):
     """Test ilrmsdmatrix module initialization."""
     ilrmsdmatrix.__init__(
         order=42,
         path=Path("0_anything"),
-        initial_params=ilrmsd_pars,
-        )
+        initial_params=ILRMSD_DEFAULT_PARAMS,
+    )
     # Once a module is initialized, it should have the following attributes
     assert ilrmsdmatrix.path == Path("0_anything")
-    assert ilrmsdmatrix._origignal_config_file == ilrmsd_pars
+    assert ilrmsdmatrix._origignal_config_file == ILRMSD_DEFAULT_PARAMS
     assert type(ilrmsdmatrix.params) == dict
     assert len(ilrmsdmatrix.params) != 0

--- a/tests/test_module_mdscoring.py
+++ b/tests/test_module_mdscoring.py
@@ -1,55 +1,73 @@
 """Test the mdscoring module."""
+
 import os
+import tempfile
 from pathlib import Path
 
 import pytest
 
-from haddock.libs.libontology import PDBFile
-from haddock.modules.scoring.mdscoring import DEFAULT_CONFIG as mdscoring_pars
-from haddock.modules.scoring.mdscoring import HaddockModule
-
-from . import golden_data
+from haddock.modules.scoring.mdscoring import \
+    DEFAULT_CONFIG as MDSCORING_DEFAULT_PARAMS
+from haddock.modules.scoring.mdscoring import HaddockModule as MDScoring
 
 
-@pytest.fixture
-def output_models():
-    """Prot-prot models using for mdscoring output."""
-    return [
-        PDBFile(
-            Path(golden_data, "protprot_complex_1.pdb"),
-            path=golden_data,
-            score=42.0
-            ),
-        PDBFile(
-            Path(golden_data, "protprot_complex_2.pdb"),
-            path=golden_data,
-            score=28.0
-            )]
+@pytest.fixture(name="mdscoring")
+def fixture_mdscoring():
+    """???"""
 
-
-def test_mdscoring_output(output_models):
-    """Test emscoring expected output."""
-    mds_module = HaddockModule(
-        order=1,
-        path=Path("1_emscoring"),
-        initial_params=mdscoring_pars
+    with tempfile.TemporaryDirectory() as tempdir:
+        os.chdir(tempdir)
+        yield MDScoring(
+            order=1, path=Path("."), initial_params=MDSCORING_DEFAULT_PARAMS
         )
-    # original names
-    mds_module.output_models = output_models
-    for mod in range(len(output_models)):
-        ori_name = "original_name_" + str(mod) + ".pdb"
-        mds_module.output_models[mod].ori_name = ori_name
-    # creating output
+
+
+@pytest.fixture(name="mdscoring_dna")
+def fixture_mdscoring_dna(mdscoring, protdna_input_list):
+    """???"""
+
+    protdna_input_list[0].score = -28.0
+    protdna_input_list[0].ori_name = "original_name_1.pdb"
+
+    protdna_input_list[1].score = 42.0
+    protdna_input_list[1].ori_name = "original_name_2.pdb"
+
+    mdscoring.output_models = protdna_input_list
+
+    yield mdscoring
+
+
+def test_mdscoring_output(mdscoring_dna, protdna_input_list):
+    """Test mdscoring expected output."""
+
     output_fname = Path("mdscoring.tsv")
-    mds_module.output(output_fname)
-    observed_outf_l = [e.split() for e in open(
-        output_fname).readlines() if not e.startswith('#')]
+    mdscoring_dna.output(output_fname)
+
+    with open(output_fname, "r", encoding="utf-8") as fh:
+        observed_outf_l = [l.split() for l in fh.readlines() if not l.startswith("#")]
+
     # expected output
     expected_outf_l = [
         ["structure", "original_name", "md5", "score"],
-        ["protprot_complex_2.pdb", "original_name_1.pdb", "None", "28.0"],
-        ["protprot_complex_1.pdb", "original_name_0.pdb", "None", "42.0"]]
-        
+        [
+            Path(protdna_input_list[0].rel_path).name,
+            Path(protdna_input_list[0].ori_name).name,
+            "None",
+            str(protdna_input_list[0].score),
+        ],
+        [
+            Path(protdna_input_list[1].rel_path).name,
+            Path(protdna_input_list[1].ori_name).name,
+            "None",
+            str(protdna_input_list[1].score),
+        ],
+    ]
+
+    assert len(observed_outf_l) == len(expected_outf_l)
+
+    for i, j in zip(observed_outf_l, expected_outf_l):
+        assert i == j
+
     assert observed_outf_l == expected_outf_l
 
     os.unlink(output_fname)

--- a/tests/test_module_rigidbody.py
+++ b/tests/test_module_rigidbody.py
@@ -1,49 +1,48 @@
 """Test the rigidbody module."""
 
 import os
+import random
 import tempfile
 from pathlib import Path
 
 import pytest
-import random
 
 from haddock.libs.libontology import Format, PDBFile, Persistent
 from haddock.libs.libsubprocess import CNSJob
-from haddock.modules.sampling.rigidbody import (
-    DEFAULT_CONFIG as DEFAULT_RIGIDBODY_PARAMS,
-)
+from haddock.modules.sampling.rigidbody import \
+    DEFAULT_CONFIG as DEFAULT_RIGIDBODY_PARAMS
 from haddock.modules.sampling.rigidbody import HaddockModule as RigidbodyModule
 
 
-@pytest.fixture
-def rigidbody_module(mocker):
-    with tempfile.NamedTemporaryFile() as fake_cns, tempfile.TemporaryDirectory() as tempdir:
-        fake_cns.file.write(b"")
-        fake_cns.file.flush()
-        fake_cns.file.seek(0)
-        os.chmod(fake_cns.name, 0o755)
-        mocker.patch("haddock.libs.libsubprocess.global_cns_exec", fake_cns.name)
+@pytest.fixture(name="rigidbody_module")
+def fixture_rigidbody_module():
+    """???"""
+    with (tempfile.TemporaryDirectory() as tempdir,):
+        os.chdir(tempdir)
 
         yield RigidbodyModule(
             order=1,
-            path=Path(tempdir),
+            path=Path("."),
             initial_params=DEFAULT_RIGIDBODY_PARAMS,
         )
 
 
 def test_prev_fnames():
     """Tests the correct retrieval of ambiguous restraints information."""
-    rigidbody = RigidbodyModule(
-        order=1,
-        path=Path("1_rigidbody"),
-        initial_params=DEFAULT_RIGIDBODY_PARAMS,
-    )
-    prev_ambig_fnames = [None for md in range(rigidbody.params["sampling"])]
-    diff_ambig_fnames = rigidbody.get_ambig_fnames(prev_ambig_fnames)  # type: ignore
-    assert diff_ambig_fnames is None
+    with tempfile.TemporaryDirectory() as tempdir:
+        os.chdir(tempdir)
+        rigidbody = RigidbodyModule(
+            order=1,
+            path=Path("1_rigidbody"),
+            initial_params=DEFAULT_RIGIDBODY_PARAMS,
+        )
+        prev_ambig_fnames = [None for md in range(rigidbody.params["sampling"])]
+        diff_ambig_fnames = rigidbody.get_ambig_fnames(prev_ambig_fnames)  # type: ignore
+        assert diff_ambig_fnames is None
 
 
 def test_rigidbody_make_cns_jobs(rigidbody_module):
+    "???"
 
     rigidbody_module.output_models = []
     rigidbody_module.envvars = {}
@@ -84,6 +83,7 @@ def test_rigidbody_make_cns_jobs(rigidbody_module):
 
 
 def test_prepare_cns_input_sequential(mocker, rigidbody_module):
+    """???"""
 
     mocker.patch(
         "haddock.modules.sampling.rigidbody.prepare_cns_input",
@@ -114,6 +114,7 @@ def test_prepare_cns_input_sequential(mocker, rigidbody_module):
 
 
 def test_prepare_cns_input_parallel(mocker, rigidbody_module):
+    """???"""
     mock_engine_cls = mocker.Mock()
     mocker.patch(
         "haddock.modules.sampling.rigidbody.get_engine", return_value=mock_engine_cls

--- a/tests/test_module_rmsdmatrix.py
+++ b/tests/test_module_rmsdmatrix.py
@@ -1,44 +1,37 @@
 """Test the rmsdmatrix module."""
-import os
-from pathlib import Path
-import tempfile
 
-import numpy as np
+import os
+import tempfile
+from pathlib import Path
+
 import pytest
 
-from haddock.libs.libontology import PDBFile
-from haddock.modules.analysis.rmsdmatrix import DEFAULT_CONFIG as rmsd_pars
-from haddock.modules.analysis.rmsdmatrix import HaddockModule
+from haddock.modules.analysis.rmsdmatrix import \
+    DEFAULT_CONFIG as DEFAULT_RMSDMATRIX_PARAMS
+from haddock.modules.analysis.rmsdmatrix import HaddockModule as Rmsdmatrix
 from haddock.modules.analysis.rmsdmatrix.rmsd import (
+    XYZWriter,
     get_pair,
     rmsd_dispatcher,
-    XYZWriter,
     )
 
-from . import golden_data
 
-
-@pytest.fixture
-def input_protdna_models():
-    """Prot-DNA models using for emscoring output."""
-    return [
-        PDBFile(
-            Path(golden_data, "protdna_complex_1.pdb"),
-            path=golden_data,
-            score=42.0
-            ),
-        PDBFile(
-            Path(golden_data, "protdna_complex_2.pdb"),
-            path=golden_data,
-            score=28.0
-            )]
+@pytest.fixture(name="rmsdmatrix")
+def fixture_rmsdmatrix():
+    """???"""
+    with tempfile.TemporaryDirectory() as tempdir:
+        os.chdir(tempdir)
+        yield Rmsdmatrix(
+            order=2, path=Path("."), initial_params=DEFAULT_RMSDMATRIX_PARAMS
+        )
+    # rmsd_module.previous_io.output = protdna_input_list
 
 
 def test_get_pair():
     """Test the get_pair() function."""
     nmodels_vec = [10, 2, 200]
     idx_vec = [10, 0, 396]
-    
+
     expexted_ivec = [1, 0, 1]
     expected_jvec = [3, 1, 199]
     for n in range(len(nmodels_vec)):
@@ -62,18 +55,16 @@ def test_rmsd_dispatcher():
     nmodels_vec = [1, 10, 5]
     tot_npairs_vec = [1, 45, 10]
     ncores_vec = [1, 2, 10]
-    
+
     expected_pairs_vec = [[1], [23, 22], [1, 1, 1, 1, 1, 1, 1, 1, 1, 1]]
     expected_ref_vec = [[0], [0, 2], [0, 0, 0, 0, 1, 1, 1, 2, 2, 3]]
     expected_mod_vec = [[1], [1, 9], [1, 2, 3, 4, 2, 3, 4, 3, 4, 4]]
 
     for n in range(len(nmodels_vec)):
         dispatcher_output = rmsd_dispatcher(
-            nmodels_vec[n],
-            tot_npairs_vec[n],
-            ncores_vec[n]
-            )
-        
+            nmodels_vec[n], tot_npairs_vec[n], ncores_vec[n]
+        )
+
         assert dispatcher_output[0] == expected_pairs_vec[n]
 
         assert dispatcher_output[1] == expected_ref_vec[n]
@@ -81,15 +72,10 @@ def test_rmsd_dispatcher():
         assert dispatcher_output[2] == expected_mod_vec[n]
 
 
-def test_overall_rmsd(input_protdna_models):
+def test_overall_rmsd(rmsdmatrix, protdna_input_list):
     """Test overall rmsdmatrix module."""
-    rmsd_module = HaddockModule(
-        order=2,
-        path=Path("2_rmsdmatrix"),
-        initial_params=rmsd_pars
-        )
-    rmsd_module.previous_io.output = input_protdna_models
-    rmsd_module._run()
+    rmsdmatrix.previous_io.output = protdna_input_list
+    rmsdmatrix._run()
 
     ls = os.listdir()
 
@@ -99,37 +85,37 @@ def test_overall_rmsd(input_protdna_models):
 
     # check correct rmsd matrix
     rmsd_matrix = open("rmsd.matrix").read()
-    
+
     expected_rmsd_matrix = "1 2 2.257" + os.linesep
 
     assert rmsd_matrix == expected_rmsd_matrix
 
-    os.unlink(Path("rmsd.matrix"))
-    os.unlink(Path("rmsd_matrix.json"))
-    os.unlink(Path("io.json"))
+    # os.unlink(Path("rmsd.matrix"))
+    # os.unlink(Path("rmsd_matrix.json"))
+    # os.unlink(Path("io.json"))
 
 
-def test_xyzwriter(input_protdna_models):
+def test_xyzwriter(protdna_input_list):
     "test XYZWriter"
     with tempfile.TemporaryDirectory() as tmpdir:
         common_keys = [
-            ('A', 10, 'N'),
-            ('A', 10, 'CA'),
-            ('A', 32, 'N'),
-            ('B', 38, 'C6'),
+            ("A", 10, "N"),
+            ("A", 10, "CA"),
+            ("A", 32, "N"),
+            ("B", 38, "C6"),
         ]
         exp_output = Path(tmpdir, "test.xyz")
         xyzwriter_obj = XYZWriter(
-            model_list=input_protdna_models,
+            model_list=protdna_input_list,
             output_name=exp_output,
             core=1,
             n_atoms=4,
             common_keys=common_keys,
             filter_resdic=None,
             allatoms=False,
-            )
+        )
         xyzwriter_obj.run()
-        
+
         assert exp_output.exists()
         # check the content
         with open(exp_output) as f:

--- a/tests/test_module_seletopclusts.py
+++ b/tests/test_module_seletopclusts.py
@@ -1,108 +1,31 @@
 """Test related to the seletopclusts module."""
 
-import os
-import pytest
-import pytest_mock  # noqa : F401
-import tempfile
 import math
+import os
+import shutil
+import tempfile
 from pathlib import Path
 
-from . import golden_data
+import pytest
 
 from haddock.libs.libontology import PDBFile
-from haddock.modules.analysis.seletopclusts import HaddockModule as SeleTopClustModule  # noqa : E501
 from haddock.modules.analysis.seletopclusts import DEFAULT_CONFIG
+from haddock.modules.analysis.seletopclusts import \
+    HaddockModule as SeleTopClustModule
 from haddock.modules.analysis.seletopclusts.seletopclusts import (
     map_clusters_models,
-    select_top_clusts_models,
     rank_clust_order,
+    select_top_clusts_models,
     size_clust_order,
     sort_models,
     write_selected_models,
     )
 
+from . import golden_data
+
 
 NB_CLUSTERS = 3
 MDL_RANK_INCREMENT = 5
-
-
-###########################
-# DEFINE FIXED INPUT DATA #
-###########################
-@pytest.fixture
-def clustered_models() -> list[PDBFile]:
-    """Set of clustered PDBfiles."""
-    models: list[PDBFile] = []
-    # Create 3 cluster of 7, 6 and 5 models respectively
-    for clt_rank in range(1, NB_CLUSTERS + 1):
-        for mdl_rank in range(clt_rank + MDL_RANK_INCREMENT - 1, 0, -1):
-            pdbfile = PDBFile(
-                Path(golden_data, "protprot_complex_1.pdb"),
-                path=golden_data,
-                )
-            # Add attributes
-            pdbfile.clt_rank = clt_rank
-            pdbfile.clt_model_rank = mdl_rank
-            models.append(pdbfile)
-    return models
-    
-
-@pytest.fixture
-def unclustered_models() -> list[PDBFile]:
-    """Set of unclustered PDBfiles."""
-    models: list[PDBFile] = []
-    # Create 3 cluster of 7, 6 and 5 models respectively
-    for clt_rank in range(1, NB_CLUSTERS + 1):
-        for _mdl_rank in range(clt_rank + MDL_RANK_INCREMENT - 1, 0, -1):
-            pdbfile = PDBFile(
-                Path(golden_data, "protprot_complex_1.pdb"),
-                path=golden_data,
-                )
-            # Do NOT add attributes
-            models.append(pdbfile)
-    return models
-
-
-@pytest.fixture
-def unranked_models() -> list[PDBFile]:
-    """List of unranked models."""
-    return [
-        PDBFile(
-            Path(golden_data, "protprot_complex_1.pdb"),
-            path=golden_data,
-            ),
-        PDBFile(
-            Path(golden_data, "protprot_complex_2.pdb"),
-            path=golden_data,
-            ),
-        ]
-
-
-@pytest.fixture
-def ranked_models() -> list[PDBFile]:
-    """List of ranked models."""
-    models: list[PDBFile] = []
-    for ind, clt_model_rank in enumerate(range(2, 0, -1), start=1):
-        pdbfile = PDBFile(
-            Path(golden_data, f"protprot_complex_{ind}.pdb"),
-            path=golden_data,
-            )
-        # Add clt model rank attribute
-        pdbfile.clt_model_rank = clt_model_rank
-        pdbfile.clt_rank = 1
-        models.append(pdbfile)
-    return models
-
-
-@pytest.fixture
-def seletopclust():
-    """Test module __init__()."""
-    with tempfile.TemporaryDirectory(dir=".") as tmpdir:
-        yield SeleTopClustModule(
-            order=1,
-            path=Path(tmpdir),
-            initial_params=DEFAULT_CONFIG,
-            )
 
 
 class MockPreviousIO:
@@ -118,9 +41,74 @@ class MockPreviousIO:
         return self.models
 
 
-###################################
-# Testing of class in __init__.py #
-###################################
+@pytest.fixture(name="clustered_models")
+def fixture_clustered_models() -> list[PDBFile]:
+    """Set of clustered PDBfiles."""
+    models: list[PDBFile] = []
+    # Create 3 cluster of 7, 6 and 5 models respectively
+    for clt_rank in range(1, NB_CLUSTERS + 1):
+        for mdl_rank in range(clt_rank + MDL_RANK_INCREMENT - 1, 0, -1):
+            with tempfile.NamedTemporaryFile(delete=False, suffix=".pdb") as temp_f:
+                dst = temp_f.name
+                src = Path(golden_data, "protprot_complex_1.pdb")
+                shutil.copy(src, dst)
+
+                pdbfile = PDBFile(file_name=dst, path=Path(dst).parent)
+                # Add attributes
+                pdbfile.clt_rank = clt_rank
+                pdbfile.clt_model_rank = mdl_rank
+                models.append(pdbfile)
+    return models
+
+
+@pytest.fixture(name="unclustered_models")
+def fixture_unclustered_models() -> list[PDBFile]:
+    """Set of unclustered PDBfiles."""
+    models: list[PDBFile] = []
+    # Create 3 cluster of 7, 6 and 5 models respectively
+    for clt_rank in range(1, NB_CLUSTERS + 1):
+        for _ in range(clt_rank + MDL_RANK_INCREMENT - 1, 0, -1):
+            with tempfile.NamedTemporaryFile(delete=False, suffix=".pdb") as temp_f:
+                dst = temp_f.name
+                src = Path(golden_data, "protprot_complex_1.pdb")
+                shutil.copy(src, dst)
+
+                pdbfile = PDBFile(file_name=dst, path=Path(dst).parent)
+
+                models.append(pdbfile)
+    return models
+
+
+@pytest.fixture(name="ranked_models")
+def fixture_ranked_models() -> list[PDBFile]:
+    """List of ranked models."""
+    models: list[PDBFile] = []
+    for ind, clt_model_rank in enumerate(range(2, 0, -1), start=1):
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".pdb") as temp_f:
+            dst = temp_f.name
+            src = Path(golden_data, f"protprot_complex_{ind}.pdb")
+            shutil.copy(src, dst)
+
+            pdbfile = PDBFile(file_name=dst, path=Path(dst).parent)
+            # Add clt model rank attribute
+            pdbfile.clt_model_rank = clt_model_rank
+            pdbfile.clt_rank = 1
+            models.append(pdbfile)
+    return models
+
+
+@pytest.fixture(name="seletopclust")
+def fixture_seletopclust():
+    """Test module __init__()."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        os.chdir(tmpdir)
+        yield SeleTopClustModule(
+            order=1,
+            path=Path("."),
+            initial_params=DEFAULT_CONFIG,
+        )
+
+
 def test_confirm_installation(seletopclust):
     """Test confirm install."""
     assert seletopclust.confirm_installation() is None
@@ -132,7 +120,7 @@ def test_init(seletopclust):
         order=42,
         path=Path("0_anything"),
         initial_params=DEFAULT_CONFIG,
-        )
+    )
 
     # Once a module is initialized, it should have the following attributes
     assert seletopclust.path == Path("0_anything")
@@ -148,7 +136,7 @@ def test_seletopclust_run(seletopclust, mocker, clustered_models):
     mocker.patch(
         "haddock.modules.BaseHaddockModule.export_io_models",
         return_value=None,
-        )
+    )
     # run main module _run() function
     module_sucess = seletopclust.run()
     assert module_sucess is None
@@ -162,32 +150,28 @@ def test_seletopclust_neg_nb_mdls(seletopclust, mocker, clustered_models):
     seletopclust.previous_io = MockPreviousIO(clustered_models)
     mocker.patch(
         "haddock.modules.BaseHaddockModule.finish_with_error",
-        side_effect=Exception('mocked error'),
-        )
+        side_effect=Exception("mocked error"),
+    )
     with pytest.raises(Exception) as moked_finish_with_error:
         # run main module _run() function
         seletopclust.run()
-    assert moked_finish_with_error.value.__str__() == 'mocked error'
+    assert moked_finish_with_error.value.__str__() == "mocked error"
 
 
-def test_seletopclust_wrong_clust_param_type(
-        seletopclust,
-        mocker,
-        clustered_models
-        ):
+def test_seletopclust_wrong_clust_param_type(seletopclust, mocker, clustered_models):
     """Test finish_with_error due to wrong cluster parameter type."""
     # Change parameter
-    seletopclust.params["top_cluster"] = '1'
+    seletopclust.params["top_cluster"] = "1"
     # Mock some functions
     seletopclust.previous_io = MockPreviousIO(clustered_models)
     mocker.patch(
         "haddock.modules.BaseHaddockModule.finish_with_error",
-        side_effect=Exception('mocked error'),
-        )
+        side_effect=Exception("mocked error"),
+    )
     with pytest.raises(Exception) as moked_finish_with_error:
         # run main module _run() function
         seletopclust.run()
-    assert moked_finish_with_error.value.__str__() == 'mocked error'
+    assert moked_finish_with_error.value.__str__() == "mocked error"
 
 
 def test_seletopclust_unclustered(seletopclust, mocker, unclustered_models):
@@ -196,17 +180,14 @@ def test_seletopclust_unclustered(seletopclust, mocker, unclustered_models):
     seletopclust.previous_io = MockPreviousIO(unclustered_models)
     mocker.patch(
         "haddock.modules.BaseHaddockModule.finish_with_error",
-        side_effect=Exception('mocked error'),
-        )
+        side_effect=Exception("mocked error"),
+    )
     with pytest.raises(Exception) as moked_finish_with_error:
         # run main module _run() function
         seletopclust.run()
-    assert moked_finish_with_error.value.__str__() == 'mocked error'
+    assert moked_finish_with_error.value.__str__() == "mocked error"
 
 
-#########################
-# DEFINE TEST FUNCTIONS #
-#########################
 def test_map_clusters_models(clustered_models):
     """Test grouping of models by clusters."""
     by_clusters = map_clusters_models(clustered_models)
@@ -248,7 +229,7 @@ def test_select_top_ranked_clusts_models(clustered_models):
         clustered_models,
         1,
         1,
-        )
+    )
     assert len(selected_models) == 1
     assert selected_models[0].clt_rank == 1
     assert selected_models[0].clt_model_rank == 1
@@ -259,7 +240,7 @@ def test_select_top_ranked_clusts_models(clustered_models):
         clustered_models,
         2,
         8,
-        )
+    )
     assert len(selected_models) == 5 + 6
 
     ind = 0
@@ -275,7 +256,7 @@ def test_select_top_ranked_clusts_models(clustered_models):
         clustered_models,
         NB_CLUSTERS + 2,
         NB_CLUSTERS + MDL_RANK_INCREMENT + 1,
-        )
+    )
     assert len(selected_models) == len(clustered_models)
     ind = 0
     for clt_rank in range(1, NB_CLUSTERS + 1):
@@ -290,7 +271,7 @@ def test_select_top_ranked_clusts_models(clustered_models):
         clustered_models,
         NB_CLUSTERS + 2,
         math.nan,
-        )
+    )
     assert len(selected_models) == len(clustered_models)
     ind = 0
     for clt_rank in range(1, NB_CLUSTERS + 1):
@@ -308,7 +289,7 @@ def test_select_top_sized_clusts_models(clustered_models):
         clustered_models,
         1,
         1,
-        )
+    )
     assert len(selected_models) == 1
     assert selected_models[0].clt_rank == 3
     assert selected_models[0].clt_model_rank == 1
@@ -319,7 +300,7 @@ def test_select_top_sized_clusts_models(clustered_models):
         clustered_models,
         2,
         8,
-        )
+    )
     assert len(selected_models) == 7 + 6
 
     ind = 0
@@ -335,7 +316,7 @@ def test_select_top_sized_clusts_models(clustered_models):
         clustered_models,
         NB_CLUSTERS + 2,
         NB_CLUSTERS + MDL_RANK_INCREMENT + 1,
-        )
+    )
     assert len(selected_models) == len(clustered_models)
     ind = 0
     for clt_rank in range(NB_CLUSTERS, 0, -1):
@@ -350,7 +331,7 @@ def test_select_top_sized_clusts_models(clustered_models):
         clustered_models,
         NB_CLUSTERS + 2,
         math.nan,
-        )
+    )
     assert len(selected_models) == len(clustered_models)
     ind = 0
     for clt_rank in range(NB_CLUSTERS, 0, -1):
@@ -360,10 +341,10 @@ def test_select_top_sized_clusts_models(clustered_models):
             ind += 1
 
 
-def test_sort_models_unranked(unranked_models):
+def test_sort_models_unranked(protprot_input_list):
     """Test sorting of unranked models."""
-    sorted_models, _note = sort_models(unranked_models)
-    assert sorted_models == unranked_models
+    sorted_models, _note = sort_models(protprot_input_list)
+    assert sorted_models == protprot_input_list
     assert type(_note) == str
 
 
@@ -371,19 +352,23 @@ def test_sort_models_ranked(ranked_models):
     """Test sorting of ranked models."""
     sorted_models, _note = sort_models(ranked_models)
     assert not _note
-    assert sorted_models[0].file_name == "protprot_complex_2.pdb"
-    assert sorted_models[1].file_name == "protprot_complex_1.pdb"
+    assert sorted_models[0].file_name == ranked_models[1].file_name
+    assert sorted_models[1].file_name == ranked_models[0].file_name
+
+    # assert sorted_models[0].file_name == "protprot_complex_2.pdb"
+    # assert sorted_models[1].file_name == "protprot_complex_1.pdb"
 
 
 def test_write_selected_models(ranked_models):
     """Test writing of models names mapping file."""
-    with tempfile.TemporaryDirectory(dir="./") as tmpdir:
-        outputfile = f"{tmpdir}test-seletopclusts.txt"
+    with tempfile.TemporaryDirectory() as tempdir:
+        os.chdir(tempdir)
+        outputfile = "test-seletopclusts.txt"
         models = write_selected_models(
-            outputfile,
-            ranked_models,
-            './',
-            )
+            output_path=outputfile,
+            models=ranked_models,
+            module_path=Path("."),
+        )
         # Validate file creation
         assert os.path.exists(outputfile)
         assert Path(outputfile).stat().st_size != 0

--- a/tests/test_module_topoaa.py
+++ b/tests/test_module_topoaa.py
@@ -1,6 +1,6 @@
 """Specific tests for topoaa."""
+
 import os
-import shutil
 import tempfile
 from math import isnan
 from pathlib import Path
@@ -9,7 +9,8 @@ import pytest
 
 from haddock.gear.yaml2cfg import read_from_yaml_config
 from haddock.modules.topology.topoaa import DEFAULT_CONFIG as topoaa_params
-from haddock.modules.topology.topoaa import HaddockModule, generate_topology
+from haddock.modules.topology.topoaa import HaddockModule as Topoaa
+from haddock.modules.topology.topoaa import generate_topology
 
 from . import golden_data
 
@@ -20,7 +21,7 @@ DEFAULT_DICT = read_from_yaml_config(topoaa_params)
 @pytest.mark.parametrize(
     "param",
     ["hisd_1", "hise_1"],
-    )
+)
 def test_variable_defaults_are_nan_in_mol1(param):
     """Test some variable defaults are as expected."""
     assert isnan(DEFAULT_DICT["mol1"][param])
@@ -28,37 +29,28 @@ def test_variable_defaults_are_nan_in_mol1(param):
 
 def test_there_is_only_one_mol():
     """Test there is only one mol parameter in topoaa."""
-    r = set(
-        p
-        for p in DEFAULT_DICT
-        if p.startswith("mol") and p[3].isdigit()
-        )
+    r = set(p for p in DEFAULT_DICT if p.startswith("mol") and p[3].isdigit())
     assert len(r) == 1
 
 
-@pytest.fixture
-def ensemble_header_w_md5():
+@pytest.fixture(name="ensemble_header_w_md5")
+def fixture_ensemble_header_w_md5():
+    """???"""
     return Path(golden_data, "ens_header.pdb")
 
 
-@pytest.fixture
-def protein():
+@pytest.fixture(name="protein")
+def fixture_protein():
+    """???"""
     return Path(golden_data, "protein.pdb")
 
 
-@pytest.fixture
-def topoaa():
-    with tempfile.TemporaryDirectory() as tmpdirname:
-        yield HaddockModule(
-            order=1,
-            path=Path(tmpdirname),
-            initial_params=topoaa_params)
-
-
-@pytest.mark.skip(reason="Not implemented yet")
-def test_confirm_installation(topoaa):
-    # topoaa.confirm_installation()
-    pass
+@pytest.fixture(name="topoaa")
+def fixture_topoaa():
+    """???"""
+    with tempfile.TemporaryDirectory() as tempdir:
+        os.chdir(tempdir)
+        yield Topoaa(order=1, path=Path("."), initial_params=topoaa_params)
 
 
 def test_generate_topology(topoaa, protein):
@@ -67,48 +59,25 @@ def test_generate_topology(topoaa, protein):
         input_pdb=protein,
         recipe_str=topoaa.recipe_str,
         defaults=topoaa.params,
-        mol_params=topoaa.params.pop('mol1'),
-        default_params_path=None)
+        mol_params=topoaa.params.pop("mol1"),
+        default_params_path=None,
+    )
 
     assert observed_inp_out == Path(protein.name).with_suffix(".inp")
-
-    observed_inp_out.unlink()
 
 
 def test_get_md5(topoaa, ensemble_header_w_md5, protein):
     """Test get_md5 method."""
     observed_md5_dic = topoaa.get_md5(ensemble_header_w_md5)
     expected_md5_dic = {
-        1: '71098743056e0b95fbfafff690703761',
-        2: 'f7ab0b7c751adf44de0f25f53cfee50b',
-        3: '41e028d8d28b8d97148dc5e548672142',
-        4: '761cb5da81d83971c2aae2f0b857ca1e',
-        5: '6c438f941cec7c6dc092c8e48e5b1c10'}
+        1: "71098743056e0b95fbfafff690703761",
+        2: "f7ab0b7c751adf44de0f25f53cfee50b",
+        3: "41e028d8d28b8d97148dc5e548672142",
+        4: "761cb5da81d83971c2aae2f0b857ca1e",
+        5: "6c438f941cec7c6dc092c8e48e5b1c10",
+    }
 
     assert observed_md5_dic == expected_md5_dic
 
     observed_md5_dic = topoaa.get_md5(protein)
     assert observed_md5_dic == {}
-
-
-@pytest.mark.skip(reason="Cannot test in Github Actions")
-def test__run(topoaa, protein):
-    """Test _run method."""
-    shutil.copy(protein, topoaa.path)
-    input_mol = Path(topoaa.path, protein.name)
-    current_pwd = Path.cwd()
-    os.chdir(topoaa.path)
-    topoaa.params['molecules'] = [input_mol]
-    topoaa.envvars = topoaa.default_envvars()
-    topoaa._run()
-    os.chdir(current_pwd)
-
-    inp = input_mol.with_suffix(".inp")
-    out = input_mol.with_suffix(".out")
-    topology = Path(input_mol.parent, f"{input_mol.stem}_haddock.psf")
-    structure = Path(input_mol.parent, f"{input_mol.stem}_haddock.pdb")
-
-    assert inp.exists()
-    assert out.exists()
-    assert topology.exists()
-    assert structure.exists()


### PR DESCRIPTION
This PR goes into #1042 and refactors the tests to account for the behaviour of `tempfile` changed in 3.12