### PR TITLE
Correction of the usage of DSSP in the topocg module

### DIFF
--- a/src/haddock/modules/topology/topocg/aa2cg.py
+++ b/src/haddock/modules/topology/topocg/aa2cg.py
@@ -32,7 +32,7 @@ from haddock.modules.topology.topocg.helper import *
 
 warnings.filterwarnings("ignore")
 
-CRYST_LINE = "CRYST1 \n"
+CRYST_LINE = "CRYST1 " + os.linesep
 
 
 def add_dummy(bead_list, dist=0.11, n=2):

--- a/src/haddock/modules/topology/topocg/aa2cg.py
+++ b/src/haddock/modules/topology/topocg/aa2cg.py
@@ -441,13 +441,13 @@ def determine_ss(structure, output_path, skipss, pdbf_path):
                 p = subprocess.Popen(["dssp", tmp_file_name, "--output-format", "dssp"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
                 dssp_raw, errors = p.communicate()
                 dssp_raw = dssp_raw.split('#')[1].split('\n')[1:-1]
-                if Path(tmp_file_name).exists(): Path(tmp_file_name).unlink()
             except:  # TODO: think about making this exception more specific
                 # no secondary structure detected for this model
-                if Path(tmp_file_name).exists(): Path(tmp_file_name).unlink()
                 log.warning('SS could not be assigned, assigning code 1 to all residues')
                 continue
-        
+            finally:
+                if Path(tmp_file_name).exists(): Path(tmp_file_name).unlink()
+
         dssp = {}
 
         for line in dssp_raw:
@@ -467,7 +467,7 @@ def determine_ss(structure, output_path, skipss, pdbf_path):
 
             # transform MARTINI > HADDOCK
             # and add it to the bfactor col
-            for residue, ss in zip(chain, martini_types):
+            for residue, ss in zip(chain, martini_types): # chain and martini_types order must match
                 code = ss_to_code[ss]
                 # for atom in residue.get_atoms():
                 for atom in residue:

--- a/src/haddock/modules/topology/topocg/aa2cg.py
+++ b/src/haddock/modules/topology/topocg/aa2cg.py
@@ -436,12 +436,12 @@ def determine_ss(structure, skipss, pdbf_path):
     """
     # calculate SS
     for model in structure:
-        tmp_file_name = create_file_with_cryst(pdbf_path)
 
         if skipss:
             continue
         else:
             try:
+                tmp_file_name = create_file_with_cryst(pdbf_path)
                 p = subprocess.Popen(["dssp", tmp_file_name, "--output-format", "dssp"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
                 dssp_raw, errors = p.communicate()
                 dssp_raw = dssp_raw.split('#')[1].split('\n')[1:-1]

--- a/src/haddock/modules/topology/topocg/aa2cg.py
+++ b/src/haddock/modules/topology/topocg/aa2cg.py
@@ -401,21 +401,26 @@ def extract_groups(pair_list):
     out.close()
 
 
-def create_file_with_cryst(pdb_file: str, pdb_file_copy: str) -> None:
+def create_file_with_cryst(output_path: str, pdb_file: str) -> None:
     """
     This function creates a new pdb because the CRYST line is missing from the pdf file.     
     This line is necessary for DSSP.
 
     Args:
+        output: str
         pdb_file: str
-        pdb_file_copy: str
 
     Returns:
+        pdb_file_copy: str
 
     """
+    pdb_file_copy = f"../{output_path}/{pdb_file.split('/')[-1][:-4]}_tmp.pdb"
+    
     with open(pdb_file, "r") as file_in, open(pdb_file_copy, "w") as file_out:
         content = file_in.read()
         file_out.write(CRYST_LINE + content)
+    
+    return(pdb_file_copy)
 
 
 def determine_ss(structure, output_path, skipss, pdbf_path):
@@ -427,12 +432,12 @@ def determine_ss(structure, output_path, skipss, pdbf_path):
         pdbf_path:
 
     Returns:
+        structure:
 
     """
     # calculate SS
     for model in structure:
-        tmp_file_name = f"../{output_path}/{pdbf_path.split('/')[-1][:-4]}_tmp.pdb"
-        create_file_with_cryst(pdbf_path, tmp_file_name)
+        tmp_file_name = create_file_with_cryst(output_path, pdbf_path)
 
         if skipss:
             continue

--- a/src/haddock/modules/topology/topocg/aa2cg.py
+++ b/src/haddock/modules/topology/topocg/aa2cg.py
@@ -422,7 +422,7 @@ def create_file_with_cryst(pdb_file: str) -> None:
     return(file_out.name)
 
 
-def determine_ss(structure, output_path, skipss, pdbf_path):
+def determine_ss(structure, skipss, pdbf_path):
     """
 
     Args:
@@ -534,7 +534,7 @@ def martinize(input_pdb, output_path, skipss):
                     atom.bfactor = 1.0
 
     # Assign HADDOCK code according to SS (1-9)
-    determine_ss(structure=aa_model, output_path = output_path, skipss=skipss, pdbf_path=pdbf_path)
+    determine_ss(structure=aa_model, skipss=skipss, pdbf_path=pdbf_path)
 
     # Strandardize naming
     # WARNING, THIS ASSUMES THAT INPUT DNA/RNA IS 3-LETTER CODE

--- a/src/haddock/modules/topology/topocg/aa2cg.py
+++ b/src/haddock/modules/topology/topocg/aa2cg.py
@@ -401,7 +401,7 @@ def extract_groups(pair_list):
     out.close()
 
 
-def create_file_with_cryst(pdb_file, pdb_file_copy):
+def create_file_with_cryst(pdb_file: str, pdb_file_copy: str) -> None:
     """
     This function creates a new pdb because the CRYST line is missing from the pdf file.     
     This line is necessary for DSSP.

--- a/src/haddock/modules/topology/topocg/aa2cg.py
+++ b/src/haddock/modules/topology/topocg/aa2cg.py
@@ -440,7 +440,7 @@ def determine_ss(structure, output_path, skipss, pdbf_path):
             try:
                 p = subprocess.Popen(["dssp", tmp_file_name, "--output-format", "dssp"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
                 dssp_raw, errors = p.communicate()
-                dssp_raw = dssp_raw.split('#')[1].split('\n')[:-1]
+                dssp_raw = dssp_raw.split('#')[1].split('\n')[1:-1]
                 if Path(tmp_file_name).exists(): Path(tmp_file_name).unlink()
             except:  # TODO: think about making this exception more specific
                 # no secondary structure detected for this model
@@ -454,7 +454,7 @@ def determine_ss(structure, output_path, skipss, pdbf_path):
             if line[11:12] in dssp.keys():
                 dssp[line[11:12]].append(line[16:17])
             else:
-                dssp[line[11:12]] = []
+                dssp[line[11:12]] = [line[16:17]]
 
         calculated_chains = list(set([e[0] for e in dssp.keys()]))
 

--- a/src/haddock/modules/topology/topocg/aa2cg.py
+++ b/src/haddock/modules/topology/topocg/aa2cg.py
@@ -439,12 +439,12 @@ def determine_ss(structure, output_path, skipss, pdbf_path):
         else:
             try:
                 p = subprocess.Popen(["dssp", tmp_file_name, "--output-format", "dssp"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+                dssp_raw, errors = p.communicate()
             except:  # TODO: think about making this exception more specific
                 # no secondary structure detected for this model
                 log.warning('SS could not be assigned, assigning code 1 to all residues')
                 continue
         
-        dssp_raw, errors = p.communicate()
         dssp_raw = dssp_raw.split('#')[1].split('\n')[:-1]
         dssp = {}
 

--- a/src/haddock/modules/topology/topocg/aa2cg.py
+++ b/src/haddock/modules/topology/topocg/aa2cg.py
@@ -412,12 +412,9 @@ def create_file_with_cryst(pdb_file, pdb_file_copy):
     Returns:
 
     """
-    file_in = open(pdb_file, "r")
-    file_out = open(pdb_file_copy, "w")
-    content = file_in.read()
-    file_out.write(CRYST_LINE + content)
-    file_in.close()
-    file_out.close()
+    with open(pdb_file, "r") as file_in, open(pdb_file_copy, "w") as file_out:
+        content = file_in.read()
+        file_out.write(CRYST_LINE + content)
 
 
 def determine_ss(structure, output_path, skipss, pdbf_path):

--- a/src/haddock/modules/topology/topocg/aa2cg.py
+++ b/src/haddock/modules/topology/topocg/aa2cg.py
@@ -21,6 +21,7 @@ import subprocess
 import warnings
 from pathlib import Path
 from haddock import log
+import tempfile
 
 from Bio.PDB import Entity
 from Bio.PDB import PDBIO
@@ -401,7 +402,7 @@ def extract_groups(pair_list):
     out.close()
 
 
-def create_file_with_cryst(output_path: str, pdb_file: str) -> None:
+def create_file_with_cryst(pdb_file: str) -> None:
     """
     This function creates a new pdb because the CRYST line is missing from the pdf file.     
     This line is necessary for DSSP.
@@ -414,13 +415,11 @@ def create_file_with_cryst(output_path: str, pdb_file: str) -> None:
         pdb_file_copy: str
 
     """
-    pdb_file_copy = f"../{output_path}/{pdb_file.split('/')[-1][:-4]}_tmp.pdb"
-    
-    with open(pdb_file, "r") as file_in, open(pdb_file_copy, "w") as file_out:
+    with open(pdb_file, "r") as file_in, tempfile.NamedTemporaryFile(mode = "w", delete=False) as file_out:
         content = file_in.read()
         file_out.write(CRYST_LINE + content)
     
-    return(pdb_file_copy)
+    return(file_out.name)
 
 
 def determine_ss(structure, output_path, skipss, pdbf_path):
@@ -437,7 +436,7 @@ def determine_ss(structure, output_path, skipss, pdbf_path):
     """
     # calculate SS
     for model in structure:
-        tmp_file_name = create_file_with_cryst(output_path, pdbf_path)
+        tmp_file_name = create_file_with_cryst(pdbf_path)
 
         if skipss:
             continue

--- a/src/haddock/modules/topology/topocg/aa2cg.py
+++ b/src/haddock/modules/topology/topocg/aa2cg.py
@@ -455,10 +455,8 @@ def determine_ss(structure, skipss, pdbf_path):
         dssp = {}
 
         for line in dssp_raw:
-            if line[11:12] in dssp.keys():
-                dssp[line[11:12]].append(line[16:17])
-            else:
-                dssp[line[11:12]] = [line[16:17]]
+            var_a, var_b = line[11], line[16]
+            dssp.setdefault(var_a, []).append(var_b)
 
         calculated_chains = list(set([e[0] for e in dssp.keys()]))
 

--- a/src/haddock/modules/topology/topocg/aa2cg.py
+++ b/src/haddock/modules/topology/topocg/aa2cg.py
@@ -24,7 +24,6 @@ from haddock import log
 from Bio.PDB import Entity
 from Bio.PDB import PDBIO
 from Bio.PDB import PDBParser
-from Bio.PDB.DSSP import DSSP
 from Bio.PDB.StructureBuilder import StructureBuilder
 
 from haddock.core.exceptions import ModuleError

--- a/src/haddock/modules/topology/topocg/aa2cg.py
+++ b/src/haddock/modules/topology/topocg/aa2cg.py
@@ -399,6 +399,23 @@ def extract_groups(pair_list):
     out.close()
 
 
+def create_file_with_cryst(pdb_file):
+    """
+    This function creates a pdb because the CRYST line is missing from the pdf file.     
+    This line is necessary for DSSP.
+
+    Args:
+        pdb_file: str
+
+    Returns:
+
+    """
+    file_in = open(pdb_file, "a")
+    file_in.seek(0) # go to the first position of the file
+    file_in.write(CRYST_LINE)
+    file_in.close()
+
+
 def determine_ss(structure, skipss, pdbf_path):
     """
 

--- a/src/haddock/modules/topology/topocg/helper.py
+++ b/src/haddock/modules/topology/topocg/helper.py
@@ -161,6 +161,7 @@ pattypes = {
 }
 
 ss_to_code = {"C": 1,  # Free,
+              " ": 1,
               "S": 2,
               "H": 3,
               "1": 4,


### PR DESCRIPTION
 You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md).

## Checklist

- [ ] Tests added for the new code
- [ ] Documentation added for the code changes
- [ ] Does not break licensing
- [x] Does not add any dependencies, if it does please add a thorough explanation

## Summary of the Pull Request  
Here, I adapt the code to produce DSSP usable pdb files and remove the usage of the DSSP function from the BioPython library, instead using the command line version.

## Related Issue
Not related to an issue

## Additional Info
The warning "No SS definition found for residue: ..." was removed, since if DSSP is installed and works, a secondary structure will be applied. 
I will look into the Codacy reports issues with the aa2cg.py script for a following pull request.
