### PR TITLE
numpy upgrade

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
   'pdb-tools>=2.5.0',
   'biopython==1.*',
   'jsonpickle>=2.1.0',
-  'numpy==1.*',
+  'numpy==2.*',
   'pyyaml>=6.0',
   'scipy>=1.10.0',
   'toml>=0.10.2',

--- a/src/haddock/libs/libinteractive.py
+++ b/src/haddock/libs/libinteractive.py
@@ -31,7 +31,7 @@ def handle_ss_file(
     """
     # now we want to calculate mean and std dev of the scores on df_ss
     # first sort the dataframe by score
-    df_ss.sort_values(by=["score"], inplace=True)
+    df_ss.sort_values(by=["score", "caprieval_rank"], inplace=True)
     # groupby cluster_id
     df_ss_grouped = df_ss.groupby("cluster_id")
     # calculate the mean and standard deviation of the first 4 elements


### PR DESCRIPTION
## Summary of the Pull Request  

- upgrades numpy to 2*
- solves a tie-breaking issue: when the score is equal the pandas sorting in `libinteractive` was giving inconsistent results (depending on the architecture). Adding an additional, unambiguous field (the `caprieval_rank`) to the sorting solves the issue.

## Related Issue
Closes #1092 
