### PR TITLE
fixed analysis on cleaned, downloaded runs

### DIFF
--- a/integration_tests/golden_data/workflow.cfg
+++ b/integration_tests/golden_data/workflow.cfg
@@ -1,0 +1,12 @@
+run_dir = "run"
+molecules = [
+    "prot.pdb",
+    "cyclic-peptide.pdb"
+]
+[topoaa]
+[rigidbody]
+sampling=4
+cmrest=True
+[clustfcc]
+min_population=1
+[caprieval]

--- a/integration_tests/test_full_workflow.py
+++ b/integration_tests/test_full_workflow.py
@@ -47,3 +47,75 @@ def test_emscoring_workflow(caplog, monkeypatch):
         assert os.path.isdir("analysis/1_emscoring_analysis") is True
         # there should be a report.html inside it
         assert os.path.isfile("analysis/1_emscoring_analysis/report.html") is True
+
+
+def test_interactive_analysis_on_workflow(monkeypatch):
+    """A comprehensive test for the interactive commands and analysis."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # copy the files to the temporary directory
+        files = [
+            "cyclic-peptide.pdb",
+            "prot.pdb",
+            "workflow.cfg",
+        ]
+        for fl in files:
+            shutil.copy(
+                Path(GOLDEN_DATA, fl),
+                Path(tmpdir, fl),
+            )
+
+        monkeypatch.chdir(tmpdir)
+
+        from haddock.clis.cli import main as cli_main
+        cli_main(
+            Path("workflow.cfg"),
+        )
+        # read run_dir in workflow.cfg
+        with open("workflow.cfg", "r") as f:
+            for line in f:
+                if "run_dir" in line:
+                    run_dir = line.split("=")[1].strip().strip('"')
+                    break
+        assert os.path.isdir(run_dir) is True
+        assert os.path.isdir(Path(run_dir, "0_topoaa")) is True
+        assert os.path.isdir(Path(run_dir, "1_rigidbody")) is True
+        assert os.path.isdir(Path(run_dir, "2_clustfcc")) is True
+        assert os.path.isdir(Path(run_dir, "3_caprieval")) is True
+        assert os.path.isdir(Path(run_dir, "analysis")) is True
+
+        # now running interactive re-clustering
+        clustfcc_dir = f"{run_dir}/2_clustfcc"
+        from haddock.clis.cli_re import maincli
+        monkeypatch.setattr("sys.argv",
+                            ["haddock3-re", "clustfcc", clustfcc_dir, "-f", "0.7"]
+                            )
+        maincli()
+        assert os.path.isdir(Path(run_dir, "2_clustfcc_interactive")) is True
+        assert Path(run_dir, "2_clustfcc_interactive/clustfcc.tsv").exists() is True
+        assert Path(run_dir, "2_clustfcc_interactive/clustfcc.txt").exists() is True
+        
+        # now running interactive re-scoring
+        capri_dir = f"{run_dir}/3_caprieval"
+        monkeypatch.setattr("sys.argv",
+                            ["haddock3-re", "score", capri_dir, "-a", "1.0"]
+                            )
+        maincli()
+        assert os.path.isdir(Path(run_dir, "3_caprieval_interactive")) is True
+        assert Path(run_dir, "3_caprieval_interactive/capri_ss.tsv").exists() is True
+
+        # now analyse the interactive folders
+        from haddock.clis.cli_analyse import main as cli_analyse
+        cli_analyse(run_dir,
+                    [2,3],
+                    10,
+                    format=None,
+                    scale=None,
+                    is_cleaned=True,
+                    inter=True)
+        exp_clustfcc_dir = Path(run_dir, "analysis", "2_clustfcc_interactive_analysis")
+        exp_caprieval_dir = Path(run_dir, "analysis", "3_caprieval_interactive_analysis")
+        assert os.path.isdir(exp_clustfcc_dir) is True
+        assert os.path.isdir(exp_caprieval_dir) is True
+        assert Path(exp_clustfcc_dir, "report.html").exists() is True
+        assert Path(exp_caprieval_dir, "report.html").exists() is True
+        

--- a/integration_tests/test_full_workflow.py
+++ b/integration_tests/test_full_workflow.py
@@ -86,6 +86,7 @@ def test_interactive_analysis_on_workflow(monkeypatch):
         # now running interactive re-clustering
         clustfcc_dir = f"{run_dir}/2_clustfcc"
         from haddock.clis.cli_re import maincli
+        # faking sys.argv in input to haddock3-re
         monkeypatch.setattr("sys.argv",
                             ["haddock3-re", "clustfcc", clustfcc_dir, "-f", "0.7"]
                             )
@@ -96,6 +97,7 @@ def test_interactive_analysis_on_workflow(monkeypatch):
         
         # now running interactive re-scoring
         capri_dir = f"{run_dir}/3_caprieval"
+        # faking sys.argv in input to haddock3-re
         monkeypatch.setattr("sys.argv",
                             ["haddock3-re", "score", capri_dir, "-a", "1.0"]
                             )

--- a/src/haddock/clis/cli_analyse.py
+++ b/src/haddock/clis/cli_analyse.py
@@ -268,7 +268,7 @@ def run_capri_analysis(
     io.load(filename)
     # unpack the files if they are compressed
     if is_cleaned:
-        path_to_unpack = io.output[0].path
+        path_to_unpack = io.output[0].rel_path.parent
         haddock3_unpack(path_to_unpack, ncores=ncores)
     # define step_order. We add one to it, as the caprieval module will
     # interpret itself as being after the selected step
@@ -277,7 +277,7 @@ def run_capri_analysis(
     caprieval_module = HaddockModule(
         order=step_order,
         path=Path(run_dir),
-        initial_params=caprieval_params,
+        init_params=caprieval_params,
     )
     caprieval_module.update_params(**capri_dict)
     # updating mode and ncores


### PR DESCRIPTION
## Checklist

- [x] Tests added for the new code
- [x] Documentation added for the code changes
- [x] Does not break licensing
- [x] Does not add any dependencies, if it does please add a thorough explanation

## Related Issue
Closes #1122 by changing the absolute path to the step folder to be analysed with the relative path. This allows the analysis to be executed on every "cleaned" run (before it was only working for standard, not cleaned runs)

Additionally, a quite comprehensive integration test is being added, in which a short but full workflow is executed including cleaning and analysis. Then two interactive commands are executed (`haddock3-re clustfcc` and `haddock3-re score`) and checked. Last, the two newly created interactive folders are analysed and the code checks for the existence of the expected report.