### PR TITLE
Solves issue #1119 related to MPI execution with mpirun or run

### DIFF
--- a/src/haddock/libs/libmpi.py
+++ b/src/haddock/libs/libmpi.py
@@ -10,6 +10,7 @@ from shutil import which
 from haddock import log
 from haddock.core.exceptions import HaddockTermination
 
+
 class MPIScheduler:
     """Schedules tasks to be executed via MPI."""
 

--- a/tests/test_libmpi.py
+++ b/tests/test_libmpi.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from haddock.libs.libmpi import MPIScheduler
+from haddock.core.exceptions import HaddockTermination
 
 
 @pytest.fixture
@@ -64,8 +65,9 @@ def test_mpischduler_run(mocker, mpischeduler):
 
     # Test error case
     mock_process.stderr.decode.return_value = "Error occurred"
-    mpischeduler.run()
-    mock_sys_exit.assert_called_once()
+    with pytest.raises(HaddockTermination) as e:
+        nothing = mpischeduler.run()
+        assert nothing is None
 
 
 def test__pickle_tasks(mpischeduler):


### PR DESCRIPTION
 You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md).

## Checklist

- [ ] Tests added for the new code
- [ ] Documentation added for the code changes
- [X] Does not break licensing
- [x] Does not add any dependencies, if it does please add a thorough explanation

It does add `setuptools` as dependency. Present by default in Python3.9 but not 3.12

## Summary of the Pull Request  

This pull request modifies the `lipmpi.py` to check for the presence of `mpirun` and if not found for `srun` instead (as used on the Lumi HPC system). 

## Related Issue

Issue #1119 
