### PR TITLE
refactored check for chain combinations

### DIFF
--- a/src/haddock/libs/libcns.py
+++ b/src/haddock/libs/libcns.py
@@ -13,6 +13,7 @@ from haddock.libs import libpdb
 from haddock.libs.libfunc import false, true
 from haddock.libs.libmath import RandomNumberGenerator
 from haddock.libs.libontology import PDBFile
+from haddock.libs.libpdb import check_combination_chains
 from haddock.libs.libutil import transform_to_list
 
 
@@ -335,25 +336,14 @@ def prepare_cns_input(
     # prepare chain/seg IDs
     segid_str = ""
     if native_segid:
-        chainid_list: list[str] = []
         if isinstance(input_element, (list, tuple)):
-            for pdb in input_element:
-
-                segids, chains = libpdb.identify_chainseg(pdb.rel_path, sort=False)
-
-                chainsegs = sorted(list(set(segids) | set(chains)))
-                # check if any of chainsegs is already in chainid_list
-                if not identifier.endswith("scoring"):
-                    if any(chainseg in chainid_list for chainseg in chainsegs):
-                        raise ValueError(
-                            f"Chain/seg IDs are not unique for pdbs {input_element}."
-                        )
-                chainid_list.extend(chainsegs)
+            chainid_list = check_combination_chains(input_element)
 
             for i, _chainseg in enumerate(chainid_list, start=1):
                 segid_str += write_eval_line(f"prot_segid_{i}", _chainseg)
 
         else:
+            chainid_list: list[str] = []
             segids, chains = libpdb.identify_chainseg(
                 input_element.rel_path, sort=False
             )

--- a/src/haddock/libs/libpdb.py
+++ b/src/haddock/libs/libpdb.py
@@ -17,7 +17,7 @@ from haddock.core.typing import (
     Optional,
     Union,
     )
-from haddock.libs.libio import working_directory
+from haddock.libs.libio import working_directory, PDBFile
 from haddock.libs.libutil import get_result_or_same_in_list, sort_numbered_paths
 
 
@@ -296,3 +296,18 @@ def read_RECORD_section(
 
 read_chainids = partial(read_RECORD_section, section_slice=slc_chainid, func=list)  # noqa: E501
 read_segids = partial(read_RECORD_section, section_slice=slc_segid, func=list)
+
+
+def check_combination_chains(combination: list[PDBFile]) -> list[str]:
+    """Check if chain IDs are unique for each pdb in combination."""
+    chainid_list: list[str] = []
+    for pdb in combination:
+        segids, chains = identify_chainseg(pdb.rel_path, sort=False)
+        chainsegs = sorted(list(set(segids) | set(chains)))
+        # check if any of chainsegs is already in chainid_list
+        if any(chainseg in chainid_list for chainseg in chainsegs):
+            raise ValueError(
+                f"Chain/seg IDs are not unique for pdbs {combination}."
+            )
+        chainid_list.extend(chainsegs)
+    return chainid_list

--- a/src/haddock/modules/sampling/rigidbody/__init__.py
+++ b/src/haddock/modules/sampling/rigidbody/__init__.py
@@ -38,6 +38,7 @@ from haddock.gear.haddockmodel import HaddockModel
 from haddock.libs.libcns import prepare_cns_input
 from haddock.libs.libontology import PDBFile
 from haddock.libs.libparallel import GenericTask, Scheduler
+from haddock.libs.libpdb import check_combination_chains
 from haddock.libs.libsubprocess import CNSJob
 from haddock.modules import get_engine
 from haddock.modules.base_cns_module import BaseCNSModule
@@ -132,6 +133,7 @@ class HaddockModule(BaseCNSModule):
         _l = []
         idx = 1
         for combination in models_to_dock:
+            check_combination_chains(combination)
             for _ in range(sampling_factor):
                 ambig_fname = (
                     ambig_fnames[idx - 1]

--- a/tests/test_libpdb.py
+++ b/tests/test_libpdb.py
@@ -1,8 +1,12 @@
 """Test lib PDB."""
+from pathlib import Path
 import pytest
 
-from haddock.libs import libpdb
 
+from haddock.libs import libpdb
+from haddock.libs.libio import PDBFile
+
+from . import golden_data
 
 chainC = [
     'ATOM      3  CA  ARG C   4      37.080  43.455  -3.421  1.00  0.00      C    C  ',  # noqa: E501
@@ -31,3 +35,28 @@ def test_read_chain_ids(lines, expected):
 def test_read_seg_ids(lines, expected):
     result = libpdb.read_segids(lines)
     assert result == expected
+
+
+@pytest.fixture(name="wrong_rigid_molecules")
+def fixture_wrong_rigidbody_molecules():
+    """fixture for wrong rigidbody input molecules."""
+    receptor = PDBFile(Path(golden_data, "protprot_complex_1.pdb"))
+    ligand = PDBFile(Path(golden_data, "protprot_complex_2.pdb"))
+    return [receptor, ligand]
+
+@pytest.fixture(name="good_rigid_molecules")
+def fixture_good_rigidbody_molecules():
+    """fixture for good rigidbody input molecules."""
+    receptor = PDBFile(Path(golden_data, "e2aP_1F3G_haddock.pdb"))
+    ligand = PDBFile(Path(golden_data, "hpr_ensemble_1_haddock.pdb"))
+    return [receptor, ligand]
+
+def test_check_combination_chains(good_rigid_molecules, wrong_rigid_molecules):
+    """Test check_combination_chains."""
+    exp_chains = ["A", "B"]
+    obs_chains = libpdb.check_combination_chains(good_rigid_molecules)
+    assert obs_chains == exp_chains
+    # when input molecules share chains there should be a ValueError
+    with pytest.raises(ValueError):
+        libpdb.check_combination_chains(wrong_rigid_molecules)
+    


### PR DESCRIPTION
## Checklist

- [x] Tests added for the new code
- [ ] Documentation added for the code changes
- [x] Does not break licensing
- [x] Does not add any dependencies, if it does please add a thorough explanation

## Summary of the Pull Request  
adds a check for duplicated chains for any possible combination of molecules at the rigidbody level even when the job preparation is done in parallel. If an error is detected, the workflow stops without executing any computation.

## Related Issue
Closes #1177 
