### PR TITLE
allow for digit fluctuation in mdscoring integration tests

### DIFF
--- a/integration_tests/test_mdscoring.py
+++ b/integration_tests/test_mdscoring.py
@@ -93,4 +93,5 @@ def test_mdscoring_default(mdscoring_module, calc_fnat):
     assert expected_interface_csv.exists(), f"{expected_interface_csv} does not exist"
     df_perint = pd.read_csv(expected_interface_csv, sep="\t", comment="#")
     # check that the score is equal to the global score (it's a dimer!)
-    assert df_perint["score"].tolist() == df["score"].tolist()
+    for perint, sc in zip(df_perint["score"].tolist(), df["score"].tolist()):
+        assert perint == pytest.approx(sc, abs=0.01)


### PR DESCRIPTION
## Checklist

- [X] Tests added for the new code
- [ ] Documentation added for the code changes
- [ ] Does not break licensing
- [ ] Does not add any dependencies, if it does please add a thorough explanation

## Summary of the Pull Request  

Allow for `0.01` digit fluctuation when comparing haddock score and per-interface score in `integration-tests/test_mdscoring.py`.

## Related Issue

Closes #1184 

