### PR TITLE
>=X.Y to ==X.*

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,10 +43,10 @@ dependencies = [
   'scipy>=1.10.0',
   'toml>=0.10.2',
   'pandas==2.*',
-  'prodigy-prot>=2',
-  'prodigy-lig>=1.1',
+  'prodigy-prot==2.*',
+  'prodigy-lig==1.*',
   'plotly==6.0.1',
-  'freesasa>=2.2.1',
+  'freesasa==2.*',
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary of the Pull Request  

Modifies the `pyproject.toml` dependencies from:
`package>=X.Y`
to 
`package==X.*`
for `pdb-tools`, `prodigy-lig` and `prodigy-prot`

## Related Issue
<!-- If this PR is related to an issue, please link it here -->

