### PR TITLE
modify entry point for prodigy prot

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
   'scipy>=1.10.0',
   'toml>=0.10.2',
   'pandas==2.*',
-  'prodigy-prot>=2',
+  'prodigy-prot==2.3.0',
   'prodigy-lig>=1.1',
   'plotly==6.0.1',
   'freesasa>=2.2.1',

--- a/src/haddock/modules/scoring/prodigyprotein/prodigy.py
+++ b/src/haddock/modules/scoring/prodigyprotein/prodigy.py
@@ -48,7 +48,8 @@ class ProdigyProtein(ProdigyWorker):
         deltaG : float
             The computed DeltaG of the input complex.
         """
-        from prodigy_prot.predict_IC import parse_structure, Prodigy
+        from prodigy_prot.modules.prodigy import Prodigy
+        from prodigy_prot.modules.parsers import parse_structure
         structure, _n_chains, _n_res = parse_structure(self.model)
         prodigy = Prodigy(structure, self.chains, self.temperature)
         prodigy.predict(


### PR DESCRIPTION
## Summary of the Pull Request  

Prodigy code base was refactored, therefore it was needed to modify the calls in haddock3 too.
Also pin the version `==2.3.0` in pyproject.toml to make sure it will last longer

## Related Issue

https://github.com/haddocking/prodigy/commit/f7db1ce86392a1ad7907b805817e12a8a272cdf7
Closes #1251
