### PR TITLE
add schedule to `ci.yml`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
     branches: [main]
   pull_request:
   workflow_dispatch: ~
+  schedule:
+    - cron: "0 */6 * * *" # every 6 hours
 
 jobs:
   ci:


### PR DESCRIPTION
Update the CI to be run on an interval - this should help us react faster to issues such as #1251 or other breaking changes upstream