### PR TITLE
Added link to BioExcel 2025 survey

### DIFF
--- a/src/haddock/gear/greetings.py
+++ b/src/haddock/gear/greetings.py
@@ -31,7 +31,7 @@ international_good_byes = [
 feedback_urls = {
     "GitHub issues": "https://github.com/haddocking/haddock3/issues",
     "BioExcel feedback": "https://www.bonvinlab.org/feedback",
-    # "BioExcel survey": "https://bioexcel.eu/bioexcel-survey-2024/",
+    "BioExcel survey": "https://bioexcel.eu/bioexcel-survey-2025/",
     "BioExcel forum": "https://ask.bioexcel.eu/c/haddock/6",
 }
 


### PR DESCRIPTION
Extremely minor change: linked https://bioexcel.eu/bioexcel-survey-2025/ instead of 2024 one in greetings.py