### PR TITLE
removed verbose log call from seletopclusts

### DIFF
--- a/src/haddock/modules/analysis/seletopclusts/seletopclusts.py
+++ b/src/haddock/modules/analysis/seletopclusts/seletopclusts.py
@@ -77,11 +77,6 @@ def select_top_clusts_models(
         else:
             # Loop over first `top_models` models
             for pdb in clt_mdls[:top_models]:
-                notes.append(
-                    f" {pdb.file_name} "
-                    f"> cluster_{pdb.clt_rank}_"
-                    f"model_{pdb.clt_model_rank}.pdb"
-                    )
                 models_to_export.append(pdb)
     return models_to_export, notes
 


### PR DESCRIPTION
## Checklist

- [ ] Tests added for the new code
- [ ] Documentation added for the code changes
- [ ] Modifications / enhancements are reflected on the [haddock3 user-manual](https://github.com/haddocking/haddock3-user-manual)
- [ ] `CHANGELOG.md` is updated to incorporate new changes
- [x] Does not break licensing
- [x] Does not add any dependencies, if it does please add a thorough explanation

## Related Issue
Closes #1264 by removing the verbose model mapping log call.
