### PR TITLE
make deepcopy of molecule params so they can be used multiple times

### DIFF
--- a/src/haddock/modules/topology/topoaa/__init__.py
+++ b/src/haddock/modules/topology/topoaa/__init__.py
@@ -26,6 +26,7 @@ them on the fly.
 import operator
 import os
 import re
+from copy import deepcopy
 from functools import partial
 from pathlib import Path
 
@@ -229,7 +230,7 @@ class HaddockModule(BaseCNSModule):
             origi_ens_dic[i] = self.get_ensemble_origin(molecule.with_parent)
             # nice variable name, isn't it? :-)
             # molecule parameters are shared among models of the same molecule
-            parameters_for_this_molecule = mol_params[mol_params_get()]
+            parameters_for_this_molecule = deepcopy(mol_params[mol_params_get()])
 
             # Extract termini parameters
             charged_nter = parameters_for_this_molecule.pop("charged_nter")


### PR DESCRIPTION
 You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md).

## Checklist

- [ ] Tests added for the new code
- [ ] Documentation added for the code changes
- [ ] Modifications / enhancements are reflected on the [haddock3 user-manual](https://github.com/haddocking/haddock3-user-manual)
- [ ] `CHANGELOG.md` is updated to incorporate new changes
- [ ] Does not break licensing
- [ ] Does not add any dependencies, if it does please add a thorough explanation

## Summary of the Pull Request  

PR #1273  added a bug when importing ensembles.
This PR solves this issue by creating a copy of the parameters for the molecules during `topoaa`, therefore allowing to use the `.pop` method without touching the initial parameters.

## Related Issue

Closes #1296


