### PR TITLE
installing mpi in a separated optinal dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           sudo apt-get install -y openmpi-bin libopenmpi3 libopenmpi-dev
 
       - name: install haddock3 with extra dependencies
-        run: pip install '.[dev,docs]'
+        run: pip install '.[mpi,dev,docs]'
 
       - name: run unit tests
         run: >-

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -30,6 +30,9 @@ pip install .
 To use the mpi implementation of haddock3 you must have mpi4py installed in the `(haddock3)` python environment, and OpenMPI in the host system.
 
 ```bash
+# Install the mpi optional set of library when installing haddock3
+$ pip install ".[mpi]"
+# or
 $ pip install mpi4py
 # or
 $ conda install -c conda-forge mpi4py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,9 +58,11 @@ dev = [
   "pytest-mock==3.14.1",
   "fastapi==0.115.12",
   "httpx==0.28.1",
-  "mpi4py==4.0.3",
   "kaleido==0.2.1",
   "pytest-random-order==1.1.1",
+]
+mpi = [
+  "mpi4py==4.0.3",
 ]
 docs = [
   "sphinx>=7",


### PR DESCRIPTION
## Checklist

- [ ] Tests added for the new code
- [ ] Documentation added for the code changes
- [ ] Modifications / enhancements are reflected on the [haddock3 user-manual](https://github.com/haddocking/haddock3-user-manual)
- [ ] `CHANGELOG.md` is updated to incorporate new changes
- [x] Does not break licensing
- [ ] Does not add any dependencies, if it does please add a thorough explanation

## Summary of the Pull Request  

Placing the installation of mpi in an additional optional dependency at installation time.
Now, to install mpi, the user should run:
`pip install ".[mpi]"`, as it as already made for the `dev` and `docs`.

## Related Issue

Closes #1283

