### PR TITLE
computing std dev in alascan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@
 - 2025-06-06: Added selection of Nter, Cter and 5'end states at topology generation - Issue #1269
 - 2025-12-06: Added new restrain_ligand sub-command in the haddock3-restraints CLI - Issue #1299
 - 2025-07-23: Added printing of covalent energies to the PDB headers - Issue #1323
+- 2025-07-24: Added computation of standard deviation in alascan cluster analyses - Issue #1332

--- a/integration_tests/test_alascan.py
+++ b/integration_tests/test_alascan.py
@@ -77,7 +77,7 @@ def test_alascan_default(alascan_module, mocker):
 
     expected_csv1 = Path(alascan_module.path, "scan_protprot_complex_1.tsv")
     expected_csv2 = Path(alascan_module.path, "scan_protprot_complex_2.tsv")
-    expected_clt_csv = Path(alascan_module.path, "scan_clt_-.tsv")
+    expected_clt_csv = Path(alascan_module.path, "scan_clt_unclustered.tsv")
 
     assert expected_csv1.exists(), f"{expected_csv1} does not exist"
     assert expected_csv2.exists(), f"{expected_csv2} does not exist"
@@ -89,9 +89,9 @@ def test_alascan_default(alascan_module, mocker):
     # ARG 17 B should have a negative delta_score
     assert df.loc[df["ori_resname"] == "ARG"].iloc[0, :]["delta_score"] < 0.0
 
-    # check clt csv
+    # check cluster csv
     df_clt = pd.read_csv(expected_clt_csv, sep="\t", comment="#")
-    assert df_clt.shape == (18, 11), f"{expected_clt_csv} has wrong shape"
+    assert df_clt.shape == (18, 16), f"{expected_clt_csv} has wrong shape"
     # average delta score of A-38-ASP should be negative
     assert (
         df_clt.loc[df_clt["full_resname"] == "A-38-ASP"].iloc[0, :]["delta_score"] < 0.0
@@ -106,7 +106,7 @@ def test_alascan_single_model(alascan_module, mocker):
     alascan_module.run()
 
     expected_csv = Path(alascan_module.path, "scan_2oob.tsv")
-    expected_clt_csv = Path(alascan_module.path, "scan_clt_-.tsv")
+    expected_clt_csv = Path(alascan_module.path, "scan_clt_unclustered.tsv")
 
     assert expected_csv.exists(), f"{expected_csv} does not exist"
     assert expected_clt_csv.exists(), f"{expected_clt_csv} does not exist"

--- a/src/haddock/libs/libplots.py
+++ b/src/haddock/libs/libplots.py
@@ -1414,7 +1414,7 @@ def make_alascan_plot(
         clt_id: int,
         scan_res: str = "ALA",
         offline: bool = False,
-        ) -> None:
+        ) -> str:
     """
     Make a plotly interactive plot.
 
@@ -1429,6 +1429,11 @@ def make_alascan_plot(
         Cluster ID.
     scan_res : str, optional
         Residue name used for the scan, by default "ALA"
+    
+    Returns
+    -------
+    html_output_filename : str
+        Name of the plot generated
     """
     plot_name = f"scan_clt_{clt_id}"
     log.info(f"Generating {scan_res} scanning plot {plot_name}")
@@ -1437,18 +1442,21 @@ def make_alascan_plot(
     width, height = 2000, 1000
     fig = go.Figure(layout={"width": width, "height": height})
     # add traces
+    # Delta HADDOCK score
     fig.add_trace(
         go.Bar(
             x=df["full_resname"],
             y=df["delta_score"],
+            error_y={"type": "data", "array": df["delta_score_std"]},
             name="delta_score",
             )
         )
-    
+    # Delta VdW
     fig.add_trace(
         go.Bar(
             x=df["full_resname"],
             y=df["delta_vdw"],
+            error_y={"type": "data", "array": df["delta_vdw_std"]},
             name="delta_vdw",
             )
         )
@@ -1457,37 +1465,46 @@ def make_alascan_plot(
         go.Bar(
             x=df["full_resname"],
             y=0.2 * df["delta_elec"],
+            error_y={"type": "data", "array": df["delta_elec_std"]},
             name="delta_elec",
             )
         )
-
+    # Delta desolvation score
     fig.add_trace(
         go.Bar(
             x=df["full_resname"],
             y=df["delta_desolv"],
+            error_y={"type": "data", "array": df["delta_desolv_std"]},
             name="delta_desolv",
             )
         )
     # prettifying layout
     fig.update_layout(
         title=f"{scan_res} scanning cluster {clt_id}",
-        xaxis=dict(
-            title=dict(text="Residue Name", font=dict(size=16)),
-            tickfont_size=14,
-            tick0=df["full_resname"],
+        xaxis={
+            "title": {"text": "Residue Name", "font": {"size": 16}},
+            "tickfont_size": 14,
+            "tick0": df["full_resname"],
             # in case we want to show less residues
-            # dtick=10,
-            ),
-        yaxis=dict(
-            title=dict(text="Average Delta (WT - mutant)", font=dict(size=16)),
-            tickfont_size=14,
-            ),
-        legend=dict(x=1.01, y=1.0, font_family="Helvetica", font_size=16),
+            # "dtick": 10,
+            },
+        yaxis={
+            "title": {
+                "text": "Average Delta (WT - mutant)",
+                "font": {"size": 16}
+                },
+            "tickfont_size": 14,
+            },
+        legend={
+            "x": 1.01, "y": 1.0,
+            "font_family": "Helvetica",
+            "font_size": 16
+            },
         barmode="group",
         bargap=0.05,
         bargroupgap=0.05,
         hovermode="x unified",
-        hoverlabel=dict(font_size=16, font_family="Helvetica"),
+        hoverlabel={"font_size": 16, "font_family": "Helvetica"},
         )
     for n in range(df.shape[0] - 1):
         fig.add_vline(x=0.5 + n, line_color="gray", opacity=0.2)
@@ -1501,6 +1518,7 @@ def make_alascan_plot(
         figure_width=width,
         offline=offline,
         )
+    return html_output_filename
 
 
 def fig_to_html(

--- a/src/haddock/modules/analysis/alascan/scan.py
+++ b/src/haddock/modules/analysis/alascan/scan.py
@@ -276,7 +276,7 @@ def alascan_cluster_analysis(models):
         if cl_id not in clt_scan:
             clt_scan[cl_id] = {}
             cl_pops[cl_id] = 0
-        # Increase the popultation of that cluster
+        # Increase the population of that cluster
         cl_pops[cl_id] += 1
         # read the scan file
         alascan_fname = f"scan_{native.file_name.removesuffix('.pdb')}.tsv"

--- a/tests/test_libplots.py
+++ b/tests/test_libplots.py
@@ -232,8 +232,14 @@ def example_capri_ss_dashcluster():
 def example_df_scan_clt():
     """Return example alascan clt DataFrame."""
     example_clt_data = [
-        ["A", 38, "ASP", "A-38-ASP", -2.0, -1.0, -0.4, -2.3, -0.5, -7.2, 1.0],
-        ["A", 69, "LYS", "A-38-ASP", -0.0, 1.0, -0.4, 0.8, 0.5, -7.2, 1.0],
+        [
+            "A", 38, "ASP", "A-38-ASP", -2.0, -1.0, 0.1, -0.4, 0.04, -2.3,
+            0.23, -0.5, 0.05, -7.2, 0.72, 1.0,
+        ],
+        [
+            "A", 69, "LYS", "A-38-ASP", -0.0, 1.0, 0.1, -0.4, 0.04, -2.3,
+            0.23, -0.5, 0.05, -7.2, 0.72, 1.0,
+        ],
     ]
     columns = [
         "chain",
@@ -242,10 +248,15 @@ def example_df_scan_clt():
         "full_resname",
         "score",
         "delta_score",
+        "delta_score_std",
         "delta_vdw",
+        "delta_vdw_std",
         "delta_elec",
+        "delta_elec_std",
         "delta_desolv",
+        "delta_desolv_std",
         "delta_bsa",
+        "delta_bsa_std",
         "frac_pres",
     ]
 

--- a/tests/test_module_alascan.py
+++ b/tests/test_module_alascan.py
@@ -270,8 +270,8 @@ def test_run(
     )
 
     alascan.run()
-    assert Path(alascan.path, "scan_clt_-.tsv").exists()
-    assert Path(alascan.path, "scan_clt_-.html").exists()
+    assert Path(alascan.path, "scan_clt_unclustered.tsv").exists()
+    assert Path(alascan.path, "scan_clt_unclustered.html").exists()
 
 
 def test_scanjob_run(scanjob_obj, mocker):
@@ -378,13 +378,13 @@ def test_alascan_cluster_analysis(protprot_input_list, scan_file, monkeypatch):
         shutil.copy(scan_file, Path("scan_protprot_complex_2.tsv"))
         alascan_cluster_analysis(protprot_input_list)
 
-        assert Path("scan_clt_-.tsv").exists()
+        assert Path("scan_clt_unclustered.tsv").exists()
 
         protprot_input_list[1].clt_id = 1
         alascan_cluster_analysis(protprot_input_list)
 
         assert Path("scan_clt_1.tsv").exists()
-        assert Path("scan_clt_-.tsv").exists()
+        assert Path("scan_clt_unclustered.tsv").exists()
 
 
 def test_create_alascan_plots(mocker, caplog):


### PR DESCRIPTION
## Checklist

- [x] Tests added for the new code
- [ ] Documentation added for the code changes
- [ ] Modifications / enhancements are reflected on the [haddock3 user-manual](https://github.com/haddocking/haddock3-user-manual)
- [ ] `CHANGELOG.md` is updated to incorporate new changes
- [x] Does not break licensing
- [x] Does not add any dependencies, if it does please add a thorough explanation

## Summary of the Pull Request  

This PR adds standard deviation computation when performing cluster analysis in the `alascan` module.
- [X] The raw output file (`scan_clt_*.tsv`) now contain the standard deviation for all components of the score.
- [X] The naming of the unclustered file is modified to `scan_clt_unclustered` (from `scan_clt_-`)
- [x] Generated plots also contain the error bars

## Related Issue

Closes #1332
<!-- If this PR is related to the haddock3 user manual, please link the PR here -->

## Additional Info
<!-- Any additional information that might be helpful, if applicable -->
