### PR TITLE
distribute `haddock-restraints` binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,8 +137,12 @@ tags
 # VSCode
 .vscode
 
-## Specific to this project
-bin/cns
+# Binaries
+src/haddock/bin/cns
+src/haddock/bin/contact_fcc
+src/haddock/bin/fast-rmsdmatrix
+src/haddock/bin/haddock-restraints
+
 # ignore generated data of the examples
 examples/*/run*
 examples/*/capriscoring-test/*
@@ -154,5 +158,4 @@ docs/haddock.modules.rst
 docs/haddock.modules.base_cns_module.rst
 docs/setup.rst
 docs/clients/*rst
-src/haddock/bin/
 log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- 2025-08-25: Distribute the `haddock-restraints` binary
 - 2025-08-22: Added check for max/min possible coordinates in CNS scripts - Issue #1350
 - 2025-08-17: Combined bumps of packages version (coverage, hypothesis, pytest-random-order and kaleido)
 - 2025-08-06: Adding guardrail in rigidbody module when no restraints provided - Issue #1345

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "haddock3"
-version = "2025.8.0"
+version = "2025.8.1"
 description = "HADDOCK3"
 readme = "README.md"
 authors = [{ name = "BonvinLab", email = "bonvinlab.support@uu.nl" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,9 +69,7 @@ docs = [
   "mock>=5.1.0",
   "myst-parser>=3.0.1",
 ]
-mpi = [
-  "mpi4py==4.1.0",
-]
+mpi = ["mpi4py==4.1.0"]
 
 [project.urls]
 Homepage = "https://github.com/haddocking/haddock3"
@@ -93,6 +91,7 @@ haddock3-analyse = "haddock.clis.cli_analyse:maincli"
 haddock3-traceback = "haddock.clis.cli_traceback:maincli"
 haddock3-re = "haddock.clis.cli_re:maincli"
 haddock3-restraints = "haddock.clis.cli_restraints:maincli"
+haddock-restraints = "haddock.clis.wrapper_haddock_restraints:main"
 
 [tool.setuptools]
 packages = ["haddock"]

--- a/setup.py
+++ b/setup.py
@@ -5,12 +5,12 @@ import os
 import platform
 import subprocess
 import sys
+import tarfile
 import urllib.request
 from pathlib import Path
 
 from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext
-
 
 CNS_BINARIES = {
     "x86_64-linux": "https://surfdrive.surf.nl/files/index.php/s/BWa5OimzbNliTi6/download",
@@ -18,6 +18,16 @@ CNS_BINARIES = {
     "arm64-darwin": "https://surfdrive.surf.nl/files/index.php/s/bYB3xPWf7iwo07X/download",
     "aarch64-linux": "https://surfdrive.surf.nl/files/index.php/s/3rHpxcufHGrntHn/download",
 }
+
+HADDOCK_RESTRAINTS_VERSION = "0.9.0"
+BASE_GITHUB_URL = f"https://github.com/haddocking/haddock-restraints/releases/download/v{HADDOCK_RESTRAINTS_VERSION}"
+HADDOCK_RESTRAINTS_BINARIES = {
+    "x86_64-linux": f"{BASE_GITHUB_URL}/haddock-restraints-v{HADDOCK_RESTRAINTS_VERSION}-x86_64-unknown-linux-gnu.tar.gz",
+    "x86_64-darwin": f"{BASE_GITHUB_URL}/haddock-restraints-v{HADDOCK_RESTRAINTS_VERSION}-x86_64-apple-darwin.tar.gz",
+    "arm64-darwin": f"{BASE_GITHUB_URL}/haddock-restraints-v{HADDOCK_RESTRAINTS_VERSION}-aarch64-apple-darwin.tar.gz",
+    "aarch64-linux": f"{BASE_GITHUB_URL}/haddock-restraints-v{HADDOCK_RESTRAINTS_VERSION}-aarch64-unknown-linux-gnu.tar.gz",
+}
+
 
 cpp_extensions = [
     Extension(
@@ -39,27 +49,27 @@ class CustomBuild(build_ext):
 
     def run(self):
         """Run the custom build"""
-        print("Building HADDOCK3 C/C++ binary dependencies...")
-        self.build_executable(
-            name="contact_fcc",
-            cmd=["g++", "-O2", "-o", "contact_fcc", "src/haddock/deps/contact_fcc.cpp"],
-        )
-        self.build_executable(
-            name="fast-rmsdmatrix",
-            cmd=[
-                "gcc",
-                "-Wall",
-                "-O3",
-                "-march=native",
-                "-std=c99",
-                "-o",
-                "fast-rmsdmatrix",
-                "src/haddock/deps/fast-rmsdmatrix.c",
-                "-lm",
-            ],
-        )
-        print("Downloading the CNS binary...")
-        self.download_cns()
+        # print("Building HADDOCK3 C/C++ binary dependencies...")
+        # self.build_executable(
+        #     name="contact_fcc",
+        #     cmd=["g++", "-O2", "-o", "contact_fcc", "src/haddock/deps/contact_fcc.cpp"],
+        # )
+        # self.build_executable(
+        #     name="fast-rmsdmatrix",
+        #     cmd=[
+        #         "gcc",
+        #         "-Wall",
+        #         "-O3",
+        #         "-march=native",
+        #         "-std=c99",
+        #         "-o",
+        #         "fast-rmsdmatrix",
+        #         "src/haddock/deps/fast-rmsdmatrix.c",
+        #         "-lm",
+        #     ],
+        # )
+        print("Downloading the binaries...")
+        self.download_binaries()
 
         # Run the standard build
         build_ext.run(self)
@@ -90,34 +100,54 @@ class CustomBuild(build_ext):
             print(f"Error building {name}: {e}")
             raise
 
-    def download_cns(self):
-        """Helper function to download the CNS binary"""
-
+    def download_binaries(self):
+        """Helper function to download binaries"""
         arch = self.get_arch()
+        binary_configs = [
+            (HADDOCK_RESTRAINTS_BINARIES, Path("haddock-restraints.tar.gz")),
+            (CNS_BINARIES, Path("cns")),
+        ]
 
-        if arch not in CNS_BINARIES:
-            print(f"Unknown architecture: {arch}")
-            sys.exit(1)
-
-        cns_binary_url = CNS_BINARIES[arch]
-
-        src_bin_dir = Path("src", "haddock", "bin")
-        src_bin_dir.mkdir(exist_ok=True, parents=True)
-
-        cns_exec = Path(src_bin_dir, "cns")
-        status, msg = self.download_file(cns_binary_url, cns_exec)
-        if not status:
-            print(msg)
-            sys.exit(1)
-
-        # Make it executable
-        os.chmod(cns_exec, 0o755)
-
-        # If build_lib exists, also copy to there
+        # Determine the target directory
         if hasattr(self, "build_lib"):
-            install_bin_dir = Path(self.build_lib, "haddock", "bin")
-            install_bin_dir.mkdir(exist_ok=True, parents=True)
-            self.copy_file(cns_exec, Path(install_bin_dir, "cns"))
+            target_bin_dir = Path(self.build_lib, "haddock", "bin")
+        else:
+            target_bin_dir = Path("src", "haddock", "bin")
+
+        target_bin_dir.mkdir(exist_ok=True, parents=True)
+
+        for binary_dict, filename in binary_configs:
+            if arch not in binary_dict:
+                print(f"Unknown architecture: {arch}")
+                sys.exit(1)
+            binary_url = binary_dict[arch]
+
+            download_path = Path(target_bin_dir, filename.name)
+            status, msg = self.download_file(binary_url, download_path)
+            if not status:
+                print(msg)
+                sys.exit(1)
+
+            if "".join(filename.suffixes) == ".tar.gz":
+                try:
+                    with tarfile.open(download_path, "r:gz") as tar:
+                        tar.extractall(path=target_bin_dir)
+                    # Remove the compressed file
+                    download_path.unlink()
+                    # The executable should be the filename without .tar.gz suffixes
+                    executable = Path(
+                        target_bin_dir, filename.with_suffix("").with_suffix("").name
+                    )
+                except tarfile.TarError as e:
+                    print(f"Error extracting {download_path}: {e}")
+                    sys.exit(1)
+            else:
+                executable = download_path
+
+            print(f"Downloaded {filename} to {executable}")
+
+            # Make it executable
+            os.chmod(executable, 0o755)
 
     @staticmethod
     def download_file(url, dest) -> tuple[bool, str]:

--- a/setup.py
+++ b/setup.py
@@ -49,25 +49,25 @@ class CustomBuild(build_ext):
 
     def run(self):
         """Run the custom build"""
-        # print("Building HADDOCK3 C/C++ binary dependencies...")
-        # self.build_executable(
-        #     name="contact_fcc",
-        #     cmd=["g++", "-O2", "-o", "contact_fcc", "src/haddock/deps/contact_fcc.cpp"],
-        # )
-        # self.build_executable(
-        #     name="fast-rmsdmatrix",
-        #     cmd=[
-        #         "gcc",
-        #         "-Wall",
-        #         "-O3",
-        #         "-march=native",
-        #         "-std=c99",
-        #         "-o",
-        #         "fast-rmsdmatrix",
-        #         "src/haddock/deps/fast-rmsdmatrix.c",
-        #         "-lm",
-        #     ],
-        # )
+        print("Building HADDOCK3 C/C++ binary dependencies...")
+        self.build_executable(
+            name="contact_fcc",
+            cmd=["g++", "-O2", "-o", "contact_fcc", "src/haddock/deps/contact_fcc.cpp"],
+        )
+        self.build_executable(
+            name="fast-rmsdmatrix",
+            cmd=[
+                "gcc",
+                "-Wall",
+                "-O3",
+                "-march=native",
+                "-std=c99",
+                "-o",
+                "fast-rmsdmatrix",
+                "src/haddock/deps/fast-rmsdmatrix.c",
+                "-lm",
+            ],
+        )
         print("Downloading the binaries...")
         self.download_binaries()
 

--- a/src/haddock/clis/wrapper_haddock_restraints.py
+++ b/src/haddock/clis/wrapper_haddock_restraints.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+import sys
+from pathlib import Path
+
+from importlib.resources import files
+
+
+def main():
+
+    binary = Path(files("haddock").joinpath("bin/haddock-restraints"))  # type: ignore
+    sys.argv[0] = str(binary)  # Replace argv[0] with actual binary path
+
+    # Execute the binary
+    import subprocess
+
+    sys.exit(subprocess.run([str(binary)] + sys.argv[1:]).returncode)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_wrapper_haddock_restraints.py
+++ b/tests/test_wrapper_haddock_restraints.py
@@ -1,0 +1,20 @@
+import pytest
+
+import haddock.clis.wrapper_haddock_restraints as wrapper
+
+
+def test_wrapper_haddock_restraints(monkeypatch):
+
+    monkeypatch.setattr("sys.argv", ["wrapper_haddock_restraints.py", "--help"])
+
+    with pytest.raises(SystemExit) as e:
+        wrapper.main()
+
+    assert e.value.code == 0
+
+    monkeypatch.setattr("sys.argv", ["wrapper_haddock_restraints.py", ""])
+
+    with pytest.raises(SystemExit) as e:
+        wrapper.main()
+
+    assert e.value.code == 2


### PR DESCRIPTION
 You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md).

## Checklist

- [x] Tests added for the new code
- [x] Documentation added for the code changes
- [x] Modifications / enhancements are reflected on the [haddock3 user-manual](https://github.com/haddocking/haddock3-user-manual)
- [x] `CHANGELOG.md` is updated to incorporate new changes
- [x] Haddock3 `version` has been incremented in `pyproject.toml`
- [x] Does not break licensing
- [x] Does not add any dependencies, if it does please add a thorough explanation

## Summary of the Pull Request  
<!-- Describe what changes were made to the code, what was added, removed, etc. -->

This PR changes `setup.py` to allow for a more generic download of binaries and it adds a new download during installation for `haddock-restraints`.

I also added `src/haddock/clis/wrapper_haddock_restraints.py` which is just a wrapper to make `haddock-restraitns` available in the `PATH`.



## Related Issue
<!-- If this PR is related to an issue, please link it here -->
<!-- If this PR is related to the haddock3 user manual, please link the PR here -->

#1353

## Additional Info
<!-- Any additional information that might be helpful, if applicable -->

I have updated the user guide with an entry about this: https://www.bonvinlab.org/haddock3-user-manual/clis.html
