### PR TITLE
add `PostInstallCommand` to check if CNS is executable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -162,32 +162,42 @@ class PostInstallCommand(install):
     @staticmethod
     def cns_warning():
         """Warn the user that CNS could not be executed"""
-        with open("/dev/tty", "w") as tty:
-            tty.write("\n" + "=" * 79 + "\n")
-            tty.write("=" * 79 + "\n")
-            tty.write("=" * 79 + "\n")
-            tty.write(
+        try:
+            with open("/dev/tty", "w") as tty:
+                tty.write("\n" + "=" * 79 + "\n")
+                tty.write("=" * 79 + "\n")
+                tty.write("=" * 79 + "\n")
+                tty.write(
+                    "\n⚠️ WARNING: The pre-compiled CNS binary could not be executed ⚠️\n\n"
+                )
+                tty.write("This may be due to missing dependencies on your system.\n")
+                tty.write(
+                    "Please refer to the installation instructions for troubleshooting steps:\n"
+                )
+                tty.write(
+                    "`https://github.com/haddocking/haddock3/blob/main/docs/CNS.md`\n\n"
+                )
+                tty.write("=" * 79 + "\n")
+                tty.write("=" * 79 + "\n")
+                tty.write("=" * 79 + "\n")
+                tty.flush()
+        except Exception as _:
+            # Fallback for systems without /dev/tty
+            sys.stderr.write(
                 "\n⚠️ WARNING: The pre-compiled CNS binary could not be executed ⚠️\n\n"
             )
-            tty.write("This may be due to missing dependencies on your system.\n")
-            tty.write(
-                "Please refer to the installation instructions for troubleshooting steps:\n"
-            )
-            tty.write(
-                "`https://github.com/haddocking/haddock3/blob/main/docs/CNS.md`\n\n"
-            )
-            tty.write("=" * 79 + "\n")
-            tty.write("=" * 79 + "\n")
-            tty.write("=" * 79 + "\n")
-            tty.flush()
 
     @staticmethod
     def cns_valid():
         """Write a message to the user that CNS works"""
-        with open("/dev/tty", "w") as tty:
-            tty.write("\n" + "=" * 79 + "\n")
-            tty.write("CNS execution passed ✅ \n")
-            tty.write("=" * 79 + "\n")
+        try:
+            # Fallback for systems without /dev/tty
+            with open("/dev/tty", "w") as tty:
+                tty.write("\n" + "=" * 79 + "\n")
+                tty.write("CNS execution passed ✅ \n")
+                tty.write("=" * 79 + "\n")
+        except Exception as _:
+            sys.stdout.write("CNS execution passed ✅ \n")
 
 
 setup(


### PR DESCRIPTION
 You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md).

## Checklist

 DOES NOT APPLY 

## Summary of the Pull Request  
<!-- Describe what changes were made to the code, what was added, removed, etc. -->

This PR adds a `PostInstallCommand` that checks if the CNS is executable or not.

If it is, it will show the user a message:

```
===============================================================================
CNS execution passed ✅ 
===============================================================================
```

and if its not it will show a warning:
```
===============================================================================
===============================================================================
===============================================================================

⚠️ WARNING: The pre-compiled CNS binary could not be executed ⚠️

This may be due to missing dependencies on your system.
Please refer to the installation instructions for troubleshooting steps:
`https://github.com/haddocking/haddock3/blob/main/docs/CNS.md`

===============================================================================
===============================================================================
===============================================================================
```

Note that because of python, this is not triggered when installing in editable mode

## Related Issue
<!-- If this PR is related to an issue, please link it here -->
<!-- If this PR is related to the haddock3 user manual, please link the PR here -->

#1355

## Additional Info
<!-- Any additional information that might be helpful, if applicable -->
