### PR TITLE
Consistancy in cluster naming in contactmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- 2025-09-04: Consistancy in cluster naming in contactmap module - Issue #1359
 - 2025-08-25: Distribute the `haddock-restraints` binary
 - 2025-08-22: Added check for max/min possible coordinates in CNS scripts - Issue #1350
 - 2025-08-17: Combined bumps of packages version (coverage, hypothesis, pytest-random-order and kaleido)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "haddock3"
-version = "2025.8.1"
+version = "2025.8.2"
 description = "HADDOCK3"
 readme = "README.md"
 authors = [{ name = "BonvinLab", email = "bonvinlab.support@uu.nl" }]

--- a/src/haddock/modules/analysis/contactmap/__init__.py
+++ b/src/haddock/modules/analysis/contactmap/__init__.py
@@ -97,13 +97,10 @@ class HaddockModule(BaseHaddockModule):
 
             # For clustered models
             else:
-                # Building basename for the job
-                name = f"cluster{clust_id}_"
                 # Handles case where clustered models were not scored before
-                if clust_rank is None:
-                    name += "unranked"
-                else:
-                    name += f"rank{clust_rank}"
+                rank_id = "Unranked" if clust_rank is None else clust_rank
+                # Building basename for the job
+                name = f"cluster{rank_id}"
                 # Create a contact map object
                 contmap_job = ClusteredContactMap(
                     [Path(model.rel_path) for model in clt_models],


### PR DESCRIPTION
 ## Checklist

- [X] Tests added for the new code
- [X] Documentation added for the code changes
- [X] Modifications / enhancements are reflected on the [haddock3 user-manual](https://github.com/haddocking/haddock3-user-manual)
- [X] `CHANGELOG.md` is updated to incorporate new changes
- [X] Haddock3 `version` has been incremented in `pyproject.toml`
- [X] Does not break licensing
- [X] Does not add any dependencies, if it does please add a thorough explanation

## Summary of the Pull Request  

Modify file names in `[contactmap]` module.
Now cluster filenames are: `cluster{rank}_modelX`.
This new naming scheme is now more consistent with other modules dealing with clusters.

## Related Issue

Closes #1359 
