### PR TITLE
add action to identify stale issues/PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,6 +6,10 @@ on:
 jobs:
   stale:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/stale@v10
         with:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,16 @@
+name: "Close stale issues and PRs"
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v10
+        with:
+          stale-issue-message: "This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days."
+          days-before-stale: 30
+          days-before-close: 5
+          exempt-issue-labels: "bug"
+          except-pr-labels: "bug"


### PR DESCRIPTION
## Summary of the Pull Request  
<!-- Describe what changes were made to the code, what was added, removed, etc. -->

This PR adds `stale.yml` which contains an action to check for stale pull-requests and issues. It will mark them as stale after 30 days of inactivity and if no reaction is made to this warning, the bot then closes it after 5 days. 

Once an issue/pr is marked as stale, the bot will give a warning and to re-start the timer someone must react to this warning by commenting on it or removing the label. Then the timer starts again, and after more 30 days of inactivity it's triggered again so on and so forth.

This is relevant to give an indication to external users which issues/pr as being worked on or are planned (postponed by commenting on it) and will also automatically clean-up the repository.

Currently there are issues/pull-requests that are years old, some others many months old, and it's not clear which are being worked on and which will no longer be added - this action will give a clear indication of that to our users.

## Related Issue
<!-- If this PR is related to an issue, please link it here -->
<!-- If this PR is related to the haddock3 user manual, please link the PR here -->

#1409 
