### PR TITLE
allow installation to continue without downloading external files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -126,12 +126,20 @@ class CustomBuild(build_ext):
             binary_url = binary_dict[arch]
 
             download_path = Path(target_bin_dir, filename.name)
-            _, _ = self.download_file(binary_url, download_path)
+            downloaded, msg = self.download_file(binary_url, download_path)
+            if not downloaded:
+                print(msg)
+                continue
 
             if arch != "x86_64-linux" and filename.name == "cns":
                 # Force the download of the linux binary, this is needed for GRID executions
                 download_path = Path(target_bin_dir, "cns_linux")
-                _, _ = self.download_file(binary_dict["x86_64-linux"], download_path)
+                downloaded, msg = self.download_file(
+                    binary_dict["x86_64-linux"], download_path
+                )
+                if not downloaded:
+                    print(msg)
+                    continue
 
             if "".join(filename.suffixes) == ".tar.gz":
                 try:


### PR DESCRIPTION
## Summary of the Pull Request  
<!-- Describe what changes were made to the code, what was added, removed, etc. -->

This PR updates the `setup.py` to not fail in case it fails to download a file

## Related Issue
<!-- If this PR is related to an issue, please link it here -->
<!-- If this PR is related to the haddock3 user manual, please link the PR here -->
#1437


## Additional Info
<!-- Any additional information that might be helpful, if applicable -->
https://github.com/haddocking/haddock3/actions/runs/19025512911/job/54328365931#logs