### PR TITLE
Minor: remove BioExcel User Survey 2025 link from log file 

### DIFF
--- a/src/haddock/gear/greetings.py
+++ b/src/haddock/gear/greetings.py
@@ -32,7 +32,7 @@ feedback_urls = {
     "GitHub issues": "https://github.com/haddocking/haddock3/issues",
     "BioExcel feedback": "https://www.bonvinlab.org/feedback",
     "BioExcel forum": "https://ask.bioexcel.eu/c/haddock/6",
-    "HADDOCK3 user manual": "https://www.bonvinlab.org/haddock3-user-manual/"
+    "Haddock3 user manual": "https://www.bonvinlab.org/haddock3-user-manual/"
 }
 
 


### PR DESCRIPTION
Remove BioExcel User Survey 2025 link from greetings. Add HADDOCK3 user manual link to greetings.


Should I add this to the changelog, or is it small enough to disregard? 