### PR TITLE
add `has_chrome` decorator

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,6 @@
 """Define common test variables."""
 
+import shutil
 import pytest
 import platform
 from pathlib import Path
@@ -45,6 +46,12 @@ has_notebook = pytest.mark.skipif(
 )
 
 has_grid = pytest.mark.skipif(not ping_dirac(), reason="Dirac not reachable")
+
+_CHROME_BINS = ("google-chrome", "google-chrome-stable", "chromium-browser", "chromium", "chrome")
+has_chrome = pytest.mark.skipif(
+    not any(shutil.which(b) for b in _CHROME_BINS),
+    reason="Google Chrome not found (required by Kaleido for PNG export)",
+)
 is_linux_x86_64 = pytest.mark.skipif(
     platform.system().lower() != "linux" or platform.machine().lower() != "x86_64",
     reason="Only runs on x86_64 Linux systems",

--- a/tests/test_libplots.py
+++ b/tests/test_libplots.py
@@ -17,7 +17,7 @@ from haddock.libs.libplots import (
     scatter_plot_handler,
     read_capri_table,
     )
-from . import data_folder, golden_data
+from . import data_folder, golden_data, has_chrome
 
 
 @pytest.fixture(name="example_capri_ss")
@@ -317,6 +317,7 @@ def test_box_plot_handler(example_capri_ss, cluster_ranking, monkeypatch):
         assert len(list(Path(".").glob("*.png"))) == 0
 
 
+@has_chrome
 def test_box_plot_handler_format(example_capri_ss, cluster_ranking, monkeypatch):
     """Test box plot generation with png format definition."""
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -345,6 +346,7 @@ def test_scatter_plot_handler(example_capri_ss, cluster_ranking, monkeypatch):
         assert len(list(Path(".").glob("*.png"))) == 0
 
 
+@has_chrome
 def test_scatter_plot_handler_format(example_capri_ss, cluster_ranking, monkeypatch):
     """Test scatter plot generation with png format definition."""
     with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
`libplots` has an implicit dependency on chrome as `fig.write_image` spawns a chromium process to render images. this is fine as most systems will have it, however the tests will fail if this dependency is not met. this PR adds a `has_chrome` decorator to skip the related tests.