### PR TITLE
Increased noe restraints array size in scoring modules - issue #1501

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- 2026-04-08: Increased NOE restraints array size in scoring modules - Issue #1501
 - 2026-03-09: Automated type casting for optional argument seed in haddock3-restraints random_removal - Issue #1485
 - 2026-02-28: Switched to ilRMSD clustering from protein-ligand examples - Issue #1481
 - 2026-02-24: Implement automated toppar generation for unknown atoms with PRODRG

--- a/src/haddock/modules/scoring/emscoring/cns/restrain-ions.cns
+++ b/src/haddock/modules/scoring/emscoring/cns/restrain-ions.cns
@@ -10,7 +10,7 @@
 ! * as part of this package.                                            *
 ! ***********************************************************************
 !
-noe class dist end
+noe nres=10000 class dist end
 
 ! first deal with monoatomic ions
 evaluate ($pcount = 0)

--- a/src/haddock/modules/scoring/mdscoring/cns/restrain-ions.cns
+++ b/src/haddock/modules/scoring/mdscoring/cns/restrain-ions.cns
@@ -10,7 +10,7 @@
 ! * as part of this package.                                            *
 ! ***********************************************************************
 !
-noe class dist end
+noe nres=10000 class dist end
 
 ! first deal with monoatomic ions
 evaluate ($pcount = 0)


### PR DESCRIPTION
## Checklist

- [ ] Tests added for the new code
- [ ] Documentation added for the code changes
- [ ] Modifications / enhancements are reflected on the [haddock3 user-manual](https://github.com/haddocking/haddock3-user-manual)
- [X] `CHANGELOG.md` is updated to incorporate new changes
- [X] Does not break licensing
- [X] Does not add any dependencies, if it does please add a thorough explanation

## Summary of the Pull Request  

Added the definition of the NOE restraint array size (nres=10000) to `restrain-ions.cns` in scoring modules emscoring and mdscoring

## Related Issue

#1501 

