### PR TITLE
Corrected automatic ion restraining in flexref - solves issue #1510

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- 2026-04-10: Corrected the definition of ion restraints in flexref - Issue #1510
 - 2026-04-08: Improved docstring in modules
 - 2026-04-08: Increased NOE restraints array size in scoring modules - Issue #1501
 - 2026-03-09: Automated type casting for optional argument seed in haddock3-restraints random_removal - Issue #1485

--- a/src/haddock/modules/refinement/emref/cns/emref.cns
+++ b/src/haddock/modules/refinement/emref/cns/emref.cns
@@ -237,7 +237,7 @@ if ($data.flags.cdih eq true) then
 end if
 
 
-{* Check for the presence of ions and add distance restraints / covalent bond == *}
+{* Check for the presence of ions and add distance restraints *}
 
 @MODULE:restrain-ions.cns
 

--- a/src/haddock/modules/refinement/emref/cns/restrain-ions.cns
+++ b/src/haddock/modules/refinement/emref/cns/restrain-ions.cns
@@ -42,7 +42,7 @@ for $id1 in id ( name "LI+1" or name "F-1"  or name "NA+1" or name "MG+2" or nam
                       resn MSE or resn NEP or resn NME or resn PHE or resn PNS or resn PRO or resn PTR or
                       resn QSR or resn SEP or resn SER or resn SEC or resn THR or resn TOP or resn TRP or
                       resn TYP or resn TYR or resn TYS or resn VAL or resn A   or resn C   or resn G   or
-                      resn T   or resn DA  or resn DC  or resn DG  or resn DT  or resn DJ )) loop search
+                      resn T   or resn U   or resn DA  or resn DC  or resn DG  or resn DT  or resn DJ )) loop search
 
          pick bond (id $id1) (id $id2) geometry
          evaluate ($upper = $result)

--- a/src/haddock/modules/refinement/flexref/cns/covalions.cns
+++ b/src/haddock/modules/refinement/flexref/cns/covalions.cns
@@ -41,7 +41,7 @@ for $id1 in id ( name "LI+1" or name "F-1"  or name "NA+1" or name "MG+2" or nam
                       resn MSE or resn NEP or resn NME or resn PHE or resn PNS or resn PRO or resn PTR or
                       resn QSR or resn SEP or resn SER or resn SEC or resn THR or resn TOP or resn TRP or
                       resn TYP or resn TYR or resn TYS or resn VAL or resn A   or resn C   or resn G   or
-                      resn T   or resn DA  or resn DC  or resn DG  or resn DT  or resn DJ )) loop search
+                      resn T   or resn U   or resn DA  or resn DC  or resn DG  or resn DT  or resn DJ )) loop search
 
         pick bond (id $id1) (id $id2) geometry
 

--- a/src/haddock/modules/refinement/flexref/cns/flexref.cns
+++ b/src/haddock/modules/refinement/flexref/cns/flexref.cns
@@ -180,6 +180,10 @@ parameter
     angle (resn TIP*) (resn TIP*) (resn TIP*) 500 TOKEN
 end
 
+{* Check for the presence of ions and add covalent bond *}
+
+@MODULE:covalions.cns
+
 
 {* Define various interaction and energetics settings *}
 
@@ -308,10 +312,8 @@ if ($Data.ssdihed eq "alphabeta" ) then
     inline @MODULE:protein-ss-restraints-alpha-beta.cns
 end if
 
-{* Check for the presence of ions and add distance restraints / covalent bond == *}
-
+{* Check for the presence of ions and add distance restraints *}
 @MODULE:restrain-ions.cns
-@MODULE:covalions.cns
 
 
 {* Check first for failed structures =========================================== *}

--- a/src/haddock/modules/refinement/flexref/cns/flexref.cns
+++ b/src/haddock/modules/refinement/flexref/cns/flexref.cns
@@ -180,11 +180,6 @@ parameter
     angle (resn TIP*) (resn TIP*) (resn TIP*) 500 TOKEN
 end
 
-{* Check for the presence of ions and add distance restraints / covalent bond == *}
-
-@MODULE:restrain-ions.cns
-@MODULE:covalions.cns
-
 
 {* Define various interaction and energetics settings *}
 
@@ -312,6 +307,11 @@ end if
 if ($Data.ssdihed eq "alphabeta" ) then
     inline @MODULE:protein-ss-restraints-alpha-beta.cns
 end if
+
+{* Check for the presence of ions and add distance restraints / covalent bond == *}
+
+@MODULE:restrain-ions.cns
+@MODULE:covalions.cns
 
 
 {* Check first for failed structures =========================================== *}

--- a/src/haddock/modules/refinement/flexref/cns/restrain-ions.cns
+++ b/src/haddock/modules/refinement/flexref/cns/restrain-ions.cns
@@ -42,7 +42,7 @@ for $id1 in id ( name "LI+1" or name "F-1"  or name "NA+1" or name "MG+2" or nam
                       resn MSE or resn NEP or resn NME or resn PHE or resn PNS or resn PRO or resn PTR or
                       resn QSR or resn SEP or resn SER or resn SEC or resn THR or resn TOP or resn TRP or
                       resn TYP or resn TYR or resn TYS or resn VAL or resn A   or resn C   or resn G   or
-                      resn T   or resn DA  or resn DC  or resn DG  or resn DT  or resn DJ )) loop search
+                      resn T   or resn U   or resn DA  or resn DC  or resn DG  or resn DT  or resn DJ )) loop search
 
          pick bond (id $id1) (id $id2) geometry
          evaluate ($upper = $result)

--- a/src/haddock/modules/refinement/mdref/cns/mdref.cns
+++ b/src/haddock/modules/refinement/mdref/cns/mdref.cns
@@ -261,7 +261,7 @@ if ($Data.ssdihed eq "alphabeta" ) then
 end if
 
 
-{* Check for the presence of ions and add distance restraints / covalent bond == *}
+{* Check for the presence of ions and add distance restraints *}
 
 @MODULE:restrain-ions.cns
 

--- a/src/haddock/modules/refinement/mdref/cns/restrain-ions.cns
+++ b/src/haddock/modules/refinement/mdref/cns/restrain-ions.cns
@@ -40,9 +40,9 @@ for $id1 in id ( name "LI+1" or name "F-1"  or name "NA+1" or name "MG+2" or nam
                       resn GLN or resn GLH or resn GLU or resn GLY or resn HIS or resn HY3 or resn HYP or
                       resn ILE or resn LEU or resn LYS or resn M3L or resn MLY or resn MLZ or resn MET or
                       resn MSE or resn NEP or resn NME or resn PHE or resn PNS or resn PRO or resn PTR or
-                      resn QSR or resn SEP or resn SER or resn THR or resn TOP or resn TRP or resn TYP or
-                      resn TYR or resn TYS or resn VAL or resn A   or resn C   or resn G   or resn T   or
-                      resn DA  or resn DC  or resn DG  or resn DT  or resn DJ )) loop search
+                      resn QSR or resn SEP or resn SER or resn SEC or resn THR or resn TOP or resn TRP or
+                      resn TYP or resn TYR or resn TYS or resn VAL or resn A   or resn C   or resn G   or
+                      resn T   or resn U   or resn DA  or resn DC  or resn DG  or resn DT  or resn DJ )) loop search
 
          pick bond (id $id1) (id $id2) geometry
          evaluate ($upper = $result)
@@ -84,9 +84,9 @@ for $id1 in id ( (resn SO4 or resn PO4 or resn WO4) and name O* ) loop mions
                       resn GLN or resn GLH or resn GLU or resn GLY or resn HIS or resn HY3 or resn HYP or
                       resn ILE or resn LEU or resn LYS or resn M3L or resn MLY or resn MLZ or resn MET or
                       resn MSE or resn NEP or resn NME or resn PHE or resn PNS or resn PRO or resn PTR or
-                      resn QSR or resn SEP or resn SER or resn THR or resn TOP or resn TRP or resn TYP or
-                      resn TYR or resn TYS or resn VAL or resn A   or resn C   or resn G   or resn T   or
-                      resn DA  or resn DC  or resn DG  or resn DT  or resn DJ )) loop search
+                      resn QSR or resn SEP or resn SER or resn SEC or resn THR or resn TOP or resn TRP or
+                      resn TYP or resn TYR or resn TYS or resn VAL or resn A   or resn C   or resn G   or
+                      resn T   or resn DA  or resn DC  or resn DG  or resn DT  or resn DJ )) loop search
 
          pick bond (id $id1) (id $id2) geometry
          evaluate ($upper = $result)

--- a/src/haddock/modules/scoring/emscoring/cns/restrain-ions.cns
+++ b/src/haddock/modules/scoring/emscoring/cns/restrain-ions.cns
@@ -10,7 +10,7 @@
 ! * as part of this package.                                            *
 ! ***********************************************************************
 !
-noe nres=10000 class dist end
+noe class dist end
 
 ! first deal with monoatomic ions
 evaluate ($pcount = 0)
@@ -42,7 +42,7 @@ for $id1 in id ( name "LI+1" or name "F-1"  or name "NA+1" or name "MG+2" or nam
                       resn MSE or resn NEP or resn NME or resn PHE or resn PNS or resn PRO or resn PTR or
                       resn QSR or resn SEP or resn SER or resn SEC or resn THR or resn TOP or resn TRP or
                       resn TYP or resn TYR or resn TYS or resn VAL or resn A   or resn C   or resn G   or
-                      resn T   or resn DA  or resn DC  or resn DG  or resn DT  or resn DJ )) loop search
+                      resn T   or resn U   or resn DA  or resn DC  or resn DG  or resn DT  or resn DJ )) loop search
 
          pick bond (id $id1) (id $id2) geometry
          evaluate ($upper = $result)

--- a/src/haddock/modules/scoring/mdscoring/cns/restrain-ions.cns
+++ b/src/haddock/modules/scoring/mdscoring/cns/restrain-ions.cns
@@ -10,7 +10,7 @@
 ! * as part of this package.                                            *
 ! ***********************************************************************
 !
-noe nres=10000 class dist end
+noe class dist end
 
 ! first deal with monoatomic ions
 evaluate ($pcount = 0)
@@ -42,7 +42,7 @@ for $id1 in id ( name "LI+1" or name "F-1"  or name "NA+1" or name "MG+2" or nam
                       resn MSE or resn NEP or resn NME or resn PHE or resn PNS or resn PRO or resn PTR or
                       resn QSR or resn SEP or resn SER or resn SEC or resn THR or resn TOP or resn TRP or
                       resn TYP or resn TYR or resn TYS or resn VAL or resn A   or resn C   or resn G   or
-                      resn T   or resn DA  or resn DC  or resn DG  or resn DT  or resn DJ )) loop search
+                      resn T   or resn U   or resn DA  or resn DC  or resn DG  or resn DT  or resn DJ )) loop search
 
          pick bond (id $id1) (id $id2) geometry
          evaluate ($upper = $result)


### PR DESCRIPTION
 You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md).

## Checklist

- [ ] Tests added for the new code
- [ ] Documentation added for the code changes
- [ ] Modifications / enhancements are reflected on the [haddock3 user-manual](https://github.com/haddocking/haddock3-user-manual)
- [X] `CHANGELOG.md` is updated to incorporate new changes
- [X] Does not break licensing
- [X] Does not add any dependencies, if it does please add a thorough explanation

## Summary of the Pull Request  

Move the call to `restraint-ions.cns` after the the call to `read_data.cns` in the flexref module.

## Related Issue

#1510 
