### PR TITLE
increased allowed simluation steps in openmm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- 2026-04-14: Increase max number of timesteps in openmm module - BioExcel forum 6072
 - 2026-04-12: Add possibility to run MD (mdref, mdscoring) without solvent - Issue #1512
 - 2026-04-10: Corrected the definition of ion restraints in flexref - Issue #1510
 - 2026-04-10: Removing analysis modules downstream when restarting - Issue #1495

--- a/src/haddock/modules/refinement/openmm/defaults.yaml
+++ b/src/haddock/modules/refinement/openmm/defaults.yaml
@@ -137,8 +137,8 @@ equilibration_timesteps:
 simulation_timesteps:
   default: 2000
   type: integer
-  min: 0
-  max: 1000000
+  min: 0 
+  max: 10000000
   title: Simulation timesteps.
   short: Simulation timesteps performed during the simulation.
   long: Simulation timesteps performed during the simulation.


### PR DESCRIPTION
## Checklist

- [X] Modifications / enhancements are reflected on the [haddock3 user-manual](https://github.com/haddocking/haddock3-user-manual)
- [X] `CHANGELOG.md` is updated to incorporate new changes
- [X] Does not break licensing
- [X] Does not add any dependencies, if it does please add a thorough explanation

## Summary of the Pull Request  

Increase maximum allowed number of simulation steps in `[openmm]` to 10 million.
This allows to generate trajectories for up to 20 ns (2fs timesteps).

## Related Issue

https://ask.bioexcel.eu/t/haddock3-user-manual-issue/6072
https://github.com/haddocking/haddock3-user-manual/pull/29

## Additional Info

Spotted on the BioExcel forum by community user
