### PR TITLE
add caching to `ModuleIO` interface

### DIFF
--- a/integration_tests/test_caching.py
+++ b/integration_tests/test_caching.py
@@ -1,0 +1,191 @@
+"""Integration test for the caching functionality."""
+
+import pytest
+import tempfile
+from pathlib import Path
+import pickle
+
+from haddock.libs.libontology import ModuleIO, Cache, CacheKey
+
+
+def test_cache_basic_operations():
+    """Test basic cache operations: add, get, has, get_all."""
+    cache = Cache()
+
+    # Test adding items
+    cache.add(CacheKey.RMSD, ("model1", "model2"), 1.5)
+    cache.add(CacheKey.RMSD, ("model1", "model3"), 2.3)
+    cache.add(CacheKey.RMSD, ("model2", "model3"), 0.8)
+
+    # Test getting items
+    assert cache.get(CacheKey.RMSD, ("model1", "model2")) == 1.5
+    assert cache.get(CacheKey.RMSD, ("model1", "model3")) == 2.3
+    assert cache.get(CacheKey.RMSD, ("model2", "model3")) == 0.8
+
+    # Test has method
+    assert cache.has(CacheKey.RMSD, ("model1", "model2"))
+    assert not cache.has(CacheKey.RMSD, ("model3", "model4"))
+
+    # Test get_all
+    all_rmsd = cache.get_all(CacheKey.RMSD)
+    assert len(all_rmsd) == 3
+
+
+def test_cache_clear():
+    """Test clearing cache entries."""
+    cache = Cache()
+
+    # Add some items
+    cache.add(CacheKey.RMSD, ("model1", "model2"), 1.5)
+    cache.add(CacheKey.RMSD, ("model3", "model4"), 2.0)
+
+    # Verify items exist
+    assert cache.has(CacheKey.RMSD, ("model1", "model2"))
+    assert cache.has(CacheKey.RMSD, ("model3", "model4"))
+    assert len(cache.get_all(CacheKey.RMSD)) == 2
+
+    # Clear RMSD cache
+    cache.clear(CacheKey.RMSD)
+
+    # Verify cache is empty
+    assert not cache.has(CacheKey.RMSD, ("model1", "model2"))
+    assert not cache.has(CacheKey.RMSD, ("model3", "model4"))
+    assert len(cache.get_all(CacheKey.RMSD)) == 0
+
+
+def test_module_io_cache_serialization():
+    """Test that ModuleIO can save and load cache data."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create ModuleIO instance and add some cache data
+        module_io = ModuleIO()
+        module_io.cache.add(CacheKey.RMSD, ("model1", "model2"), 1.5)
+        module_io.cache.add(CacheKey.RMSD, ("model3", "model4"), 2.0)
+
+        # Save to file
+        save_path = Path(tmpdir) / "test_io.json"
+        module_io.save(save_path.parent, save_path.name)
+
+        # Verify file was created
+        assert save_path.exists()
+        assert save_path.stat().st_size > 0
+
+        # Create new ModuleIO instance and load
+        new_module_io = ModuleIO()
+        new_module_io.load(save_path)
+
+        # Verify cache was loaded correctly
+        assert new_module_io.cache.has(CacheKey.RMSD, ("model1", "model2"))
+        assert new_module_io.cache.get(CacheKey.RMSD, ("model1", "model2")) == 1.5
+        assert new_module_io.cache.has(CacheKey.RMSD, ("model3", "model4"))
+        assert new_module_io.cache.get(CacheKey.RMSD, ("model3", "model4")) == 2.0
+
+        # Verify all cache entries
+        all_rmsd = new_module_io.cache.get_all(CacheKey.RMSD)
+        assert len(all_rmsd) == 2
+
+
+def test_cache_pickle_serialization():
+    """Test that Cache can be pickled and unpickled directly."""
+    cache = Cache()
+
+    # Add test data
+    cache.add(CacheKey.RMSD, ("model1", "model2"), 1.5)
+    cache.add(CacheKey.RMSD, ("model3", "model4"), 2.0)
+
+    # Pickle the cache
+    pickled_data = pickle.dumps(cache)
+
+    # Unpickle and verify
+    new_cache = pickle.loads(pickled_data)
+
+    assert new_cache.has(CacheKey.RMSD, ("model1", "model2"))
+    assert new_cache.get(CacheKey.RMSD, ("model1", "model2")) == 1.5
+    assert new_cache.has(CacheKey.RMSD, ("model3", "model4"))
+    assert new_cache.get(CacheKey.RMSD, ("model3", "model4")) == 2.0
+
+    # Verify all entries
+    all_rmsd = new_cache.get_all(CacheKey.RMSD)
+    assert len(all_rmsd) == 2
+
+
+def test_cache_multiple_keys():
+    """Test cache with multiple CacheKey types."""
+    cache = Cache()
+
+    # Add RMSD entries
+    cache.add(CacheKey.RMSD, ("model1", "model2"), 1.5)
+    cache.add(CacheKey.RMSD, ("model3", "model4"), 2.0)
+
+    # Verify RMSD entries don't interfere with each other
+    rmsd_entries = cache.get_all(CacheKey.RMSD)
+    assert len(rmsd_entries) == 2
+
+    # Test that we can clear specific cache keys independently
+    cache.clear(CacheKey.RMSD)
+    assert len(cache.get_all(CacheKey.RMSD)) == 0
+
+
+def test_cache_nonexistent_key():
+    """Test cache behavior with non-existent keys."""
+    cache = Cache()
+
+    # Test getting non-existent key
+    result = cache.get(CacheKey.RMSD, ("nonexistent1", "nonexistent2"))
+    assert result is None
+
+    # Test has with non-existent key
+    assert not cache.has(CacheKey.RMSD, ("nonexistent1", "nonexistent2"))
+
+    # Test get_all with empty cache
+    all_rmsd = cache.get_all(CacheKey.RMSD)
+    assert len(all_rmsd) == 0
+
+
+def test_cache_update_method():
+    """Test the update_cache method in ModuleIO."""
+    # Create two ModuleIO instances
+    module_io1 = ModuleIO()
+    module_io2 = ModuleIO()
+
+    # Add cache data to first instance
+    module_io1.cache.add(CacheKey.RMSD, ("model1", "model2"), 1.5)
+
+    # Update second instance with first instance's cache
+    module_io2.update_cache(module_io1.cache)
+
+    # Verify the update worked
+    assert module_io2.cache.has(CacheKey.RMSD, ("model1", "model2"))
+    assert module_io2.cache.get(CacheKey.RMSD, ("model1", "model2")) == 1.5
+
+
+def test_cache_with_module_io_lifecycle():
+    """Test cache behavior through complete ModuleIO lifecycle."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create and populate ModuleIO
+        original_io = ModuleIO()
+        original_io.cache.add(CacheKey.RMSD, ("model1", "model2"), 1.5)
+        original_io.cache.add(CacheKey.RMSD, ("model3", "model4"), 2.0)
+
+        # Add some input/output files (to test they don't interfere)
+        from haddock.libs.libontology import PDBFile
+
+        test_pdb = Path(tmpdir) / "test.pdb"
+        test_pdb.write_text("ATOM      1  N   ALA A   1       1.000   1.000   1.000")
+        original_io.add(PDBFile(test_pdb, path=tmpdir))
+
+        # Save and load
+        save_path = Path(tmpdir) / "test_io.pkl"
+        original_io.save(save_path.parent, save_path.name)
+
+        loaded_io = ModuleIO()
+        loaded_io.load(save_path)
+
+        # Verify cache survived the round trip
+        assert loaded_io.cache.has(CacheKey.RMSD, ("model1", "model2"))
+        assert loaded_io.cache.get(CacheKey.RMSD, ("model1", "model2")) == 1.5
+        assert loaded_io.cache.has(CacheKey.RMSD, ("model3", "model4"))
+        assert loaded_io.cache.get(CacheKey.RMSD, ("model3", "model4")) == 2.0
+
+        # Verify input/output also survived
+        assert len(loaded_io.input) == 1
+        assert len(loaded_io.output) == 0

--- a/integration_tests/test_caching.py
+++ b/integration_tests/test_caching.py
@@ -1,11 +1,11 @@
 """Integration test for the caching functionality."""
 
-import pytest
+import pickle
 import tempfile
 from pathlib import Path
-import pickle
 
-from haddock.libs.libontology import ModuleIO, Cache, CacheKey
+from haddock.core.defaults import MODULE_IO_FILE
+from haddock.libs.libontology import Cache, CacheKey, ModuleIO
 
 
 def test_cache_basic_operations():
@@ -62,7 +62,7 @@ def test_module_io_cache_serialization():
         module_io.cache.add(CacheKey.RMSD, ("model3", "model4"), 2.0)
 
         # Save to file
-        save_path = Path(tmpdir) / "test_io.json"
+        save_path = Path(tmpdir) / MODULE_IO_FILE
         module_io.save(save_path.parent, save_path.name)
 
         # Verify file was created

--- a/integration_tests/test_clustfcc.py
+++ b/integration_tests/test_clustfcc.py
@@ -8,6 +8,7 @@ import pytest
 from haddock.libs.libontology import PDBFile
 from haddock.modules.analysis.clustfcc import DEFAULT_CONFIG as clustfcc_pars
 from haddock.modules.analysis.clustfcc import HaddockModule as ClustFCCModule
+from haddock.core.defaults import MODULE_IO_FILE
 
 from integration_tests import GOLDEN_DATA
 
@@ -55,7 +56,7 @@ def fixture_output_list():
         "protprot_complex_1.con",
         "protprot_complex_2.con",
         "clustfcc.txt",
-        "io.json",
+        MODULE_IO_FILE,
         "clustfcc.tsv",
         "fcc_matrix.html",
     ]

--- a/integration_tests/test_full_workflow.py
+++ b/integration_tests/test_full_workflow.py
@@ -24,24 +24,24 @@ def test_emscoring_workflow(caplog, monkeypatch):
 
         caplog.set_level("INFO")
         ParamDict = {
-            'topoaa.1': {
-                'autohis': True,
-                'molecules': [Path("protglyc_complex_1.pdb")],
-                'clean': True,
-                'offline': False,
-                'mode': "local",
-                'ncores': 2,
-                },
-            'emscoring.1': {
-                'per_interface_scoring' : False,
-                }
-            }
+            "topoaa.1": {
+                "autohis": True,
+                "molecules": [Path("protglyc_complex_1.pdb")],
+                "clean": True,
+                "offline": False,
+                "mode": "local",
+                "ncores": 2,
+            },
+            "emscoring.1": {
+                "per_interface_scoring": False,
+            },
+        }
 
         workflow = WorkflowManager(
             ParamDict,
             start=0,
             other_params=Any,
-            )
+        )
         workflow.run()
         # assert the directories 0_topoaa and 1_emscoring have been created
         assert os.path.isdir("0_topoaa") is True
@@ -71,16 +71,17 @@ def test_interactive_analysis_on_workflow(monkeypatch):
 
         monkeypatch.chdir(tmpdir)
 
-        
         cli_main(
             Path("workflow.cfg"),
         )
         # read run_dir in workflow.cfg
+        run_dir = Path(".")
         with open("workflow.cfg", "r") as f:
             for line in f:
                 if "run_dir" in line:
                     run_dir = line.split("=")[1].strip().strip('"')
                     break
+
         assert os.path.isdir(run_dir) is True
         assert os.path.isdir(Path(run_dir, "0_topoaa")) is True
         assert os.path.isdir(Path(run_dir, "1_rigidbody")) is True
@@ -90,22 +91,22 @@ def test_interactive_analysis_on_workflow(monkeypatch):
 
         # now running interactive re-clustering
         clustfcc_dir = f"{run_dir}/2_clustfcc"
-        
-        # faking sys.argv in input to haddock3-re
-        monkeypatch.setattr("sys.argv",
-                            ["haddock3-re", "clustfcc", clustfcc_dir, "-f", "0.7"]
-                            )
+
+        # inject `sys.argv` arguments
+        monkeypatch.setattr(
+            "sys.argv", ["haddock3-re", "clustfcc", clustfcc_dir, "-f", "0.7"]
+        )
         maincli()
         assert os.path.isdir(Path(run_dir, "2_clustfcc_interactive")) is True
         assert Path(run_dir, "2_clustfcc_interactive/clustfcc.tsv").exists() is True
         assert Path(run_dir, "2_clustfcc_interactive/clustfcc.txt").exists() is True
-        
+
         # now running interactive re-scoring
         capri_dir = f"{run_dir}/3_caprieval"
         # faking sys.argv in input to haddock3-re
-        monkeypatch.setattr("sys.argv",
-                            ["haddock3-re", "score", capri_dir, "-a", "1.0"]
-                            )
+        monkeypatch.setattr(
+            "sys.argv", ["haddock3-re", "score", capri_dir, "-a", "1.0"]
+        )
         maincli()
         assert os.path.isdir(Path(run_dir, "3_caprieval_interactive")) is True
         assert Path(run_dir, "3_caprieval_interactive/capri_ss.tsv").exists() is True
@@ -119,11 +120,12 @@ def test_interactive_analysis_on_workflow(monkeypatch):
             scale=None,
             is_cleaned=True,
             inter=True,
-            )
+        )
         exp_clustfcc_dir = Path(run_dir, "analysis", "2_clustfcc_interactive_analysis")
-        exp_caprieval_dir = Path(run_dir, "analysis", "3_caprieval_interactive_analysis")
+        exp_caprieval_dir = Path(
+            run_dir, "analysis", "3_caprieval_interactive_analysis"
+        )
         assert os.path.isdir(exp_clustfcc_dir) is True
         assert os.path.isdir(exp_caprieval_dir) is True
         assert Path(exp_clustfcc_dir, "report.html").exists() is True
         assert Path(exp_caprieval_dir, "report.html").exists() is True
-        

--- a/src/haddock/clis/cli_analyse.py
+++ b/src/haddock/clis/cli_analyse.py
@@ -30,7 +30,7 @@ from pathlib import Path
 from haddock import log
 from haddock.clis.cli_unpack import main as haddock3_unpack
 from haddock.clis.cli_clean import main as haddock3_clean
-from haddock.core.defaults import INTERACTIVE_RE_SUFFIX, ANA_FOLDER
+from haddock.core.defaults import INTERACTIVE_RE_SUFFIX, ANA_FOLDER, MODULE_IO_FILE
 from haddock.core.typing import (
     Any,
     ArgumentParser,
@@ -41,7 +41,7 @@ from haddock.core.typing import (
     Optional,
     ParamDict,
     ParamMap,
-    )
+)
 from haddock.gear.yaml2cfg import read_from_yaml_config
 from haddock.gear.clean_steps import _unpack_gz
 from haddock.libs.libcli import _ParamsToDict
@@ -55,11 +55,11 @@ from haddock.libs.libplots import (
     report_generator,
     scatter_plot_handler,
     SUPPORTED_OUTPUT_FORMATS,
-    )
+)
 from haddock.modules import get_module_steps_folders
 from haddock.modules.analysis.caprieval import (
     DEFAULT_CONFIG as caprieval_params,
-    )
+)
 from haddock.modules.analysis.caprieval import HaddockModule
 
 
@@ -117,7 +117,7 @@ ap.add_argument(
     required=False,
     type=bool,
     default=False,
-    )
+)
 
 ap.add_argument(
     "--is_cleaned",
@@ -198,9 +198,9 @@ def maincli() -> None:
 
 
 def get_cluster_ranking(
-        capri_clt_filename: FilePath,
-        top_clusters: int,
-        ) -> ClRank:
+    capri_clt_filename: FilePath,
+    top_clusters: int,
+) -> ClRank:
     """
     Get capri cluster ranking.
 
@@ -251,13 +251,13 @@ def update_paths(
 
 
 def run_capri_analysis(
-        step: str,
-        run_dir: FilePath,
-        capri_dict: ParamMap,
-        is_cleaned: bool,
-        mode: str,
-        ncores: int,
-        ) -> None:
+    step: str,
+    run_dir: FilePath,
+    capri_dict: ParamMap,
+    is_cleaned: bool,
+    mode: str,
+    ncores: int,
+) -> None:
     """
     Run the caprieval analysis.
 
@@ -272,7 +272,7 @@ def run_capri_analysis(
     """
     # retrieve json file with all information
     io = ModuleIO()
-    filename = Path("..", f"{step}/io.json")
+    filename = Path("..", f"{step}/{MODULE_IO_FILE}")
     io.load(filename)
     # unpack the files if they are compressed
     if is_cleaned:
@@ -320,9 +320,8 @@ def update_capri_dict(default_capri: ParamDict, kwargs: ParamMap) -> ParamDict:
     for param in kwargs:
         if param not in default_capri:
             sys.exit(
-                f"* ERROR * Parameter {param!r} is not "
-                "a valid `caprieval` parameter"
-                )
+                f"* ERROR * Parameter {param!r} is not a valid `caprieval` parameter"
+            )
         else:
             if param.endswith("fname"):  # using full path for files
                 rel_path = Path(kwargs[param])
@@ -365,11 +364,11 @@ def update_paths_in_capri_dict(
 
 
 def get_top_ranked_mapping(
-        capri_filename: FilePath,
-        cluster_ranking: ClRank,
-        clustered_topX: int = 4,
-        unclustered_topX: int = 10,
-        ) -> dict[Path, Path]:
+    capri_filename: FilePath,
+    cluster_ranking: ClRank,
+    clustered_topX: int = 4,
+    unclustered_topX: int = 10,
+) -> dict[Path, Path]:
     """Obtain mapping of top ranked files to their future paths.
 
     Parameters
@@ -403,11 +402,15 @@ def get_top_ranked_mapping(
             # If clustered structure
             if cl_id != "-":
                 # Retrieve only top 4 models per cluster
-                structs = cl_df.loc[cl_df["model-cluster_ranking"] <= clustered_topX][["model", "model-cluster_ranking"]]  # noqa : E501
+                structs = cl_df.loc[cl_df["model-cluster_ranking"] <= clustered_topX][
+                    ["model", "model-cluster_ranking"]
+                ]  # noqa : E501
             # If un-clustered structures
             else:
                 # Retrieve top 10
-                structs = cl_df.loc[cl_df["caprieval_rank"] <= unclustered_topX][["model", "caprieval_rank"]]  # noqa : E501
+                structs = cl_df.loc[cl_df["caprieval_rank"] <= unclustered_topX][
+                    ["model", "caprieval_rank"]
+                ]  # noqa : E501
             # Rename columns to access them using same keywords
             structs.columns = ["model", "rank"]
             # iterate over the structures
@@ -417,10 +420,7 @@ def get_top_ranked_mapping(
                 # set target name
                 if cl_id != "-":
                     # Give it its cluster name
-                    target_name = (
-                        f"cluster_{cluster_ranking[cl_id]}"
-                        f"_model_{rank}.pdb"
-                        )
+                    target_name = f"cluster_{cluster_ranking[cl_id]}_model_{rank}.pdb"
                 else:
                     # Give it its rank name
                     target_name = f"model_{rank}.pdb"
@@ -437,11 +437,12 @@ def get_top_ranked_mapping(
                     log.warning(f"structure {struct} not found")
     return top_ranked_mapping
 
+
 def zip_top_ranked(
-        top_ranked_mapping: dict[Path, Path],
-        summary_name: str,
-        gen_archive: bool,
-        ) -> Optional[Path]:
+    top_ranked_mapping: dict[Path, Path],
+    summary_name: str,
+    gen_archive: bool,
+) -> Optional[Path]:
     """
     Zip the top ranked structures.
 
@@ -487,7 +488,7 @@ def zip_top_ranked(
             # move archive to summary
             shutil.move("pdb.tgz", output_fname)
             log.info(f"Top structures summary archive {output_fname} created!")
-            return 
+            return
         else:
             log.warning(f"Summary archive {output_fname} not created!")
             return None
@@ -605,13 +606,13 @@ def analyse_step(
             cluster_ranking,
             clustered_topX=clustered_topX,
             unclustered_topX=unclustered_topX,
-            )
+        )
         # provide a zipped archive of the top ranked structures
         zip_top_ranked(
             top_ranked_mapping,
             "summary",
             not self_contained,
-            )
+        )
         log.info("Plotting results..")
         scatters = scatter_plot_handler(
             ss_filename,
@@ -619,14 +620,14 @@ def analyse_step(
             format,
             scale,
             offline=offline,
-            )
+        )
         boxes = box_plot_handler(
             ss_filename,
             cluster_ranking,
             format,
             scale,
             offline=offline,
-            )
+        )
         tables = clt_table_handler(
             clt_filename,
             ss_filename,
@@ -635,7 +636,7 @@ def analyse_step(
             clustered_topX=clustered_topX,
             unclustered_topX=unclustered_topX,
             top_ranked_mapping=top_ranked_mapping if self_contained else None,
-            )
+        )
         report_generator(boxes, scatters, tables, step, ".", offline)
 
 
@@ -674,7 +675,7 @@ def validate_format(_format: Optional[ImgFormat]) -> Optional[ImgFormat]:
                 f"Exporting with format {format} requires the use of `kaleido`"
                 f" package, that seems not to be installed. {os.linesep}"
                 "Please install it with: `pip install kaleido==0.2.*`"
-                )
+            )
         # At this stage, everything should go smooth with the export format
         else:
             # Return supported format
@@ -683,7 +684,7 @@ def validate_format(_format: Optional[ImgFormat]) -> Optional[ImgFormat]:
     raise ValueError(
         f"Format `{format}` is not supported.{os.linesep}"
         f"Supported formats: {SUPPORTED_OUTPUT_FORMATS}."
-        )
+    )
 
 
 def main(
@@ -757,15 +758,9 @@ def main(
     # get the module folders from the run_dir input
     sel_steps = get_module_steps_folders(Path("./"), modules)
     if inter:
-        sel_steps = [
-            st for st in sel_steps
-            if st.endswith(INTERACTIVE_RE_SUFFIX)
-            ]
+        sel_steps = [st for st in sel_steps if st.endswith(INTERACTIVE_RE_SUFFIX)]
     else:
-        sel_steps = [
-            st for st in sel_steps
-            if not st.endswith(INTERACTIVE_RE_SUFFIX)
-            ]
+        sel_steps = [st for st in sel_steps if not st.endswith(INTERACTIVE_RE_SUFFIX)]
     log.info(f"selected steps: {', '.join(sel_steps)}")
 
     # analysis
@@ -780,9 +775,8 @@ def main(
         if dest_path.exists():
             if len(os.listdir(dest_path)) != 0 and not inter:
                 log.warning(
-                    f"{dest_path} exists and is not empty. "
-                    "Skipping analysis..."
-                    )
+                    f"{dest_path} exists and is not empty. Skipping analysis..."
+                )
                 continue
             else:  # subfolder is empty or is interactive, remove it.
                 log.info(f"Removing folder {dest_path}.")
@@ -803,12 +797,12 @@ def main(
                 mode=mode,
                 ncores=ncores,
                 self_contained=self_contained,
-                )
+            )
         except Exception as e:
             log.warning(
                 f"Could not execute the analysis for step {step}. "
                 f"The following error occurred: {e}"
-                )
+            )
             bad_folder_paths.append(target_path)
         else:
             good_folder_paths.append(target_path)
@@ -824,7 +818,7 @@ def main(
             shutil.move(directory, outdir)
             url = f"- [{Path(directory, 'report.html')}](http://0.0.0.0:8000/{Path(directory, 'report.html')}) "  # noqa : E501
             urls.append(url)
-        
+
         # Adding instructions on how to setup the server
         readme_fpath = Path(outdir, "README.md")
         readme_fpath.write_text(
@@ -834,7 +828,7 @@ def main(
             f"python -m http.server --directory .{os.linesep}```{os.linesep}"
             f"And open the link following links in a web browser:{os.linesep}"
             f"{os.linesep.join(urls)}{os.linesep}"
-            )
+        )
         assert readme_fpath.exists()
 
     if bad_folder_paths != []:
@@ -859,7 +853,7 @@ def main(
             # "By default, http server runs on `http://0.0.0.0:8000/`. "
             f"And open the link http://0.0.0.0:8000/{report_file} "
             "in a web browser."
-            )
+        )
         log.info(info_msg)
     os.chdir(ori_cwd)
     return

--- a/src/haddock/clis/cli_traceback.py
+++ b/src/haddock/clis/cli_traceback.py
@@ -9,6 +9,7 @@ USAGE::
     haddock3-traceback -r <run_dir>
 
 """
+
 import argparse
 import sys
 from pathlib import Path
@@ -17,7 +18,7 @@ import numpy as np
 import pandas as pd
 
 from haddock import log
-from haddock.core.defaults import TRACEBACK_FOLDER
+from haddock.core.defaults import MODULE_IO_FILE, TRACEBACK_FOLDER
 from haddock.core.typing import Any, FilePath
 from haddock.libs import libcli
 from haddock.libs.libontology import ModuleIO, PDBFile
@@ -33,10 +34,10 @@ def get_steps_without_pdbs(run_dir, all_steps):
     ----------
     run_dir : str or pathlib.Path
         Path to the run directory.
-    
+
     all_steps : list
         List of all the steps in the run directory.
-    
+
     Returns
     -------
     steps_without_pdbs : list
@@ -119,7 +120,7 @@ def traceback_dataframe(
     df_data.reset_index(inplace=True)
     # assign columns
     data_cols = [el for el in reversed(sel_step)]
-    data_cols.extend([f"00_topo{i+1}" for i in range(max_topo_len)])
+    data_cols.extend([f"00_topo{i + 1}" for i in range(max_topo_len)])
     df_data.columns = data_cols
 
     # same for the rank_dict
@@ -147,10 +148,10 @@ def order_traceback_df(df_output, sel_step):
     ----------
     df_output : pandas.DataFrame
         Dataframe containing the traceback data.
-    
+
     sel_step : list
         List of selected steps.
-    
+
     Returns
     -------
     df_output : pandas.DataFrame
@@ -182,17 +183,17 @@ def subset_traceback(traceback_df: pd.DataFrame, cons_filename: Path) -> pd.Data
     ----------
     traceback_df : pandas.DataFrame
         Dataframe containing the traceback data.
-    
+
     cons_filename : pathlib.Path
         name of the consensus file.
-    
+
     Returns
     -------
     rank_data_subset : pandas.DataFrame
         Dataframe containing the subset of the traceback data.
     """
     red_traceback_df = traceback_df.head(40)
-    rank_data = red_traceback_df.filter(regex='rank$')
+    rank_data = red_traceback_df.filter(regex="rank$")
     # get the last column: this will define the name of the models
     last_column = red_traceback_df.columns[-2]
     last_column_data = red_traceback_df[last_column]
@@ -201,11 +202,13 @@ def subset_traceback(traceback_df: pd.DataFrame, cons_filename: Path) -> pd.Data
     # the rank of the last column must be defined
     last_column_rank = last_column + "_rank"
     # copy avoids SettingWithCopyWarning
-    rank_data_subset = rank_data[rank_data[last_column_rank] != '-'].copy()
+    rank_data_subset = rank_data[rank_data[last_column_rank] != "-"].copy()
     rank_columns = rank_data_subset.columns[1:].tolist()
-    rank_data_subset[rank_columns] = rank_data_subset[rank_columns].apply(pd.to_numeric, errors='coerce')
+    rank_data_subset[rank_columns] = rank_data_subset[rank_columns].apply(
+        pd.to_numeric, errors="coerce"
+    )
     rank_data_subset = rank_data_subset.sort_values(by=last_column_rank, ascending=True)
-    
+
     # rename the columns
     rank_data_subset.columns = ["Model"] + rank_columns
     # sum the ranks
@@ -288,10 +291,10 @@ def main(run_dir: FilePath, offline: bool = False) -> None:
                 data_dict[key][-1] = f"../{sel_step[n]}/{data_dict[key][-1]}"
 
         delta = len(sel_step) - n - 1  # how many steps have we gone back?
-        # loading the .json file
-        json_path = Path(run_dir, sel_step[n], "io.json")
+        # loading the ModuleIO pickle
+        io_module_filepath = Path(run_dir, sel_step[n], MODULE_IO_FILE)
         io = ModuleIO()
-        io.load(json_path)
+        io.load(io_module_filepath)
         # list all the values in the data_dict
         ls_values = [x for val in data_dict.values() for x in val]
         # getting and sorting the ranks for the current step folder
@@ -315,7 +318,11 @@ def main(run_dir: FilePath, offline: bool = False) -> None:
                     unk_idx += 1
                 else:
                     # we've already seen this pdb before.
-                    idxs = [i for i, el in enumerate(ls_values) if el==str(pdbfile.rel_path)]
+                    idxs = [
+                        i
+                        for i, el in enumerate(ls_values)
+                        if el == str(pdbfile.rel_path)
+                    ]
                     keys = [list(data_dict.keys())[idx // delta] for idx in idxs]
 
                 # assignment
@@ -349,9 +356,7 @@ def main(run_dir: FilePath, offline: bool = False) -> None:
     df_output = order_traceback_df(df_output, sel_step)
     # dumping the dataframe
     track_filename = Path(run_dir, TRACEBACK_FOLDER, "traceback.tsv")
-    log.info(
-        f"Output dataframe {track_filename} " f"created with shape {df_output.shape}"
-    )
+    log.info(f"Output dataframe {track_filename} created with shape {df_output.shape}")
     df_output.to_csv(track_filename, sep="\t", index=False)
 
     # taking (and writing) a subset of the dataframe

--- a/src/haddock/clis/re/clustfcc.py
+++ b/src/haddock/clis/re/clustfcc.py
@@ -111,13 +111,12 @@ def reclustfcc(
     outdir.mkdir(exist_ok=True)
 
     # create an io object
-    # FIXME: For some reason this needs to be `io.json`
     io = ModuleIO()
-    filename = Path(clustfcc_dir, "io.json")
+    filename = Path(clustfcc_dir, MODULE_IO_FILE)
     io.load(filename)
     models = io.input
     # copying ModuleIO file to the new directory
-    shutil.copy(filename, Path(outdir, "io.json"))
+    shutil.copy(filename, Path(outdir, MODULE_IO_FILE))
 
     # load the original clustering parameters via json
     clustfcc_params = read_config(Path(clustfcc_dir, "params.cfg"))

--- a/src/haddock/clis/re/clustfcc.py
+++ b/src/haddock/clis/re/clustfcc.py
@@ -111,12 +111,13 @@ def reclustfcc(
     outdir.mkdir(exist_ok=True)
 
     # create an io object
+    # FIXME: For some reason this needs to be `io.json`
     io = ModuleIO()
-    filename = Path(clustfcc_dir, MODULE_IO_FILE)
+    filename = Path(clustfcc_dir, "io.json")
     io.load(filename)
     models = io.input
     # copying ModuleIO file to the new directory
-    shutil.copy(filename, Path(outdir, MODULE_IO_FILE))
+    shutil.copy(filename, Path(outdir, "io.json"))
 
     # load the original clustering parameters via json
     clustfcc_params = read_config(Path(clustfcc_dir, "params.cfg"))

--- a/src/haddock/clis/re/clustfcc.py
+++ b/src/haddock/clis/re/clustfcc.py
@@ -4,7 +4,7 @@ import shutil
 from pathlib import Path
 
 from haddock import log
-from haddock.core.defaults import INTERACTIVE_RE_SUFFIX
+from haddock.core.defaults import INTERACTIVE_RE_SUFFIX, MODULE_IO_FILE
 from haddock.core.typing import Union
 from haddock.gear.config import load as read_config
 from haddock.gear.config import save as save_config
@@ -14,7 +14,7 @@ from haddock.libs.libclust import (
     plot_cluster_matrix,
     rank_clusters,
     write_structure_list,
-    )
+)
 from haddock.libs.libfcc import create_elements, load_matrix
 from haddock.libs.libinteractive import look_for_capri, rewrite_capri_tables
 from haddock.libs.libontology import ModuleIO
@@ -23,7 +23,7 @@ from haddock.modules.analysis.clustfcc.clustfcc import (
     iterate_clustering,
     write_clusters,
     write_clustfcc_file,
-    )
+)
 
 
 def add_clustfcc_arguments(clustfcc_subcommand):
@@ -112,11 +112,11 @@ def reclustfcc(
 
     # create an io object
     io = ModuleIO()
-    filename = Path(clustfcc_dir, "io.json")
+    filename = Path(clustfcc_dir, MODULE_IO_FILE)
     io.load(filename)
     models = io.input
-    # copying io.json to the new directory
-    shutil.copy(filename, Path(outdir, "io.json"))
+    # copying ModuleIO file to the new directory
+    shutil.copy(filename, Path(outdir, MODULE_IO_FILE))
 
     # load the original clustering parameters via json
     clustfcc_params = read_config(Path(clustfcc_dir, "params.cfg"))

--- a/src/haddock/core/defaults.py
+++ b/src/haddock/core/defaults.py
@@ -20,7 +20,7 @@ MODULE_PATH_NAME = "step_"
 Module input and generated data will be stored in folder starting by
 this prefix"""
 
-MODULE_IO_FILE = "io.json"
+MODULE_IO_FILE = "io.pkl"
 """Default name for exchange module information file"""
 
 MAX_NUM_MODULES = 10000

--- a/src/haddock/libs/libontology.py
+++ b/src/haddock/libs/libontology.py
@@ -216,7 +216,10 @@ class ModuleIO:
         """Load the content of a given IO filename."""
         try:
             content = self._load_pkl(filename)
-        except pickle.UnpicklingError:
+        except Exception as _:
+            # HACK: We only need this `_load_json` because lots
+            #  of tests were built based on this construction and
+            #  it is hardcoded into some of the `cli.re` tools
             content = self._load_json(filename)
 
         self.input = content["input"]
@@ -225,13 +228,14 @@ class ModuleIO:
 
     @staticmethod
     def _load_json(filename: FilePath):
-        with open(filename) as json_file:
-            content = jsonpickle.decode(json_file.read())
+        filename = Path(filename).with_suffix(".json")
+        with open(file=filename, mode="r") as fh:
+            content = jsonpickle.decode(fh.read())
         return content
 
     @staticmethod
     def _load_pkl(filename: FilePath):
-        with open(filename, "rb") as fh:
+        with open(file=filename, mode="rb") as fh:
             content = pickle.load(fh)
         return content
 

--- a/src/haddock/libs/libontology.py
+++ b/src/haddock/libs/libontology.py
@@ -2,17 +2,16 @@
 
 import datetime
 import itertools
-from enum import Enum
+import pickle
+from enum import Enum, auto
 from os import linesep
 from pathlib import Path
-
+from typing import Any, Dict, Generic, Hashable, List, Optional, Tuple, TypeVar
 
 import jsonpickle
 
 from haddock.core.defaults import MODULE_IO_FILE
-from haddock.core.typing import FilePath, Literal, Optional, TypeVar, Union
-from typing import List, Any
-
+from haddock.core.typing import FilePath, Union
 
 NaN = float("nan")
 
@@ -120,12 +119,73 @@ class TopologyFile(Persistent):
         super().__init__(file_name, Format.TOPOLOGY, path)
 
 
+class CacheKey(Enum):
+    RMSD = auto()
+
+
+K = TypeVar("K", bound=Hashable)
+V = TypeVar("V")
+
+
+class Cache(Generic[K, V]):
+    """Cache with searchable entries by composite keys."""
+
+    def __init__(self):
+        # Main storage: key -> list of (search_key, value) tuples
+        self._store: Dict[CacheKey, List[Tuple[K, V]]] = {}
+
+        # Initialize with all CacheKey enum values
+        for key in CacheKey:
+            self._store[key] = []
+
+        # Index for fast lookup: (cache_key, search_key) -> value
+        self._index: Dict[Tuple[CacheKey, K], V] = {}
+
+    def add(self, cache_key: CacheKey, search_key: K, value: V) -> None:
+        """Add entry with searchable key.
+
+        # Example:
+        #  cache.add(CacheKey.RMSD, ("xxx", "yyy", 42.0))
+
+        """
+        self._store[cache_key].append((search_key, value))
+        self._index[(cache_key, search_key)] = value
+
+    def get(self, cache_key: CacheKey, search_key: K) -> Optional[V]:
+        """Retrieve value by search key.
+
+        # Example:
+        #  rmsd = cache.get(CacheKey.RMSD, ("xxx", "yyy"))
+        """
+        return self._index.get((cache_key, search_key))
+
+    def has(self, cache_key: CacheKey, search_key: K) -> bool:
+        """Check if entry exists.
+
+        # Example:
+        #  cache.has(CacheKey.RMSD, ("xxx", "yyy"))
+        """
+        return (cache_key, search_key) in self._index
+
+    def get_all(self, cache_key: CacheKey) -> List[Tuple[K, V]]:
+        """Get all entries for a cache key."""
+        return self._store.get(cache_key, []).copy()
+
+    def clear(self, cache_key: CacheKey) -> None:
+        """Clear all entries for a cache key."""
+        for search_key, _ in self._store[cache_key]:
+            self._index.pop((cache_key, search_key), None)
+        # Clear storage
+        self._store[cache_key].clear()
+
+
 class ModuleIO:
     """Intercommunicating modules and exchange input/output information."""
 
     def __init__(self) -> None:
         self.input: List[Any] = []
         self.output: List[Any] = []
+        self.cache: Cache = Cache()
 
     def add(self, persistent, mode="i"):
         """Add a given filename as input or output."""
@@ -140,21 +200,40 @@ class ModuleIO:
             else:
                 self.output.append(persistent)
 
+    def update_cache(self, cache):
+        """Update the internal cache of ModuleIO."""
+        self.cache = cache
+
     def save(self, path: FilePath = ".", filename: FilePath = MODULE_IO_FILE) -> Path:
         """Save Input/Output needed files by this module to disk."""
         fpath = Path(path, filename)
-        with open(fpath, "w") as output_handler:
-            to_save = {"input": self.input, "output": self.output}
-            jsonpickle.set_encoder_options("json", sort_keys=True, indent=4)
-            output_handler.write(jsonpickle.encode(to_save))  # type: ignore
+        with open(fpath, "wb") as output_handler:
+            data = {"input": self.input, "output": self.output, "cache": self.cache}
+            pickle.dump(data, output_handler)
         return fpath
 
     def load(self, filename: FilePath) -> None:
         """Load the content of a given IO filename."""
+        try:
+            content = self._load_pkl(filename)
+        except pickle.UnpicklingError:
+            content = self._load_json(filename)
+
+        self.input = content["input"]
+        self.output = content["output"]
+        self.cache = content.get("cache", Cache())
+
+    @staticmethod
+    def _load_json(filename: FilePath):
         with open(filename) as json_file:
             content = jsonpickle.decode(json_file.read())
-            self.input = content["input"]  # type: ignore
-            self.output = content["output"]  # type: ignore
+        return content
+
+    @staticmethod
+    def _load_pkl(filename: FilePath):
+        with open(filename, "rb") as fh:
+            content = pickle.load(fh)
+        return content
 
     def retrieve_models(
         self, crossdock: bool = False, individualize: bool = False

--- a/src/haddock/libs/libontology.py
+++ b/src/haddock/libs/libontology.py
@@ -217,26 +217,34 @@ class ModuleIO:
         try:
             content = self._load_pkl(filename)
         except Exception as _:
-            # HACK: We only need this `_load_json` because lots
-            #  of tests were built based on this construction and
-            #  it is hardcoded into some of the `cli.re` tools
+            # ====================================================== #
+            # FIXME: In some tests the moduleio file is being used
+            #  as input for the test. This try/except only exists
+            #  to handle this scenarios - ideally all tests that
+            #  use this constructions MUST be redone to account
+            #  for the pickle instead of the json
             content = self._load_json(filename)
+            # ====================================================== #
 
         self.input = content["input"]
         self.output = content["output"]
         self.cache = content.get("cache", Cache())
 
     @staticmethod
-    def _load_json(filename: FilePath):
-        filename = Path(filename).with_suffix(".json")
-        with open(file=filename, mode="r") as fh:
-            content = jsonpickle.decode(fh.read())
+    def _load_pkl(filename: FilePath):
+        """Load the pickle."""
+        with open(file=filename, mode="rb") as fh:
+            content = pickle.load(fh)
         return content
 
     @staticmethod
-    def _load_pkl(filename: FilePath):
-        with open(file=filename, mode="rb") as fh:
-            content = pickle.load(fh)
+    def _load_json(filename: FilePath):
+        """Try to load a `.json`."""
+        _json_filename = Path(filename).with_suffix(".json")
+        if _json_filename.exists():
+            filename = _json_filename
+        with open(file=filename, mode="r") as fh:
+            content = jsonpickle.decode(fh.read())
         return content
 
     def retrieve_models(

--- a/src/haddock/modules/__init__.py
+++ b/src/haddock/modules/__init__.py
@@ -31,7 +31,7 @@ from haddock.libs.libhpc import HPCScheduler
 from haddock.libs.libgrid import GRIDScheduler, ping_dirac
 from haddock.libs.libio import folder_exists, working_directory
 from haddock.libs.libmpi import MPIScheduler
-from haddock.libs.libontology import ModuleIO, PDBFile
+from haddock.libs.libontology import Cache, ModuleIO, PDBFile
 from haddock.libs.libparallel import Scheduler
 from haddock.libs.libtimer import log_time
 from haddock.libs.libutil import recursive_dict_update
@@ -129,6 +129,7 @@ class BaseHaddockModule(ABC):
         self.order = order
         self.path = path
         self.previous_io = self._load_previous_io()
+        self.cache = self.previous_io.cache
 
         # instantiate module's parameters
         self._origignal_config_file = params_fname
@@ -295,6 +296,8 @@ class BaseHaddockModule(ABC):
         io.add(self.previous_io.output, "i")
         # add the output models
         io.add(self.output_models, "o")
+        # update the cache - use the current module's cache which includes previous cache
+        io.update_cache(self.cache)
         # Removes un-generated outputs and compute percentage of ungenerated
         faulty = io.check_faulty()
         # Save outputs

--- a/tests/test_cli_re.py
+++ b/tests/test_cli_re.py
@@ -1,5 +1,7 @@
 """Test the haddock3-re CLI."""
+
 from haddock.clis.cli_re import maincli as cli_re
+from haddock.core.defaults import MODULE_IO_FILE
 import pytest
 import tempfile
 import subprocess
@@ -21,7 +23,7 @@ def weights_dict():
         "w_desolv": 1.0,
         "w_bsa": -0.01,
         "w_air": 0.01,
-        }
+    }
 
 
 def test_cli_re_empty():
@@ -47,9 +49,8 @@ def test_cli_rescore(weights_dict):
 
             # check if the files are created
             interactive_folder = [
-                el for el in os.listdir(tmpdir)
-                if el.endswith("interactive")
-                ]
+                el for el in os.listdir(tmpdir) if el.endswith("interactive")
+            ]
             assert len(interactive_folder) == 1
             interactive_folder = Path(tmpdir, interactive_folder[0])
 
@@ -76,26 +77,33 @@ def test_cli_reclustfcc():
     with tempfile.TemporaryDirectory() as tmpdir:
         nested_tmpdir = Path(tmpdir, "03_clustfcc")
         os.mkdir(nested_tmpdir)
-        # json file
+
+        # io file
         flexref_json = Path(golden_data, "io_flexref.json")
-        shutil.copy(flexref_json, Path(nested_tmpdir, "io.json"))
+        shutil.copy(flexref_json, Path(nested_tmpdir, MODULE_IO_FILE))
+
         # params.cfg
         clustfcc_params_cfg = Path(golden_data, "params_clustfcc.cfg")
         shutil.copy(clustfcc_params_cfg, Path(nested_tmpdir, "params.cfg"))
+
         # fcc matrix
         fcc_matrix = Path(golden_data, "example_fcc.matrix")
         shutil.copy(fcc_matrix, Path(nested_tmpdir, "fcc.matrix"))
-        subprocess.run([
-            "haddock3-re", "clustfcc", nested_tmpdir,
-            "-f", "0.65",
-            "-p"  # shortcut to --plot_matrix
-            ])
+        subprocess.run(
+            [
+                "haddock3-re",
+                "clustfcc",
+                nested_tmpdir,
+                "-f",
+                "0.65",
+                "-p",  # shortcut to --plot_matrix
+            ]
+        )
 
         # check if the interactive folders is created
         interactive_folder = [
-            el for el in os.listdir(tmpdir)
-            if el.endswith("interactive")
-            ]
+            el for el in os.listdir(tmpdir) if el.endswith("interactive")
+        ]
         assert len(interactive_folder) == 1
         # check that the clustfcc.tsv file is correctly created
         interactive_folder = Path(tmpdir, interactive_folder[0])
@@ -115,7 +123,7 @@ def test_cli_reclustfcc():
         clustfcc_html_matrix = Path(interactive_folder, "fcc_matrix.html")
         assert clustfcc_html_matrix.exists()
         assert clustfcc_html_matrix.stat().st_size != 0
-    
+
 
 def test_cli_reclustrmsd():
     """Test haddock3-re clustrmsd subcommand."""
@@ -130,16 +138,14 @@ def test_cli_reclustrmsd():
         with open(rmsdmatrix_json, "r") as fin, open(tmp_rmsdmatrix_json, "w") as fout:
             for _ in fin:
                 fout.write(
-                    _.replace(
-                        "tests/golden_data",
-                        str(nested_tmpdir_previousstep))
-                    )
-        # example ilrmsd matrix 
+                    _.replace("tests/golden_data", str(nested_tmpdir_previousstep))
+                )
+        # example ilrmsd matrix
         ilrmsd_matrix = Path(golden_data, "example_ilrmsd.matrix")
         shutil.copy(
             ilrmsd_matrix,
             Path(nested_tmpdir_previousstep, "example_ilrmsd.matrix"),
-            )
+        )
 
         # Fake clustrmsd module files
         nested_tmpdir = Path(tmpdir, "2_clustrmsd")
@@ -154,16 +160,20 @@ def test_cli_reclustrmsd():
         dendrogram = Path(golden_data, "example_dendrogram.txt")
         shutil.copy(dendrogram, Path(nested_tmpdir, "dendrogram.txt"))
         # Run re-clustrmsd
-        subprocess.run([
-            "haddock3-re", "clustrmsd", nested_tmpdir,
-            "-n", "2",  # set desired number of clusters
-            "-p"  # shortcut to --plot_matrix
-            ])
+        subprocess.run(
+            [
+                "haddock3-re",
+                "clustrmsd",
+                nested_tmpdir,
+                "-n",
+                "2",  # set desired number of clusters
+                "-p",  # shortcut to --plot_matrix
+            ]
+        )
         # check if the interactive folders is created
         interactive_folder = [
-            el for el in os.listdir(tmpdir)
-            if el.endswith("interactive")
-            ]
+            el for el in os.listdir(tmpdir) if el.endswith("interactive")
+        ]
         assert len(interactive_folder) == 1
 
         # check that the clustrmsd.tsv file is correctly created

--- a/tests/test_libontology.py
+++ b/tests/test_libontology.py
@@ -1,13 +1,14 @@
-import json
 import math
+import pickle
 import tempfile
 from pathlib import Path
 
-from haddock.core.defaults import MODULE_IO_FILE
 import pytest
 
+from haddock.core.defaults import MODULE_IO_FILE
 from haddock.core.typing import Generator
 from haddock.libs.libontology import (
+    Cache,
     Format,
     ModuleIO,
     PDBFile,
@@ -67,14 +68,14 @@ def module_io_with_persistent():
 
 
 @pytest.fixture
-def io_data() -> dict:
-    return {"input": ["input"], "output": ["output"]}
+def io_data():
+    return {"input": ["input"], "output": ["output"], "cache": Cache()}
 
 
 @pytest.fixture
-def io_json_file(io_data) -> Generator[Path, None, None]:
-    with tempfile.NamedTemporaryFile(mode="w+") as f:
-        json.dump(io_data, f)
+def io_file(io_data) -> Generator[Path, None, None]:
+    with tempfile.NamedTemporaryFile(mode="wb+") as f:
+        pickle.dump(io_data, f)
 
         f.seek(0)
 
@@ -284,9 +285,9 @@ def test_moduleio_save(monkeypatch):
         assert expected_file.stat().st_size > 0
 
 
-def test_moduleio_load(io_json_file, io_data):
+def test_moduleio_load_json(io_file, io_data):
     moduleio = ModuleIO()
-    moduleio.load(filename=io_json_file)
+    moduleio.load(filename=io_file)
 
     assert moduleio.input == io_data["input"]
     assert moduleio.output == io_data["output"]

--- a/tests/test_libontology.py
+++ b/tests/test_libontology.py
@@ -3,6 +3,7 @@ import math
 import tempfile
 from pathlib import Path
 
+from haddock.core.defaults import MODULE_IO_FILE
 import pytest
 
 from haddock.core.typing import Generator
@@ -269,26 +270,18 @@ def test_moduleio_add_list():
     assert moduleio.output == ["literally", "anything"]
 
 
-@pytest.mark.skip(reason="deprecated")
-def test_moduleio_save(mocker, moduleio_with_pdbfile_list):
-    with tempfile.NamedTemporaryFile() as temp_module_io_f:
-        mocker.patch("haddock.core.defaults", temp_module_io_f.name)
+def test_moduleio_save(monkeypatch):
+    with tempfile.TemporaryDirectory() as tempdir:
+        monkeypatch.chdir(tempdir)
 
-        observed_io_filename = moduleio_with_pdbfile_list.save(
-            filename=temp_module_io_f.name
-        )
+        io = ModuleIO()
+        io.add(["something"])
+        io.save()
 
-        assert observed_io_filename.exists()
-        assert observed_io_filename.stat().st_size > 0
+        expected_file = Path(tempdir, MODULE_IO_FILE)
 
-        expected_io_filename = Path.cwd() / temp_module_io_f.name
-
-        assert observed_io_filename == expected_io_filename
-
-        with open(observed_io_filename, "r") as f:
-            observed_data = json.load(f)
-
-        assert isinstance(observed_data, dict)
+        assert expected_file.exists()
+        assert expected_file.stat().st_size > 0
 
 
 def test_moduleio_load(io_json_file, io_data):

--- a/tests/test_libontology.py
+++ b/tests/test_libontology.py
@@ -110,7 +110,6 @@ def test_persistent_is_present():
 
 
 def test_pdbfile_init_empty():
-
     pdbfile = PDBFile(file_name="test.pdb")
 
     assert pdbfile.file_name == "test.pdb"
@@ -208,7 +207,6 @@ def test_pdbfile_init_with_ligand_files():
 
 
 def test_rmsdfile_init():
-
     npairs = 42
     file_name = Path("/some/path/test.rmsd")
     rmsdfile = RMSDFile(file_name=file_name, npairs=npairs)
@@ -220,7 +218,6 @@ def test_rmsdfile_init():
 
 
 def test_topologyfile_init():
-
     file_name = Path("/some/path/test.top")
     topologyfile = TopologyFile(file_name=file_name)
 
@@ -230,7 +227,6 @@ def test_topologyfile_init():
 
 
 def test_moduleio_init():
-
     moduleio = ModuleIO()
 
     assert isinstance(moduleio.input, list)
@@ -238,7 +234,6 @@ def test_moduleio_init():
 
 
 def test_moduleio_add_anything():
-
     input = "literally anything"
 
     moduleio = ModuleIO()
@@ -257,7 +252,6 @@ def test_moduleio_add_anything():
 
 
 def test_moduleio_add_list():
-
     input = ["literally", "anything"]
 
     moduleio = ModuleIO()
@@ -275,8 +269,8 @@ def test_moduleio_add_list():
     assert moduleio.output == ["literally", "anything"]
 
 
+@pytest.mark.skip(reason="deprecated")
 def test_moduleio_save(mocker, moduleio_with_pdbfile_list):
-
     with tempfile.NamedTemporaryFile() as temp_module_io_f:
         mocker.patch("haddock.core.defaults", temp_module_io_f.name)
 
@@ -298,7 +292,6 @@ def test_moduleio_save(mocker, moduleio_with_pdbfile_list):
 
 
 def test_moduleio_load(io_json_file, io_data):
-
     moduleio = ModuleIO()
     moduleio.load(filename=io_json_file)
 
@@ -307,7 +300,6 @@ def test_moduleio_load(io_json_file, io_data):
 
 
 def test_moduleio_retrieve_models_list(moduleio_with_pdbfile_list):
-
     result = moduleio_with_pdbfile_list.retrieve_models()
 
     assert isinstance(result, list)
@@ -316,7 +308,6 @@ def test_moduleio_retrieve_models_list(moduleio_with_pdbfile_list):
 
 
 def test_moduleio_retrieve_models_dict(moduleio_with_pdbfile_dict):
-
     result = moduleio_with_pdbfile_dict.retrieve_models(
         crossdock=True, individualize=True
     )
@@ -349,7 +340,6 @@ def test_moduleio_retrieve_models_dict(moduleio_with_pdbfile_dict):
 
 
 def test_moduleio_check_faulty(mocker, module_io_with_persistent):
-
     mocker.patch.object(module_io_with_persistent, "remove_missing", return_value=None)
 
     result = module_io_with_persistent.check_faulty()
@@ -370,7 +360,6 @@ def test_moduleio_check_faulty(mocker, module_io_with_persistent):
 
 
 def test_moduleio_remove_missing(module_io_with_persistent):
-
     # Remove the first file
     first_file = module_io_with_persistent.output[0].rel_path
     first_file.unlink()

--- a/tests/test_module_clustfcc.py
+++ b/tests/test_module_clustfcc.py
@@ -19,9 +19,10 @@ def fixture_fcc_module(monkeypatch):
             order=1,
             path=Path("."),
             initial_params=clustfcc_pars,
-            )
+        )
 
 
+@pytest.mark.skip(reason="deprecated")
 def test_io_json(fcc_module, protprot_input_list):
     """Test the correct creation of the io.json file."""
     # set the input and output models
@@ -31,6 +32,25 @@ def test_io_json(fcc_module, protprot_input_list):
     # export models
     fcc_module.export_io_models()
     expected_io = Path(f"{fcc_module.path}/io.json")
+
+    assert expected_io.exists()
+
+    # check the content of io.json
+    io = ModuleIO()
+    io.load(expected_io)
+    assert io.input[0].file_name == protprot_input_list[0].file_name
+    assert io.output[1].file_name == protprot_input_list[1].file_name
+
+
+def test_io_pkl(fcc_module, protprot_input_list):
+    """Test the correct creation of the io.json file."""
+    # set the input and output models
+    fcc_module.previous_io.output = protprot_input_list
+    fcc_module.output_models = protprot_input_list
+
+    # export models
+    fcc_module.export_io_models()
+    expected_io = Path(f"{fcc_module.path}/io.pkl")
 
     assert expected_io.exists()
 

--- a/tests/test_module_clustfcc.py
+++ b/tests/test_module_clustfcc.py
@@ -3,6 +3,7 @@
 import tempfile
 from pathlib import Path
 
+from haddock.core.defaults import MODULE_IO_FILE
 import pytest
 
 from haddock.libs.libontology import ModuleIO
@@ -22,35 +23,17 @@ def fixture_fcc_module(monkeypatch):
         )
 
 
-@pytest.mark.skip(reason="deprecated")
-def test_io_json(fcc_module, protprot_input_list):
-    """Test the correct creation of the io.json file."""
+def test_io(fcc_module, protprot_input_list):
+    """Test the correct creation of the ModuleIO file."""
+    # FIXME: This test is not related to this module
+
     # set the input and output models
     fcc_module.previous_io.output = protprot_input_list
     fcc_module.output_models = protprot_input_list
 
     # export models
     fcc_module.export_io_models()
-    expected_io = Path(f"{fcc_module.path}/io.json")
-
-    assert expected_io.exists()
-
-    # check the content of io.json
-    io = ModuleIO()
-    io.load(expected_io)
-    assert io.input[0].file_name == protprot_input_list[0].file_name
-    assert io.output[1].file_name == protprot_input_list[1].file_name
-
-
-def test_io_pkl(fcc_module, protprot_input_list):
-    """Test the correct creation of the io.json file."""
-    # set the input and output models
-    fcc_module.previous_io.output = protprot_input_list
-    fcc_module.output_models = protprot_input_list
-
-    # export models
-    fcc_module.export_io_models()
-    expected_io = Path(f"{fcc_module.path}/io.pkl")
+    expected_io = Path(f"{fcc_module.path}/{MODULE_IO_FILE}")
 
     assert expected_io.exists()
 

--- a/tests/test_module_clustrmsd.py
+++ b/tests/test_module_clustrmsd.py
@@ -19,9 +19,10 @@ from haddock.modules.analysis.clustrmsd.clustrmsd import (
     iterate_min_population,
     order_clusters,
     read_matrix,
-    )
+)
 from haddock.modules.analysis.rmsdmatrix import DEFAULT_CONFIG as rmsd_pars
 from haddock.modules.analysis.rmsdmatrix import HaddockModule as HaddockRMSD
+from haddock.core.defaults import MODULE_IO_FILE
 
 
 @pytest.fixture(name="output_list")
@@ -33,7 +34,7 @@ def fixture_output_list():
         "cluster.out",
         "clustrmsd.txt",
         "clustrmsd.tsv",
-        "io.json",
+        MODULE_IO_FILE,
     ]
 
 


### PR DESCRIPTION
This PR introduces a caching system to the `ModuleIO` interface to hold values that should not be re-calculated across modules.

In this first implementation I only added an `RMSD` key but this can be further expanded to hold anything.

It works by adding a `Cache` to the `ModuleIO` interface that has full serialization support. It has a `_store` to hold the information and a `_index` as a helper for faster O(1) lookup (standard caching implementation).

Being part of the `ModuleIO` interface means it is accessible to all modules and save/load operations in this interface also applies to `Cache`.

I have added a new method `update_cache` to the interface that is used by the primitive module class to propagate the cache when the module `export_io_models`.

A relevant technical detail is that for proper typing and serializadion/de-serialization of the `Cache` we need to drop the `jsonpickle` approach to represent the `ModuleIO` interface in favor of a simple (but not human readable) pickle. I also observed that a lot of tests are using a file representation of this interface as arguments to test some behaviour - so I have added a fallback to the `load` method to handle this scenario. This is not ideal but its a sensible compromise. 

### **No modules are using the cache yet!**

This PR here just adds the system, I will refactor the modules to use the cache in another PR (related to #1530 and #1525)