### PR TITLE
add missing `libpdb.sanitize` in `autotoppar` elif logic

### DIFF
--- a/integration_tests/__init__.py
+++ b/integration_tests/__init__.py
@@ -22,6 +22,8 @@ has_cns = pytest.mark.skipif(
 tests_path = Path(__file__).resolve().parents[0]
 GOLDEN_DATA = Path(tests_path, "golden_data")
 
+EXAMPLE_DIR = Path(__file__).resolve().parent.parent / "examples"
+
 try:
     import mpi4py
 

--- a/integration_tests/test_topoaa.py
+++ b/integration_tests/test_topoaa.py
@@ -1,16 +1,14 @@
-import tempfile
 import copy
 import gzip
+import tempfile
 from pathlib import Path
 
-import shutil
 import pytest
 
 from haddock.modules.topology.topoaa import DEFAULT_CONFIG as DEFAULT_TOPOAA_CONFIG
 from haddock.modules.topology.topoaa import HaddockModule as TopoaaModule
 
-from . import CNS_EXEC, has_grid
-from integration_tests import GOLDEN_DATA
+from . import CNS_EXEC, EXAMPLE_DIR, GOLDEN_DATA, has_grid
 
 
 @pytest.fixture
@@ -54,6 +52,44 @@ def extract_nter_cter(fpath) -> tuple[str, str]:
                 # Increment last residue
                 cter += _
     return nter, cter
+
+
+@pytest.mark.parametrize("autotoppar_flag", [False, True])
+def test_topoaa_prot_pep_ens_autotoppar(topoaa_module, autotoppar_flag):
+
+    _data_dir = Path(EXAMPLE_DIR, "docking-protein-peptide", "data")
+    topoaa_module.params["molecules"] = [
+        Path(_data_dir, "1NX1_protein.pdb"),
+        Path(_data_dir, "DAIDALSSDFT_3conformations.pdb"),
+    ]
+    topoaa_module.params["mol1"]["prot_segid"] = "A"
+    # Create mol2 parameters by copying the ones found for mol1
+    topoaa_module.params["mol2"] = copy.deepcopy(topoaa_module.params["mol1"])
+    topoaa_module.params["mol2"]["prot_segid"] = "B"
+    topoaa_module.params["debug"] = True
+    topoaa_module.params["autotoppar"] = autotoppar_flag
+    topoaa_module.run()
+
+    expected_files = [
+        "1NX1_protein.inp",
+        "1NX1_protein_haddock.psf",
+        "1NX1_protein_haddock.pdb",
+        "DAIDALSSDFT_3conformations_1.inp",
+        "DAIDALSSDFT_3conformations_1.pdb",
+        "DAIDALSSDFT_alpha_from_DAIDALSSDFT_3conformations_1_haddock.psf",
+        "DAIDALSSDFT_alpha_from_DAIDALSSDFT_3conformations_1_haddock.pdb",
+        "DAIDALSSDFT_3conformations_2.inp",
+        "DAIDALSSDFT_3conformations_2.pdb",
+        "DAIDALSSDFT_ext_from_DAIDALSSDFT_3conformations_2_haddock.psf",
+        "DAIDALSSDFT_ext_from_DAIDALSSDFT_3conformations_2_haddock.pdb",
+        "DAIDALSSDFT_3conformations_3.inp",
+        "DAIDALSSDFT_3conformations_3.pdb",
+        "DAIDALSSDFT_polyII_from_DAIDALSSDFT_3conformations_3_haddock.psf",
+        "DAIDALSSDFT_polyII_from_DAIDALSSDFT_3conformations_3_haddock.pdb",
+    ]
+
+    for f in expected_files:
+        assert Path(topoaa_module.path, f).exists(), f"{f} not found"
 
 
 @has_grid
@@ -189,7 +225,9 @@ def test_topoaa_module_ligand_hydrogen_build(topoaa_module):
     assert expected_psf.exists()
     assert expected_pdb.exists()
     assert expected_gz.exists()
-    file_content = gzip.open(Path(topoaa_module.path, "oseltamivir.out.gz"), 'rt').read()
+    file_content = gzip.open(
+        Path(topoaa_module.path, "oseltamivir.out.gz"), "rt"
+    ).read()
     assert 'hydrogen_build="unknown"' in file_content
 
 

--- a/src/haddock/modules/topology/topoaa/__init__.py
+++ b/src/haddock/modules/topology/topoaa/__init__.py
@@ -325,6 +325,7 @@ class HaddockModule(BaseCNSModule):
                         libpdb.sanitize(model, overwrite=True, custom_topology=top_path)
                     else:
                         self.log("No unknown atoms found")
+                        libpdb.sanitize(model, overwrite=True)
                         _params = self.params
                 else:
                     libpdb.sanitize(model, overwrite=True)


### PR DESCRIPTION
 You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md).

## Checklist

- [x] Tests added for the new code
- [x] Documentation added for the code changes
- [ ] Modifications / enhancements are reflected on the [haddock3 user-manual](https://github.com/haddocking/haddock3-user-manual)
- [ ] `CHANGELOG.md` is updated to incorporate new changes
- [x] Does not break licensing
- [x] Does not add any dependencies, if it does please add a thorough explanation

## Summary of the Pull Request  
<!-- Describe what changes were made to the code, what was added, removed, etc. -->

Adds a missing `libpdb.sanitize` I forgot to add in the `elif` tree of `autoppar`. Great catch @amjjbonvin (:

## Related Issue
<!-- If this PR is related to an issue, please link it here -->
<!-- If this PR is related to the haddock3 user manual, please link the PR here -->

#1531

## Additional Info
<!-- Any additional information that might be helpful, if applicable -->
