### PR TITLE
improve modules docstrings for CG modules

### DIFF
--- a/src/haddock/modules/refinement/cgtoaa/__init__.py
+++ b/src/haddock/modules/refinement/cgtoaa/__init__.py
@@ -2,6 +2,12 @@
 
 The ``[cgtoaa]`` module translate the CG conformations into AA representations, 
 implemented in CNS.
+
+For this module to be functional, it needs to be run in a workflow where ``[topocg]``
+is present upstream.
+
+For more details about this module, please `refer to the haddock3 user manual
+<https://www.bonvinlab.org/haddock3-user-manual/modules/refinement.html#cgtoaa-module>`_
 """
 
 from pathlib import Path

--- a/src/haddock/modules/topology/topocg/__init__.py
+++ b/src/haddock/modules/topology/topocg/__init__.py
@@ -1,16 +1,19 @@
 """Create and manage CNS coarse-grained topology.
 
 The ``[topocg]`` module is dedicated to the generation of CNS compatible
-parameters (.param) and topologies (.psf) for each of the input structures.
+parameters and topologies (``.psf``) for each of the input structures.
 
 It will:
 - Convert an all atom model to a Martini coarse-grained model
 - Detect missing atoms 
 - Re-build them when missing
-- Build and write out topologies (psf) and coordinates (pdb) files
+- Build and write out topologies (``.psf``) and coordinates (``.pdb``) files
 - Write out a restrain file to convert back the CG model to all atoms
 
 Only standard amino acids and nucleic acids are supported.
+
+For more details about this module, please `refer to the haddock3 user manual
+<https://www.bonvinlab.org/haddock3-user-manual/modules/topology.html#topocg-module>`_
 """
 
 import operator


### PR DESCRIPTION
## Checklist

- [X] Documentation added for the code changes

## Summary of the Pull Request  

Slight improvements on the `__init__.py` for both `[topocg]` and `[cgtoaa]` modules to provide direct links to the haddock3-user-manual
