### PR TITLE
fix FutureWarning when assigning string to int64 cluster_id column - issue #1569

### DIFF
--- a/src/haddock/libs/libplots.py
+++ b/src/haddock/libs/libplots.py
@@ -849,6 +849,7 @@ def create_other_cluster(
     other_structs_df = structs_df[structs_df['cluster_ranking'] >= max_clusters].copy()
     # drop other clusters from structs_df
     structs_df = structs_df[structs_df['cluster_ranking'] < max_clusters].copy()
+    other_structs_df['cluster_id'] = other_structs_df['cluster_id'].astype(object)
     other_structs_df.loc[:,'cluster_id'] = 'Other'
     other_structs_df.loc[:,'cluster_ranking'] = max_clusters
     inner_rank = other_structs_df['caprieval_rank'].rank(method='first').astype(int)  # noqa : E501


### PR DESCRIPTION
Cast cluster_id to object dtype before assigning 'Other' to avoid pandas FutureWarning about incompatible dtype assignment.

 You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md).

## Checklist

- [ ] Tests added for the new code
- [ ] Documentation added for the code changes
- [ ] Modifications / enhancements are reflected on the [haddock3 user-manual](https://github.com/haddocking/haddock3-user-manual)
- [ ] `CHANGELOG.md` is updated to incorporate new changes
- [X] Does not break licensing
- [X] Does not add any dependencies, if it does please add a thorough explanation

## Summary of the Pull Request  

Corrected libplot to avoid future issues.

## Related Issue

#1569
