### PR TITLE
add dev docker image on main push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ on:
       - docs/*
       - pyproject.toml
       - setup.py
+      - Dockerfile
   pull_request:
   workflow_dispatch: ~
   schedule:
@@ -119,3 +120,20 @@ jobs:
       - name: run integration tests
         run: >-
           pytest -v --random-order integration_tests/
+
+  # Verify the Docker image still builds successfully (image is not pushed)
+  docker-build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: build docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: false

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,9 +3,11 @@ name: Create and publish a Docker image
 
 on:
   push:
-    # run only against tags
+    # run on release tags and on merges to main
     tags:
       - "*"
+    branches:
+      - main
 
 env:
   REGISTRY: ghcr.io
@@ -38,6 +40,10 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=tag
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') }}
+            type=raw,value=dev,enable=${{ github.ref == 'refs/heads/main' }}
 
       - name: Build and push
         uses: docker/build-push-action@v5

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #==============================================================================================
-FROM python:3.14-slim
+FROM python:3.14
 
 # uv is used to speed up dependency resolution and installation
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,19 @@
 #==============================================================================================
-FROM python:3.13
+FROM python:3.14-slim
+
+# uv is used to speed up dependency resolution and installation
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
+
+# mpi4py (mpi extra) needs an MPI implementation available at build time
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends openmpi-bin libopenmpi-dev \
+  && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /opt/software
 COPY . .
-RUN pip install --no-cache-dir .
+
+RUN uv pip install --system --no-cache '.[mpi,dev,docs,notebooks]'
+
 WORKDIR /data
 ENTRYPOINT [ "haddock3" ]
 #==============================================================================================


### PR DESCRIPTION
Build a dev Docker image on every push to main, constantly overwritten — does not affect latest, which remains tied to release tags.

This will make the latest version of the code available via `dev` tag in `ghcr.io` - which is valuable given the release conditions of the project are arbitrary