### PR TITLE
skip mpi scheduler test if no mpirun/srun

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -52,6 +52,10 @@ has_chrome = pytest.mark.skipif(
     not any(shutil.which(b) for b in _CHROME_BINS),
     reason="Google Chrome not found (required by Kaleido for PNG export)",
 )
+has_mpi_launcher = pytest.mark.skipif(
+    not any(shutil.which(b) for b in ("mpirun", "srun")),
+    reason="MPI launcher not found",
+)
 is_linux_x86_64 = pytest.mark.skipif(
     platform.system().lower() != "linux" or platform.machine().lower() != "x86_64",
     reason="Only runs on x86_64 Linux systems",

--- a/tests/test_libmpi.py
+++ b/tests/test_libmpi.py
@@ -9,6 +9,7 @@ import pytest
 
 from haddock.libs.libmpi import MPIScheduler
 from haddock.core.exceptions import HaddockTermination
+from . import has_mpi_launcher
 
 
 @pytest.fixture
@@ -31,6 +32,7 @@ def test_mpischeduler_init():
     assert mpi.ncores == cores
 
 
+@has_mpi_launcher
 def test_mpischduler_run(mocker, mpischeduler):
     # Mock the necessary methods and objects
     mock_pickle_tasks = mocker.patch.object(


### PR DESCRIPTION
 You are about to submit a new Pull Request. Before continuing make sure you read the [contributing guidelines](CONTRIBUTING.md).

## Checklist

- [ ] Tests added for the new code
- [ ] Documentation added for the code changes
- [ ] Modifications / enhancements are reflected on the [haddock3 user-manual](https://github.com/haddocking/haddock3-user-manual)
- [ ] `CHANGELOG.md` is updated to incorporate new changes
- [ ] Does not break licensing
- [ ] Does not add any dependencies, if it does please add a thorough explanation

## Summary of the Pull Request  
<!-- Describe what changes were made to the code, what was added, removed, etc. -->
The MPI scheduler test failed in the absence of mpirun/srun. Now it is skipped instead. 

## Related Issue
<!-- If this PR is related to an issue, please link it here -->
<!-- If this PR is related to the haddock3 user manual, please link the PR here -->

## Additional Info
<!-- Any additional information that might be helpful, if applicable -->
