### PR TITLE
update documentation contributions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,24 +63,13 @@ HADDOCK3 maintains minimal dependencies:
 
 ## Documentation Contributions
 
-HADDOCK3 documentation uses Sphinx with Markdown and reStructuredText:
+- Update docstrings for any function, class, or module you add or change.
+- Update the relevant pages under `docs/pages/` for user-facing changes.
+- New modules need a title to be added manually in `docs/titles.yaml`.
+- Confirm `docs/` still builds without introducing new warnings before submitting.
 
-### Local Documentation Build
-
-```bash
-# Install documentation dependencies
-pip install -e '.[docs]'
-
-# Build documentation
-sphinx-apidoc -f -e -o docs/ src/haddock -d 1
-sphinx-build -b html docs haddock3-docs
-```
-
-### Documentation Structure
-
-- Source files in `docs/` directory
-- Follow existing organization and formatting
-- Update both code docstrings and markdown files
+See [docs/README.md](https://github.com/haddocking/haddock3/blob/main/docs/README.md)
+for how to build the docs locally and how docstrings should be formatted.
 
 ## Pull Request Requirements
 


### PR DESCRIPTION
update `CONTRIBUTING.md` to reflect changes to the docs documentation - now centralized at `docs/README.md` but we keep the expectations of what should be added there in `CONTRIBUTING.md`