### PR TITLE
docs: add caprifilter title for Sphinx module pages (#1607)

### DIFF
--- a/devtools/build_defaults_rst.py
+++ b/devtools/build_defaults_rst.py
@@ -31,6 +31,7 @@ MODULE_TITLE_DICT = {
     "emscoring": "Energy Minimization scoring module",
     "clustfcc": "FCC Clustering module",
     "caprieval": "CAPRI Evaluation module",
+    "caprifilter": "CAPRI filter module",
     "contactmap": "Contact Map module",
     "clustrmsd": "RMSD Clustering module",
     "rmsdmatrix": "RMSD Matrix calculation module",
@@ -373,7 +374,7 @@ def main() -> None:
     clients_folder.mkdir(exist_ok=True)
 
     cli_rst_files = Path('docs').glob(
-        f"haddock.clis*.rst"
+        "haddock.clis*.rst"
     )
     for cli_rst_file in cli_rst_files:
         target_rst = Path(


### PR DESCRIPTION
## Summary
- Add `"caprifilter": "CAPRI filter module"` to `MODULE_TITLE_DICT` so `change_title()` applies a human-readable heading when docs are built.
- Remove a pointless f-string prefix.

Closes #1607