### PR TITLE
skip `test_contactmap.py::test_contactmap_example` if not enough memory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,7 @@ jobs:
           # Already covered by test-linux-py314, don't run again
           - os: ubuntu-latest
             python-version: "3.14"
-      fail-fast: false
+      fail-fast: true
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
         run: uv pip install openmm "pdbfixer @ https://github.com/openmm/pdbfixer/archive/refs/tags/v1.10.tar.gz"
 
       - name: run unit tests
-        run: uv run pytest -v --random-order tests/ --cov --cov-report=
+        run: uv run pytest -x -v --random-order tests/ --cov --cov-report=
 
       - name: generate coverage report
         run: |
@@ -108,10 +108,10 @@ jobs:
           coverage-reports: ./coverage.xml
 
       - name: run integration tests
-        run: uv run pytest -v --random-order integration_tests/
+        run: uv run pytest -x -v --random-order integration_tests/
 
       - name: run end to end tests
-        run: uv run pytest -v --random-order --no-cov end-to-end_tests/
+        run: uv run pytest -x -v --random-order --no-cov end-to-end_tests/
 
       - name: check if docs are buildable
         working-directory: docs
@@ -164,10 +164,10 @@ jobs:
         run: uv sync --extra mpi --extra dev --extra docs --extra notebooks
 
       - name: run unit tests
-        run: uv run pytest -v --random-order tests/
+        run: uv run pytest -x -v --random-order tests/
 
       - name: run integration tests
-        run: uv run pytest -v --random-order integration_tests/
+        run: uv run pytest -x -v --random-order integration_tests/
 
   # Verify the Docker image still builds successfully (image is not pushed)
   docker-build:

--- a/integration_tests/test_contactmap.py
+++ b/integration_tests/test_contactmap.py
@@ -1,16 +1,16 @@
 """Integration-test of the CONTact MAP module."""
 
+import glob
 import os
-import pytest
 import tempfile
 from pathlib import Path
-import glob
 
+import psutil
+import pytest
 
 from haddock.libs.libontology import PDBFile
-from haddock.modules.analysis.contactmap import HaddockModule as CMapModule
 from haddock.modules.analysis.contactmap import DEFAULT_CONFIG as CONTMAP_CONF
-
+from haddock.modules.analysis.contactmap import HaddockModule as CMapModule
 from integration_tests import GOLDEN_DATA
 
 
@@ -55,6 +55,10 @@ class MockPreviousIO:
         return models
 
 
+@pytest.mark.skipif(
+    psutil.virtual_memory().available < 3000000000,
+    reason="not enough memory to run this test",
+)
 def test_contactmap_example(contactmap, monkeypatch, mocker):
     """Test the contact map module run."""
     # mock the previous_io behavior

--- a/integration_tests/test_contactmap.py
+++ b/integration_tests/test_contactmap.py
@@ -5,10 +5,10 @@ import os
 import tempfile
 from pathlib import Path
 
-import psutil
 import pytest
 
 from haddock.libs.libontology import PDBFile
+from haddock.libs.libutil import get_available_memory
 from haddock.modules.analysis.contactmap import DEFAULT_CONFIG as CONTMAP_CONF
 from haddock.modules.analysis.contactmap import HaddockModule as CMapModule
 from integration_tests import GOLDEN_DATA
@@ -56,7 +56,7 @@ class MockPreviousIO:
 
 
 @pytest.mark.skipif(
-    psutil.virtual_memory().available < 3000000000,
+    get_available_memory() < 4,
     reason="not enough memory to run this test",
 )
 def test_contactmap_example(contactmap, monkeypatch, mocker):


### PR DESCRIPTION
this `test_contactmap.py::test_contactmap_example` might fail if ends up in a machine with less than 3Gb of ram during the CI - here I added a skip that checks if the machine has enough memory to run the test or not