### PR TITLE
raise error on mixed TOML/CFG module headers

### DIFF
--- a/src/haddock/clis/re/clustfcc.py
+++ b/src/haddock/clis/re/clustfcc.py
@@ -14,7 +14,7 @@ from haddock.libs.libclust import (
     plot_cluster_matrix,
     rank_clusters,
     write_structure_list,
-    )
+)
 from haddock.libs.libfcc import create_elements, load_matrix
 from haddock.libs.libinteractive import look_for_capri, rewrite_capri_tables
 from haddock.libs.libontology import ModuleIO
@@ -23,7 +23,7 @@ from haddock.modules.analysis.clustfcc.clustfcc import (
     iterate_clustering,
     write_clusters,
     write_clustfcc_file,
-    )
+)
 
 
 def add_clustfcc_arguments(clustfcc_subcommand):
@@ -119,7 +119,9 @@ def reclustfcc(
     shutil.copy(filename, Path(outdir, "io.json"))
 
     # load the original clustering parameters via json
-    clustfcc_params = read_config(Path(clustfcc_dir, "params.cfg"))
+    # module params are internally generated as a mix of toml and cfg format
+    # set strict to false
+    clustfcc_params = read_config(Path(clustfcc_dir, "params.cfg"), strict=False)
     key = list(clustfcc_params["final_cfg"].keys())[0]
     clustfcc_params = clustfcc_params["final_cfg"][key]
     log.info(f"Previous clustering parameters: {clustfcc_params}")

--- a/src/haddock/clis/re/clustrmsd.py
+++ b/src/haddock/clis/re/clustrmsd.py
@@ -1,4 +1,5 @@
 """haddock3-re clustrmsd subcommand."""
+
 from pathlib import Path
 import numpy as np
 
@@ -15,7 +16,7 @@ from haddock.libs.libclust import (
     plot_cluster_matrix,
     rank_clusters,
     write_structure_list,
-    )
+)
 from haddock.libs.libinteractive import look_for_capri, rewrite_capri_tables
 from haddock.libs.libontology import ModuleIO
 from haddock.modules.analysis.clustrmsd.clustrmsd import (
@@ -25,7 +26,7 @@ from haddock.modules.analysis.clustrmsd.clustrmsd import (
     order_clusters,
     write_clusters,
     write_clustrmsd_file,
-    )
+)
 
 
 def add_clustrmsd_arguments(clustrmsd_subcommand):
@@ -33,71 +34,71 @@ def add_clustrmsd_arguments(clustrmsd_subcommand):
     clustrmsd_subcommand.add_argument(
         "clustrmsd_dir",
         help="The clustrmsd directory to recluster.",
-        )
-    
+    )
+
     clustrmsd_subcommand.add_argument(
         "-n",
         "--n_clusters",
         help="number of clusters to generate.",
         required=False,
         type=int,
-        )
-    
+    )
+
     clustrmsd_subcommand.add_argument(
         "-d",
         "--clust_cutoff",
         help="clustering cutoff distance.",
         required=False,
         type=float,
-        )
-    
+    )
+
     clustrmsd_subcommand.add_argument(
         "-t",
         "--min_population",
         help="minimum cluster population.",
         required=False,
         type=int,
-        )
-    
+    )
+
     clustrmsd_subcommand.add_argument(
         "-p",
         "--plot_matrix",
         help="Generate the matrix plot with the clusters.",
         required=False,
         default=False,
-        action='store_true',
-        )
+        action="store_true",
+    )
 
     return clustrmsd_subcommand
 
 
 def reclustrmsd(
-        clustrmsd_dir: str,
-        n_clusters: Union[bool, int] = None,
-        clust_cutoff: Union[bool, float] = None,
-        min_population: Union[bool, int] = None,
-        plot_matrix: bool = True,
-        ) -> Path:
+    clustrmsd_dir: str,
+    n_clusters: Union[bool, int] = None,
+    clust_cutoff: Union[bool, float] = None,
+    min_population: Union[bool, int] = None,
+    plot_matrix: bool = True,
+) -> Path:
     """
     Recluster the models in the clustrmsd directory.
-    
+
     Parameters
     ----------
     clustrmsd_dir : str
         Path to the clustrmsd directory.
-    
+
     n_clusters : Union[bool, int]
         Number of clusters to generate.
-    
+
     clust_cutoff : Union[bool, float]
         Clustering cutoff distance.
-    
+
     min_population : Union[bool, int]
         Cluster population min_population.
-    
+
     plot_matrix : bool
         Should the corresponding matrix plot be generated.
-    
+
     Returns
     -------
     outdir : Path
@@ -118,15 +119,17 @@ def reclustrmsd(
     models = io.input
 
     # load the original clustering parameters via json
-    clustrmsd_params = read_config(Path(clustrmsd_dir, "params.cfg"))
-    key = list(clustrmsd_params['final_cfg'].keys())[0]
-    clustrmsd_params = clustrmsd_params['final_cfg'][key]
+    # module params are internally generated as a mix of toml and cfg format
+    # set strict to false
+    clustrmsd_params = read_config(Path(clustrmsd_dir, "params.cfg"), strict=False)
+    key = list(clustrmsd_params["final_cfg"].keys())[0]
+    clustrmsd_params = clustrmsd_params["final_cfg"][key]
     log.info(f"Previous clustering parameters: {clustrmsd_params}")
 
     # setting previous tolerance, just in case no new parameters are given
     tolerance_param_name, tolerance = clustrmsd_tolerance_params(
         clustrmsd_params,
-        )
+    )
 
     # adjust the parameters
     if n_clusters is not None:
@@ -134,11 +137,12 @@ def reclustrmsd(
         clustrmsd_params["criterion"] = "maxclust"
         tolerance = n_clusters
     else:
+        # FIXME: Unreachable
         if clust_cutoff is not None:
             clustrmsd_params["clust_cutoff"] = clust_cutoff
             clustrmsd_params["criterion"] = "distance"
             tolerance = clust_cutoff
-    
+
     if min_population is not None:
         clustrmsd_params["min_population"] = min_population
 
@@ -147,8 +151,8 @@ def reclustrmsd(
     log.info(
         f"Clustering with {tolerance_param_name} = {tolerance}, "
         f"and criterion {clustrmsd_params['criterion']}"
-        )
-    
+    )
+
     # load the clustering dendrogram
     dendrogram = np.loadtxt(Path(clustrmsd_dir, "dendrogram.txt"))
 
@@ -157,17 +161,16 @@ def reclustrmsd(
         dendrogram,
         tolerance,
         clustrmsd_params["criterion"],
-        )
+    )
     log.info(f"clusters {cluster_arr}")
 
-    if clustrmsd_params['criterion'] == "distance":
+    if clustrmsd_params["criterion"] == "distance":
         cluster_arr, min_population = iterate_min_population(
-            cluster_arr,
-            clustrmsd_params['min_population']
-            )
-        clustrmsd_params['min_population'] = min_population
+            cluster_arr, clustrmsd_params["min_population"]
+        )
+        clustrmsd_params["min_population"] = min_population
     log.info(f"Updated clustering parameters = {clustrmsd_params}")
-    
+
     # processing the clusters
     clusters, cluster_arr = order_clusters(cluster_arr)
     log.info(f"clusters = {clusters}")
@@ -179,22 +182,21 @@ def reclustrmsd(
         models,
         out_filename=Path(outdir, "cluster.out"),
         rmsd_matrix=None,
-        centers=False
-        )
+        centers=False,
+    )
 
     score_dic, sorted_score_dic = rank_clusters(
-        clt_dic,
-        clustrmsd_params["min_population"]
-        )
-    
+        clt_dic, clustrmsd_params["min_population"]
+    )
+
     output_models = add_cluster_info(sorted_score_dic, clt_dic)
-    
+
     write_structure_list(
         models,
         output_models,
         out_fname=Path(outdir, "clustrmsd.tsv"),
-        )
-    
+    )
+
     write_clustrmsd_file(
         clusters,
         clt_dic,
@@ -203,15 +205,15 @@ def reclustrmsd(
         sorted_score_dic,
         clustrmsd_params,
         output_fname=Path(outdir, "clustrmsd.txt"),
-        )
-    
+    )
+
     # Draw the matrix
     if clustrmsd_params["plot_matrix"]:
         if not (matrix_json_path := search_previousstep_matrix(clustrmsd_dir)):
             log.warn(
                 "Could not find the rmsd matrix in previous step."
                 " Unable to produce a graph out of it!"
-                )
+            )
         else:
             log.info("Generating graphical representation of the clusters.")
             matrix_io = ModuleIO()
@@ -220,26 +222,26 @@ def reclustrmsd(
             final_order_idx, labels, cluster_ids = [], [], []
             for pdb in output_models:
                 final_order_idx.append(models.index(pdb))
-                labels.append(pdb.file_name.replace('.pdb', ''))
+                labels.append(pdb.file_name.replace(".pdb", ""))
                 cluster_ids.append(pdb.clt_id)
             # Get custom cluster data
             matrix_cluster_dt, cluster_limits = get_cluster_matrix_plot_clt_dt(
                 cluster_ids
-                )
+            )
             # Define output filename
-            html_matrix_basepath = Path(outdir, 'rmsd_matrix')
+            html_matrix_basepath = Path(outdir, "rmsd_matrix")
             # Plot matrix
             html_matrixpath = plot_cluster_matrix(
                 get_matrix_path(matrix_io.input[0]),
                 final_order_idx,
                 labels,
-                dttype='RMSD(Å)',
+                dttype="RMSD(Å)",
                 reverse=True,
                 diag_fill=0,
                 output_fname=html_matrix_basepath,
                 matrix_cluster_dt=matrix_cluster_dt,
                 cluster_limits=cluster_limits,
-                )
+            )
             log.info(f"Plotting matrix in {html_matrixpath}")
 
     # save the io.json file
@@ -272,14 +274,14 @@ def search_previousstep_matrix(clustrmsd_dir: str) -> Optional[Path]:
         Path to the matrix_json file.
     """
     # Compute previous step index
-    previous_step_ind = int(str(Path(clustrmsd_dir).name).split('_')[0]) - 1
+    previous_step_ind = int(str(Path(clustrmsd_dir).name).split("_")[0]) - 1
     workflow_dir = Path(clustrmsd_dir).parent
     # Try to get previous step directory name
     try:
         previous_steps = get_module_steps_folders(
             workflow_dir,
             [previous_step_ind],
-            )
+        )
         previous_step = previous_steps[0]
     except IndexError:
         return None

--- a/src/haddock/gear/config.py
+++ b/src/haddock/gear/config.py
@@ -53,6 +53,7 @@ all TOML rules apply regarding defining ``parameter = value`` pairs.
 
 Read more about TOML for Python here: https://pypi.org/project/toml/
 """
+
 import collections.abc
 import os
 import re
@@ -80,6 +81,10 @@ _main_header_re = re.compile(r"^ *\[(\w+)\]", re.ASCII)
 # Matches ['<name>.<digit>']
 _main_quoted_header_re = re.compile(r"^ *\[\'(\w+)\.\d+\'\]", re.ASCII)
 
+# Matches a quoted bare header ['<name>'] (pure TOML, no numeric suffix).
+# Normalized like a main header so all instances of a module carry a `.N`.
+_main_quoted_bare_header_re = re.compile(r"^ *\[\'(\w+)\'\]", re.ASCII)
+
 # Captures sub-headers
 # https://regex101.com/r/6OpJJ8/1
 # thanks https://stackoverflow.com/questions/39158902
@@ -106,14 +111,14 @@ _keys_that_accept_files = [
 ]
 
 
-class ConfigFormatError(Exception):
-    """Exception if there is a format error."""
+class ConfigFormatError(ConfigurationError):
+    """Exception raised when incompatible config header formats are mixed."""
 
     pass
 
 
 # main public API
-def load(fpath: FilePath) -> ParamDict:
+def load(fpath: FilePath, strict: bool = True) -> ParamDict:
     """
     Load an HADDOCK3 configuration file to a dictionary.
 
@@ -123,6 +128,13 @@ def load(fpath: FilePath) -> ParamDict:
     ----------
     fpath : str or :external:py:class:`pathlib.Path`
         Path to user configuration file.
+
+    strict : bool
+        When ``True`` (default), reject numeric dotted headers such as
+        ``[module.1]`` which silently merge into sub-tables and drop
+        workflow steps silently. Set to ``False`` only when reloading internally
+        generated ``params.cfg`` files, which legitimately contain such
+        numeric sub-tables. See :py:func:`loads`.
 
     Returns
     -------
@@ -135,14 +147,15 @@ def load(fpath: FilePath) -> ParamDict:
         * :py:func:`loads`
     """
     try:
-        return loads(Path(fpath).read_text())
+        return loads(Path(fpath).read_text(), strict=strict)
+    except ConfigFormatError:
+        # raise instead of masking
+        raise
     except Exception as err:
-        raise ConfigurationError(
-            "Something is wrong with the config file."
-        ) from err  # noqa: E501
+        raise ConfigurationError("Something is wrong with the config file.") from err  # noqa: E501
 
 
-def loads(cfg_str: str) -> ParamDict:
+def loads(cfg_str: str, strict: bool = True) -> ParamDict:
     """
     Read a string representing a config file to a dictionary.
 
@@ -161,11 +174,20 @@ def loads(cfg_str: str) -> ParamDict:
         The string representing the config file. Accepted formats are
         the HADDOCK3 config file or pure `toml` syntax.
 
+    strict : bool
+        When ``True`` (default), a numeric dotted header such as
+        ``[module.1]`` raises :py:class:`ConfigFormatError`. Repeated
+        HADDOCK3 modules must be declared with repeated bare headers
+        (``[module]`` written several times); the dotted form is a TOML
+        sub-table and would silently drop the intended step. Set to
+        ``False`` only when reloading internally generated ``params.cfg``
+        files, which legitimately store numeric sub-tables.
+
     Returns
     -------
     all_configs : dict
         A dictionary holding all the configuration file steps:
-        
+
         - 'raw_input': Original input file as provided by user.
         - 'cleaned_input': Regex cleaned input file.
         - 'loaded_cleaned_input': Dict of toml loaded cleaned input.
@@ -176,11 +198,24 @@ def loads(cfg_str: str) -> ParamDict:
     new_lines: list[str] = []
     cfg_lines = cfg_str.split(os.linesep)
     counter: dict[str, int] = {}
+    styles: dict[str, str] = {}
+
+    def register_style(name: str, style: str) -> None:
+        """Reject mixing numbered and unnumbered instances of a module."""
+        previous = styles.setdefault(name, style)
+        if strict and previous != style:
+            raise ConfigFormatError(
+                f"Inconsistent headers for module '{name}': a numbered "
+                f"instance (['{name}.N']) is mixed with an unnumbered one "
+                f"([{name}] or ['{name}']). Use one style consistently for "
+                "every instance of a module."
+            )
 
     # this for-loop normalizes all headers regardless of their input format.
     for line in cfg_lines:
         if group := _main_header_re.match(line):
             name = group[1]
+            register_style(name, "bare")
             counter.setdefault(name, 0)
             counter[name] += 1
             count = counter[name]
@@ -188,6 +223,15 @@ def loads(cfg_str: str) -> ParamDict:
 
         elif group := _main_quoted_header_re.match(line):
             name = group[1]
+            register_style(name, "numbered")
+            counter.setdefault(name, 0)
+            counter[name] += 1
+            count = counter[name]
+            new_line = f"['{name}.{count}']"
+
+        elif group := _main_quoted_bare_header_re.match(line):
+            name = group[1]
+            register_style(name, "bare")
             counter.setdefault(name, 0)
             counter[name] += 1
             count = counter[name]
@@ -195,6 +239,18 @@ def loads(cfg_str: str) -> ParamDict:
 
         elif group := _sub_header_re.match(line):
             name = group[1]
+            # A numeric first sub-segment (e.g. `[caprieval.1]`) is the
+            # ambiguous mix of the `.cfg` repeated-header format and TOML
+            # NOTE: For some reason internally haddock will generate this
+            # mix of toml-cfg - here we reject it unless we are reloading
+            # an internally generated `params.cfg` (strict=False)
+            if strict and group[2].split(".")[1].isdigit():
+                raise ConfigFormatError(
+                    f"Ambiguous config header '[{name}{group[2]}]': numeric "
+                    "dotted headers are not valid HADDOCK3 module syntax. "
+                    "To declare repeated modules use bare repeated headers: "
+                    f"'[{name}]' written several times or '[\"{name}.N\"]'"
+                )
             count = counter[name]  # name should be already defined here
             new_line = f"['{name}.{count}'{group[2]}]"
 
@@ -220,7 +276,7 @@ def loads(cfg_str: str) -> ParamDict:
         cfg_dict = toml.loads(cfg)  # Try to load it with the toml library
     except Exception as err:
         raise ConfigurationError(
-            "Some thing is wrong with the config file: " f"{str(err)}"
+            f"Some thing is wrong with the config file: {str(err)}"
         ) from err
 
     final_cfg = convert_variables_to_paths(cfg_dict)

--- a/src/haddock/modules/__init__.py
+++ b/src/haddock/modules/__init__.py
@@ -71,7 +71,9 @@ incompatible_defaults_params = find_incompatible_parameters(modules_defaults_pat
 
 config_readers = {
     ".yaml": read_from_yaml_config,
-    ".cfg": config.load,
+    # module params are internally generated as a mix of toml and cfg format
+    # set strict to false
+    ".cfg": partial(config.load, strict=False),
 }
 
 _step_folder_regex = tuple(

--- a/src/haddock/modules/analysis/caprieval/capri.py
+++ b/src/haddock/modules/analysis/caprieval/capri.py
@@ -59,7 +59,8 @@ def save_scoring_weights(cns_step: str) -> Path:
     scoring_params_fname : Path
         Path to the json file.
     """
-    cns_params = read_config(Path("..", cns_step, "params.cfg"))
+    # `params.cfg` is a mix of toml and cfg format, set strict to false
+    cns_params = read_config(Path("..", cns_step, "params.cfg"), strict=False)
     key = list(cns_params["final_cfg"].keys())[0]
     scoring_pars = {kv: cns_params["final_cfg"][key][kv] for kv in WEIGHTS}
 

--- a/tests/test_examples_general.py
+++ b/tests/test_examples_general.py
@@ -3,6 +3,7 @@ Test general implementation in haddock3 modules.
 
 Ensures all modules follow the same compatible architecture.
 """
+
 import importlib.util
 import pytest
 
@@ -15,7 +16,7 @@ from haddock.gear.prepare_run import (
     validate_module_names_are_not_misspelled,
     validate_parameters_are_not_misspelled,
     validate_modules_params,
-    )
+)
 from haddock.gear.parameters import config_optional_general_parameters_dict
 from haddock.libs.libutil import recursive_dict_update, remove_dict_keys
 from haddock.modules import non_mandatory_general_parameters_defaults
@@ -23,12 +24,12 @@ from haddock.modules import non_mandatory_general_parameters_defaults
 
 examples_path = Path(
     Path(__file__).resolve().parents[1],
-    'examples',
-    )
+    "examples",
+)
 
 
-examples_cfg_files = list(examples_path.rglob('*.cfg'))
-examples_cfg_files_test = list(examples_path.rglob('*-test.cfg'))
+examples_cfg_files = list(examples_path.rglob("*.cfg"))
+examples_cfg_files_test = list(examples_path.rglob("*-test.cfg"))
 
 
 def test_there_are_config_examples():
@@ -49,7 +50,8 @@ def fixture_example_config(request):
 
 def test_config_reader_can_read_example_configs(example_config):
     """Test gear.config_reader can read examples' configuration file."""
-    read_config(example_config)
+    strict = Path(example_config).name != "params.cfg"
+    read_config(example_config, strict=strict)
 
 
 def test_integration_examples():
@@ -94,12 +96,12 @@ def validate_cfg_file(cfg_file: Path) -> bool:
         params = recursive_dict_update(
             config_optional_general_parameters_dict,
             config_files["final_cfg"],
-            )
+        )
 
         params = recursive_dict_update(
             non_mandatory_general_parameters_defaults,
             params,
-            )
+        )
 
         validate_module_names_are_not_misspelled(params)
 
@@ -111,7 +113,7 @@ def validate_cfg_file(cfg_file: Path) -> bool:
         validate_parameters_are_not_misspelled(
             general_params,
             reference_parameters=ALL_POSSIBLE_GENERAL_PARAMETERS,
-            )
+        )
 
         validate_modules_params(modules_params, 20)
     except Exception as e:

--- a/tests/test_gear_config.py
+++ b/tests/test_gear_config.py
@@ -1,4 +1,6 @@
 """Test config reader."""
+
+import os
 from math import isnan
 from pathlib import Path
 
@@ -8,12 +10,12 @@ from haddock.gear import config
 
 
 @pytest.mark.parametrize(
-    'line,expected',
+    "line,expected",
     [
-        ('[header]', 'header'),
-        ('[under_scores_work]', 'under_scores_work'),
-        ],
-    )
+        ("[header]", "header"),
+        ("[under_scores_work]", "under_scores_work"),
+    ],
+)
 def test_main_header_re(line, expected):
     """Test header regex."""
     result = config._main_header_re.match(line)
@@ -21,13 +23,13 @@ def test_main_header_re(line, expected):
 
 
 @pytest.mark.parametrize(
-    'line,expected,expected2',
+    "line,expected,expected2",
     [
-        ('[another.header]', 'another', '.header'),
-        ('[another.header_2]', 'another', '.header_2'),
-        ('[another.header.h3]', 'another', '.header.h3'),
-        ],
-    )
+        ("[another.header]", "another", ".header"),
+        ("[another.header_2]", "another", ".header_2"),
+        ("[another.header.h3]", "another", ".header.h3"),
+    ],
+)
 def test_sub_header_re(line, expected, expected2):
     """Test header regex."""
     group = config._sub_header_re.match(line)
@@ -36,12 +38,12 @@ def test_sub_header_re(line, expected, expected2):
 
 
 @pytest.mark.parametrize(
-    'line,expected',
+    "line,expected",
     [
-        ("['header.3']", 'header'),
-        ("['header.1234']", 'header'),
-        ],
-    )
+        ("['header.3']", "header"),
+        ("['header.1234']", "header"),
+    ],
+)
 def test_main_quoted_header_re(line, expected):
     """Test quoted header regex."""
     result = config._main_quoted_header_re.match(line)
@@ -49,12 +51,12 @@ def test_main_quoted_header_re(line, expected):
 
 
 @pytest.mark.parametrize(
-    'line,expected1,expected2',
+    "line,expected1,expected2",
     [
-        ("['another.3'.header]", 'another', '.header'),
-        ("['another.3'.header.some]", 'another', '.header.some'),
-        ],
-    )
+        ("['another.3'.header]", "another", ".header"),
+        ("['another.3'.header.some]", "another", ".header.some"),
+    ],
+)
 def test_sub_quoted_header_re(line, expected1, expected2):
     """Test sub quoted header regex."""
     result = config._sub_quoted_header_re.match(line)
@@ -63,43 +65,43 @@ def test_sub_quoted_header_re(line, expected1, expected2):
 
 
 @pytest.mark.parametrize(
-    'line',
+    "line",
     [
-        '[[header]]',
-        '[héàder]',
+        "[[header]]",
+        "[héàder]",
         'value = "some_string"',
-        '[header with spaces]',
-        '[not.valid]',
-        ],
-    )
+        "[header with spaces]",
+        "[not.valid]",
+    ],
+)
 def test_main_header_re_wrong(line):
     """Test main header wrong."""
     assert config._main_header_re.match(line) is None
 
 
 @pytest.mark.parametrize(
-    'line',
+    "line",
     [
-        '[[header]]',
+        "[[header]]",
         'value = "some_string"',
-        '[header with spaces]',
-        '[not.valid with spaces]',
-        '[single]',
-        ],
-    )
+        "[header with spaces]",
+        "[not.valid with spaces]",
+        "[single]",
+    ],
+)
 def test_sub_header_re_wrong(line):
     """Test sub header wrong."""
     assert config._sub_header_re.match(line) is None
 
 
 @pytest.mark.parametrize(
-    'header,name',
+    "header,name",
     [
-        ('header', 'header'),
-        ('header.1', 'header'),
-        ('header.1.1..1', 'header'),
-        ],
-    )
+        ("header", "header"),
+        ("header.1", "header"),
+        ("header.1.1..1", "header"),
+    ],
+)
 def test_get_module_name(header, name):
     """Test get module name."""
     assert config.get_module_name(header) == name
@@ -144,10 +146,10 @@ _config_example_dict_1 = {
             "bsa": 0.1,
             "elec": -1,
             "list1": [1, 2, 3],
-            },
         },
-    "headerone.2": {'weights': {'other': 50}},
-    }
+    },
+    "headerone.2": {"weights": {"other": 50}},
+}
 
 _config_example_2 = """num1 = 10
 molecules = ["../some/file", "../some/otherfile"]
@@ -175,10 +177,10 @@ _config_example_dict_2 = {
             "d2": {
                 "var3": True,
                 "list_": [1, 2, 3, 4],
-                },
             },
         },
-    }
+    },
+}
 
 # this examples shows the behaviour of subkey repetition
 _config_example_3 = """
@@ -195,29 +197,29 @@ _config_example_dict_3 = {
         "d1": {
             "val2": 10,
             "val3": 20,
-            }
         }
-    }
+    },
+}
 
 
 @pytest.mark.parametrize(
-    'config_example,expected',
+    "config_example,expected",
     [
         (_config_example_1, _config_example_dict_1),
         (_config_example_2, _config_example_dict_2),
         (_config_example_3, _config_example_dict_3),
-        ],
-    )
+    ],
+)
 def test_load(config_example, expected):
     """Test read config."""
     r = config.loads(config_example)
-    assert r['final_cfg'] == expected
+    assert r["final_cfg"] == expected
 
 
 def test_load_nan_vlaue():
     """Test read config."""
     r = config.loads("param=nan")
-    assert isnan(r['final_cfg']["param"])
+    assert isnan(r["final_cfg"]["param"])
 
 
 @pytest.mark.parametrize(
@@ -226,13 +228,13 @@ def test_load_nan_vlaue():
         _config_example_dict_1,
         _config_example_dict_2,
         _config_example_dict_3,
-        ]
-    )
+    ],
+)
 def test_save_config(conf):
     target = Path("dummy_config.cfg")
     config.save(conf, target)
     loaded = config.load(target)
-    assert loaded['final_cfg'] == conf
+    assert loaded["final_cfg"] == conf
     target.unlink()
 
 
@@ -242,8 +244,8 @@ def test_save_config(conf):
         _config_example_dict_1,
         _config_example_dict_2,
         _config_example_dict_3,
-        ]
-    )
+    ],
+)
 def test_save_config_toml(conf):
     target = Path("dummy_config.toml")
     config.save(conf, target, pure_toml=True)
@@ -253,12 +255,12 @@ def test_save_config_toml(conf):
 @pytest.mark.parametrize(
     "paramline",
     [
-        'param=true',
-        'sampling_factor=false',
-        'sym3 =true',
-        'sym4 = false',
-        ]
-    )
+        "param=true",
+        "sampling_factor=false",
+        "sym3 =true",
+        "sym4 = false",
+    ],
+)
 def test_not_uppercase_bool(paramline):
     """Test lower case regex."""
     assert config._uppercase_bool_re.match(paramline) is None
@@ -267,14 +269,14 @@ def test_not_uppercase_bool(paramline):
 @pytest.mark.parametrize(
     "paramline,expectedparam,expectedbool",
     [
-        ('param=True', 'param=', 'true'),
-        ('param = False', 'param = ', 'false'),
-        ('sampling_factor =False', 'sampling_factor =', 'false'),
-        ('sym3=True', 'sym3=', 'true'),
-        ('_strange_1_param_= False', '_strange_1_param_= ', 'false'),
-        ('_strange1_2_3param_ = True', '_strange1_2_3param_ = ', 'true'),
-        ]
-    )
+        ("param=True", "param=", "true"),
+        ("param = False", "param = ", "false"),
+        ("sampling_factor =False", "sampling_factor =", "false"),
+        ("sym3=True", "sym3=", "true"),
+        ("_strange_1_param_= False", "_strange_1_param_= ", "false"),
+        ("_strange1_2_3param_ = True", "_strange1_2_3param_ = ", "true"),
+    ],
+)
 def test_uppercase_bool(paramline, expectedparam, expectedbool):
     """Test lower case regex."""
     groups = config._uppercase_bool_re.match(paramline)
@@ -283,3 +285,83 @@ def test_uppercase_bool(paramline, expectedparam, expectedbool):
     assert paramgroup == expectedparam  # Able to catch parameter
     lowercase_bool = groups[4].lower()
     assert lowercase_bool == expectedbool  # Able to lowercase boolean
+
+
+_mixed_format_cfg = os.linesep.join(["[caprieval]", "[caprieval.1]", "[caprieval.2]"])
+
+
+def test_loads_mixed_format_raises():
+    """Numeric dotted headers mixed with bare headers must raise."""
+    with pytest.raises(config.ConfigFormatError):
+        config.loads(_mixed_format_cfg)
+
+
+def test_loads_mixed_format_is_configuration_error():
+    """ConfigFormatError is a ConfigurationError subclass."""
+    from haddock.core.exceptions import ConfigurationError
+
+    with pytest.raises(ConfigurationError):
+        config.loads(_mixed_format_cfg)
+
+
+def test_loads_mixed_format_lenient():
+    """strict=False parses numeric sub-tables (generated params.cfg)."""
+    r = config.loads(_mixed_format_cfg, strict=False)
+    # the three headers collapse into a single caprieval step with two
+    # numeric sub-tables, matching how a generated params.cfg reloads.
+    assert list(r["final_cfg"].keys()) == ["caprieval.1"]
+
+
+def test_loads_word_subtable_allowed_under_strict():
+    """Word sub-tables (e.g. `[module.weights]`) remain valid under strict."""
+    cfg = os.linesep.join(["[module]", "[module.weights]", "val = 1"])
+    r = config.loads(cfg)
+    assert r["final_cfg"]["module.1"]["weights"] == {"val": 1}
+
+
+_pure_toml_cfg = os.linesep.join(
+    ["[topoaa]", "[rigidbody]", "['caprieval.1']", "['caprieval.2']"]
+)
+
+
+def test_loads_pure_toml_quoted_headers():
+    """Proper pure-TOML quoted headers keep every step, never dropped."""
+    r = config.loads(_pure_toml_cfg)  # strict default must not raise
+    assert list(r["final_cfg"].keys()) == [
+        "topoaa.1",
+        "rigidbody.1",
+        "caprieval.1",
+        "caprieval.2",
+    ]
+
+
+@pytest.mark.parametrize(
+    "headers",
+    [
+        # quoted-bare instance mixed with a quoted-numbered instance
+        ["[topoaa]", "['caprieval']", "['caprieval.1']"],
+        # unquoted-bare (cfg) instance mixed with a quoted-numbered instance
+        ["[topoaa]", "[caprieval]", "['caprieval.1']"],
+    ],
+)
+def test_loads_mixed_numbered_and_bare_raises(headers):
+    """Mixing numbered and unnumbered instances of a module must raise."""
+    with pytest.raises(config.ConfigFormatError):
+        config.loads(os.linesep.join(headers))
+
+
+@pytest.mark.parametrize(
+    "headers,expected",
+    [
+        # all bare (cfg style)
+        (["[caprieval]", "[caprieval]"], ["caprieval.1", "caprieval.2"]),
+        # all numbered (pure TOML style)
+        (["['caprieval.1']", "['caprieval.2']"], ["caprieval.1", "caprieval.2"]),
+        # all quoted-bare
+        (["['caprieval']", "['caprieval']"], ["caprieval.1", "caprieval.2"]),
+    ],
+)
+def test_loads_consistent_style_is_accepted(headers, expected):
+    """A single consistent header style for a module is accepted."""
+    r = config.loads(os.linesep.join(headers))
+    assert list(r["final_cfg"].keys()) == expected


### PR DESCRIPTION
> Before submitting, read the [contributing guidelines](CONTRIBUTING.md) and the [AI policy](AI-POLICY.md).

## What does this PR do and why?
<!-- Please explain what you did in this PR -->

haddock config files accept two header styles: the custom `.cfg` format with repeated bare headers (ex: `[caprieval]` written several times) and pure TOML with quoted numbered headers (`['caprieval.1']`). 

when the two were mixed, the parser silently ate the extra definitions as sub-tables instead of creating workflow steps, so runs were quietly incomplete with no error - meaning the modules would be dropped without any warning/error.

this PR updates the parser `gear/config.py` to detect ambiguous mixes of `.cfg` and `.toml` and raise a clear `ConfigFormatError`:

| Config input | Result |
|---|---|
| `[caprieval]` xN (`cfg` style) | ✅ N steps |
| `['caprieval.1']`, `['caprieval.2']` (TOML style) | ✅ 2 steps |
| `[caprieval.1]` (unquoted numeric) | ❌ raises `ConfigFormatError` |
| `[caprieval]` + `['caprieval.1']` (bare + numbered) | ❌ raises `ConfigFormatError` |
| `['caprieval']` + `['caprieval.1']` (bare + numbered, quoted) | ❌ raises `ConfigFormatError` |


IMPORTANT: Because the parser is also used to reload internally generated `params.cfg` files  which for some reason are a mix of cfg-toml, I added a `strict` flag the new checks. The reload happens in (`caprieval/capri.py, clis/re/clustrmsd.py`, `clis/re/clustfcc.py`, and the `.cfg` reader in `modules/__init__.py`) these have been updated with `strict=False` to make the change less disruptive.


## How was this tested?
<!-- Explain how the changes were verified -->

Added unit tests in `tests/test_gear_config.py` covering the cases mentioned in the table above

## AI assistance
<!-- Did AI tools play a meaningful role in this PR? If so, note what they helped with and how you verified the output. Leave blank if not applicable. -->

used `qwen3-coder-next:q8_0` to locate the parsing logic, trace the cfg-toml mixed `params.cfg` file reload paths and to draft the tests. Code was written manually and AI edits were checked.

## Checklist

- [x] Tests cover the new and/or changed code
- ~[ ] Documentation updated if needed (also in the [haddock3 user-manual](https://github.com/haddocking/haddock3-user-manual)~
- ~[ ] `CHANGELOG.md` updated for user-facing changes~

## Related issues
<!-- Link any relevant GitHub issues or user-manual PRs -->

#1616, https://github.com/haddocking/haddock-runner/issues/190

## Notes for reviewers
<!-- Anything that needs special attention, known limitations, or follow-up work -->

maybe consider whether the user-manual should document the "pick one header style" rule, the examples are using the custom `.cfg` format and it's not properly documented anywhere - I'd recommend default to `.toml` in the future
