### PR TITLE
Add choices to filter_by parameter of caprifilter module

### DIFF
--- a/src/haddock/gear/prepare_run.py
+++ b/src/haddock/gear/prepare_run.py
@@ -725,8 +725,15 @@ def validate_param_range(param: dict, val: Any) -> Optional[str]:
     """
     # Case for choices
     if "choices" in param.keys():
-        if val not in (choices := param["choices"]):
-            return f'Value "{val}" is not among the accepted choices: {choices}'  # noqa : E501
+        if param['type'] == 'list':
+            if set(val) - set(param["choices"]):
+                return (
+                    f'Value "{val}" is not among the accepted choices: '
+                    f"{param['choices']}"
+                )
+        else:
+            if val not in (choices := param["choices"]):
+                return f'Value "{val}" is not among the accepted choices: {choices}'  # noqa : E501
     # Case for ranges
     elif "min" in param.keys() and "max" in param.keys():
         if val < param["min"] or val > param["max"]:

--- a/src/haddock/gear/prepare_run.py
+++ b/src/haddock/gear/prepare_run.py
@@ -725,7 +725,7 @@ def validate_param_range(param: dict, val: Any) -> Optional[str]:
     """
     # Case for choices
     if "choices" in param.keys():
-        if param["type"] == "list":
+        if param.get("type") == "list":
             if set(val) - set(param["choices"]):
                 return (
                     f'Value "{val}" is not among the accepted choices: '

--- a/src/haddock/gear/prepare_run.py
+++ b/src/haddock/gear/prepare_run.py
@@ -725,7 +725,7 @@ def validate_param_range(param: dict, val: Any) -> Optional[str]:
     """
     # Case for choices
     if "choices" in param.keys():
-        if param['type'] == 'list':
+        if param["type"] == "list":
             if set(val) - set(param["choices"]):
                 return (
                     f'Value "{val}" is not among the accepted choices: '

--- a/src/haddock/modules/analysis/caprifilter/defaults.yaml
+++ b/src/haddock/modules/analysis/caprifilter/defaults.yaml
@@ -14,10 +14,16 @@ filter_by:
   type: list
   minitems: 1
   maxitems: 6
+  choices:
+    - rmsd
+    - irmsd
+    - lrmsd
+    - ilrmsd
+    - fnat
+    - dockq
   title: Metrics to filter by.
   short: List of CAPRI metrics to use for filtering.
-  long: List of CAPRI metrics to filter on. Valid values are rmsd, irmsd, lrmsd,
-    ilrmsd, fnat, dockq. Each metric must have its corresponding
+  long: List of CAPRI metrics to filter on. Each metric must have its corresponding
     {metric}_filter_cutoff and {metric}_filter_out parameters set. All
     filters are applied simultaneously (AND logic), so a model must pass
     every active filter to be kept.


### PR DESCRIPTION
> Before submitting, read the [contributing guidelines](CONTRIBUTING.md) and the [AI policy](AI-POLICY.md).

## What does this PR do and why?
Add choices to the filter_by parameter of caprifilter module

When rendering in [workflow builder](https://github.com/i-VRESSE/workflow-builder) without choices it looks like
<img width="835" height="430" alt="wb-array-str" src="https://github.com/user-attachments/assets/b235ec0b-a6ce-4563-8b7f-272f27b5240f" />

with choices it looks like

<img width="851" height="233" alt="wb-multi-select" src="https://github.com/user-attachments/assets/13d09f98-15ca-429d-b4f0-9f241632c004" />

To see it in workflow builder yourself use PR https://github.com/i-VRESSE/workflow-builder/pull/180

## How was this tested?
1. I took screenshots above
2. I build sphinx docs and choices are rendered at http://localhost:8000/src/modules/analysis/haddock.modules.analysis.caprifilter.html#filter-by
3. Passed `pytest -v tests/test_modules_general.py::test_yaml_keys[modules7]`

## AI assistance
It only converted the valid values string into a yaml list, which I verified.

## Checklist

- [x] Tests cover the new and/or changed code
- [ ] Documentation updated if needed (also in the [haddock3 user-manual](https://github.com/haddocking/haddock3-user-manual)
- [ ] `CHANGELOG.md` updated for user-facing changes

## Related issues
<!-- Link any relevant GitHub issues or user-manual PRs -->

## Notes for reviewers
<!-- Anything that needs special attention, known limitations, or follow-up work -->
