### PR TITLE
Corrected ranking in caprieval for reverse sorting - Issue #1621

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 =======
+- 2026-07-10: Corrected ranking in caprieval for reverse sorting - Issue #1621
 - 2026-07-09: Added `deeprank` scoring module using deeprank-gnn-esm - Issue #569
 - 2026-07-07: Re-add `gdock` as a sampling module
 - 2026-07-02: Added support 1-O-methyl-2-N-Acetyl-alpha-D-galactopyranose (NGM) - Issue #1608

--- a/src/haddock/libs/libcapri.py
+++ b/src/haddock/libs/libcapri.py
@@ -973,7 +973,7 @@ def capri_cluster_analysis(
     # Rank according to the score
     score_rankkey_values = [(key, v["score"]) for key, v in output_dic.items()]
     score_rankkey_values.sort(
-        key=lambda x: x[1], 
+        key=lambda x: x[1],
         reverse=True if not sort_ascending else False,
     )
     for i, k in enumerate(score_rankkey_values):

--- a/src/haddock/libs/libcapri.py
+++ b/src/haddock/libs/libcapri.py
@@ -748,7 +748,10 @@ def rank_according_to_score(
                               its rank based on the 'score'.
     """
     score_rankkey_values = [(k, v["score"]) for k, v in data.items()]
-    score_rankkey_values.sort(key=lambda x: x[1])
+    score_rankkey_values.sort(
+        key=lambda x: x[1],
+        reverse=True if not sort_ascending else False,
+    )
 
     for i, k in enumerate(score_rankkey_values):
         data_idx, _ = k
@@ -969,7 +972,10 @@ def capri_cluster_analysis(
 
     # Rank according to the score
     score_rankkey_values = [(key, v["score"]) for key, v in output_dic.items()]
-    score_rankkey_values.sort(key=lambda x: x[1])
+    score_rankkey_values.sort(
+        key=lambda x: x[1], 
+        reverse=True if not sort_ascending else False,
+    )
     for i, k in enumerate(score_rankkey_values):
         idx, _ = k
         output_dic[idx]["caprieval_rank"] = i + 1

--- a/tests/test_module_caprieval.py
+++ b/tests/test_module_caprieval.py
@@ -9,6 +9,7 @@ import pytest
 from haddock.libs.libcapri import (
     CAPRI,
     capri_cluster_analysis,
+    rank_according_to_score,
 )
 from haddock.modules.analysis.caprieval.capri import get_previous_cns_step
 
@@ -203,6 +204,9 @@ def test_capri_cluster_analysis(protprot_caprimodule, protprot_input_list, monke
             path=Path("."),
         )
 
+        # With sort_ascending=False the caprieval_rank is assigned by score in
+        # descending order, so the highest-scoring cluster (id 2, score 50) is
+        # ranked first.
         observed_outf_l = read_capri_file("capri_clt.txt")
         expected_outf_l = [
             [
@@ -219,6 +223,8 @@ def test_capri_cluster_analysis(protprot_caprimodule, protprot_input_list, monke
                 "lrmsd_std",
                 "dockq",
                 "dockq_std",
+                "ilrmsd",
+                "ilrmsd_std",
                 "rmsd",
                 "rmsd_std",
                 "caprieval_rank",
@@ -237,9 +243,11 @@ def test_capri_cluster_analysis(protprot_caprimodule, protprot_input_list, monke
                 "0.000",
                 "nan",
                 "nan",
+                "4.300",
+                "0.000",
                 "0.010",
                 "0.000",
-                "2",
+                "1",
             ],
             [
                 "1",
@@ -255,11 +263,52 @@ def test_capri_cluster_analysis(protprot_caprimodule, protprot_input_list, monke
                 "0.000",
                 "nan",
                 "nan",
+                "4.300",
+                "0.000",
                 "0.010",
                 "0.000",
-                "1",
+                "2",
             ],
         ]
+        assert observed_outf_l == expected_outf_l
+
+
+def test_rank_according_to_score_ascending():
+    """Test that the lowest score is ranked first when sort_ascending is True."""
+    data = {
+        0: {"score": 42.0, "irmsd": 1.0},
+        1: {"score": 50.0, "irmsd": 2.0},
+        2: {"score": 10.0, "irmsd": 3.0},
+    }
+    ranked = rank_according_to_score(data, sort_key="score", sort_ascending=True)
+
+    # Returned dict is keyed by rank (1..n) in ascending score order
+    assert [v["score"] for v in ranked.values()] == [10.0, 42.0, 50.0]
+    # caprieval_rank follows the score: lowest score gets rank 1
+    assert ranked[1]["score"] == 10.0
+    assert ranked[1]["caprieval_rank"] == 1
+    assert ranked[2]["caprieval_rank"] == 2
+    assert ranked[3]["score"] == 50.0
+    assert ranked[3]["caprieval_rank"] == 3
+
+
+def test_rank_according_to_score_descending():
+    """Test that the highest score is ranked first when sort_ascending is False."""
+    data = {
+        0: {"score": 42.0, "irmsd": 1.0},
+        1: {"score": 50.0, "irmsd": 2.0},
+        2: {"score": 10.0, "irmsd": 3.0},
+    }
+    ranked = rank_according_to_score(data, sort_key="score", sort_ascending=False)
+
+    # Returned dict is keyed by rank (1..n) in descending score order
+    assert [v["score"] for v in ranked.values()] == [50.0, 42.0, 10.0]
+    # caprieval_rank follows the score: highest score gets rank 1
+    assert ranked[1]["score"] == 50.0
+    assert ranked[1]["caprieval_rank"] == 1
+    assert ranked[2]["caprieval_rank"] == 2
+    assert ranked[3]["score"] == 10.0
+    assert ranked[3]["caprieval_rank"] == 3
 
 
 def test_get_previous_cns_step():


### PR DESCRIPTION
## What does this PR do and why?

Corrected `libcapri.py` so that when `sort_ascending=false` the `caprieval_rank` reported in `capri_ss.tsv` match the actually sorting of the file

Added a test for this.

## How was this tested?

By running a test example from the docking-protein-protein example, adding `sort_ascending=false` to a caprieval module and check that the `caprieval_ranks` are matching the sort order.

## AI assistance

AI was used to add the test

## Checklist

- [X] Tests cover the new and/or changed code
- [ ] Documentation updated if needed (also in the [haddock3 user-manual](https://github.com/haddocking/haddock3-user-manual)
- [X] `CHANGELOG.md` updated for user-facing changes

## Related issues

#1621

## Notes for reviewers

Note that the reranking is only affecting the single structure analysis reported in `capri_ss.tsv`

Better not to change the reported `cluster_rank` in the `capri_clt.tsv` file as this rank corresponds to the cluster naming. In this case, the reverse sorting should be enabled directly in the `seletopclust` module (see issue #1620)