### PR TITLE
add `sqlite3` check to `deeprank_is_available`

### DIFF
--- a/src/haddock/modules/scoring/deeprank/deeprank.py
+++ b/src/haddock/modules/scoring/deeprank/deeprank.py
@@ -10,8 +10,23 @@ from pdbtools import pdb_mkensemble
 
 
 def deeprank_is_available() -> bool:
-    """Check whether the `deeprank_gnn` package is importable."""
-    import deeprank_gnn  # type: ignore  # noqa: F401
+    """Check whether deeprank-gnn-esm's requirements are met."""
+    try:
+        import sqlite3  # noqa: F401
+    except ImportError as err:
+        raise ImportError(
+            "The `deeprank` module requires a python interpreter built with "
+            "sqlite3 support, which is missing from your current "
+            "environment."
+        ) from err
+
+    try:
+        import deeprank_gnn  # type: ignore  # noqa: F401
+    except ImportError as err:
+        raise ImportError(
+            "The `deeprank` module requires the `deeprank_gnn` package, "
+            "which is not installed in your current environment."
+        ) from err
 
     return True
 

--- a/tests/test_module_deeprank.py
+++ b/tests/test_module_deeprank.py
@@ -1,12 +1,16 @@
 """Tests for the deeprank scoring module wrapper."""
 
-import tempfile
+import builtins
 import shutil
+import tempfile
 from pathlib import Path
 
 import pytest
 
-from haddock.modules.scoring.deeprank.deeprank import DeeprankWrapper
+from haddock.modules.scoring.deeprank.deeprank import (
+    DeeprankWrapper,
+    deeprank_is_available,
+)
 
 from . import golden_data as GOLDEN_DATA
 from .conftest import has_deeprank
@@ -41,6 +45,22 @@ def deeprank_wrapper_ensemble():
             chain_i="A",
             chain_j="B",
         )
+
+
+def test_deeprank_is_available_requires_sqlite3(monkeypatch):
+    """Must raise a clear error when the interpreter lacks sqlite3 support."""
+    real_import = builtins.__import__
+
+    # mock not being able to find `sqlite3`
+    def fake_import(name, *args, **kwargs):
+        if name == "sqlite3":
+            raise ImportError("No module named '_sqlite3'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    with pytest.raises(ImportError, match="sqlite3"):
+        deeprank_is_available()
 
 
 @has_deeprank


### PR DESCRIPTION
> Before submitting, read the [contributing guidelines](CONTRIBUTING.md) and the [AI policy](AI-POLICY.md).

## What does this PR do and why?
<!-- Please explain what you did in this PR -->

This PR adds an explicit check for deeprank's dependency on the python interpreter to have been compiled with `sqlite3`

## How was this tested?
<!-- Explain how the changes were verified -->

Running with a python interpreter compiled with `sqlite3` and without

## AI assistance
<!-- Did AI tools play a meaningful role in this PR? If so, note what they helped with and how you verified the output. Leave blank if not applicable. -->

None

## Checklist

- [x] Tests cover the new and/or changed code
- [ ] Documentation updated if needed (also in the [haddock3 user-manual](https://github.com/haddocking/haddock3-user-manual)
- [ ] `CHANGELOG.md` updated for user-facing changes

## Related issues
<!-- Link any relevant GitHub issues or user-manual PRs -->

https://github.com/haddocking/haddock3/issues/1624, https://github.com/haddocking/deeprank-gnn-esm/issues/34

## Notes for reviewers
<!-- Anything that needs special attention, known limitations, or follow-up work -->

This is an edge case, full python installations commonly used by users will have it's python interpreter compiled with `sqlite3` - but in thin environments this is not the case.
