### PR TITLE
update `ctrl-c` `ctrl-v` guidelines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,8 @@ underlying idea to whatever you're working on.
 > may change this file. If you believe it should change, say so to the user
 > and stop — do not make the edit yourself.
 
+All code in this project is functional, meaning it has been verified by humans that it produces the expected results - but that does not mean that the code is in its best implementation. If you copy code from somewhere else, try to improve it, do not assume it is already optimal.
+
 ## Overview
 
 HADDOCK3 is a modular biomolecular docking platform developed by BonvinLab (Utrecht University). It uses a workflow engine that chains discrete modules together, where each module's output (PDB files + metadata) becomes the next module's input. CNS (Crystallography & NMR System) is the primary external computational engine for sampling and refinement.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,8 @@ src/haddock/
 - **Function Design**: Small, testable functions preferred over complex classes
 - **Naming**: Use descriptive variable names
 - **Comments**: Explain *why* not *how*
+- **Reuse**: Existing code being functional doesn't mean it's the best
+  implementation. If you ctrl-c ctrl-v code from elsewhere in the codebase evaluate it on its own merits and improve it if you can.
 - **Documentation**: Update docstrings and markdown files
 - **Formatting**: Code is formatted with [ruff](https://docs.astral.sh/ruff/)
   (`ruff format`); CI checks formatting of changed files on every pull request


### PR DESCRIPTION
This PR adds a new guideline related to copying and adapting code. 

It's common practice in this project to start some implementation by copying some functional part of the code and adapting it to the new feature. 

So here I added two lines clarifying that it should not be assumed that just because some piece of code has been added to the project that it is a good implementation and/or that it should not be improved. People might defer reviews/suggestions for improvement using the `ctrl-c` `ctrl-v` argument, so by having this guideline clearly stated we can hope that bad or sub-optimal functional implementations will not be propagated.