### PR TITLE
Removed the molecule sanitisation and ensemble splitting from topocg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- 2026-07-31: Fixed topocg issue removing ligands - Issue #1638
 - 2026-07-27: Added `rnascan` module for mutagenesis scanning of RNA bases (mutating interface nucleotides to A, C, G, U) - Issue #1631
 - 2026-07-22: Added protein-DNA docking Jupyter notebook
 - 2026-07-21: Fixed `gen_archive=true` crash (`Directory not empty`) on non-local filesystems (NFS, gcsfuse/s3fs, overlayfs) - Issue #1626

--- a/src/haddock/modules/topology/topocg/__init__.py
+++ b/src/haddock/modules/topology/topocg/__init__.py
@@ -37,7 +37,6 @@ from haddock.libs.libaa2cg import (
     gen_cg_tbl_backmapping_fname,
     )
 from haddock.libs.libontology import Format, PDBFile, TopologyFile
-from haddock.libs.libstructure import make_molecules
 from haddock.libs.libsubprocess import CNSJob
 from haddock.modules import get_engine
 from haddock.modules.base_cns_module import BaseCNSModule
@@ -169,7 +168,7 @@ class HaddockModule(BaseCNSModule):
         lines = text.split(os.linesep)
         REMARK_lines = (line for line in lines if line.startswith("REMARK"))
         re_origin = re.compile(
-            "REMARK\s+MODEL\s+(\d+)\s+(FROM|from|From)\s+(([\w_-]+\.?)+)"
+            r"REMARK\s+MODEL\s+(\d+)\s+(FROM|from|From)\s+(([\w_-]+\.?)+)"
         )  # noqa : E501
         for line in REMARK_lines:
             if match := re_origin.search(line):
@@ -183,10 +182,13 @@ class HaddockModule(BaseCNSModule):
         """Execute module."""
 
         try:
-            _molecules = self.previous_io.output
-            molecules = []
-            for mol in _molecules:
-                molecules.append(make_molecules([mol[key].rel_path for key in mol]))
+            # Models already come split into individual structures from the
+            # previous (topoaa) step, so we can use them directly. Each entry
+            # of `molecules` is the list of model paths for one input molecule.
+            molecules = [
+                [pdbfile.rel_path for pdbfile in mol.values()]
+                for mol in self.previous_io.output
+            ]
         except Exception as e:
             self.finish_with_error(e)
 
@@ -221,57 +223,35 @@ class HaddockModule(BaseCNSModule):
 
         force_field = self.params["cgffversion"]
 
-        for i, molecule in enumerate(molecules, start=1):
-            #self.log(f"Molecule {i}: {molecule.with_parent}")
+        for i, models in enumerate(molecules, start=1):
             shape_dic[i] = False
-            # Copy the molecule to the step folder
             models_dic[i] = []
 
-            # Split models
-            # these come already sorted
-            splited_models = [
-                libpdb.split_ensemble(Path(mol.file_name), dest=Path.cwd(),)[0]
-                for mol in molecule
-            ]
-
             # check for shape
-            if libpdb.check_mol_shape(splited_models[0]):
+            if libpdb.check_mol_shape(models[0]):
                 shape_dic[i] = True
 
             # Get psf files for aa topology
             psf_files[i] = [
-                Path(mol.parent, f"{mol.stem}.{Format.TOPOLOGY}")
-                for mol in splited_models
+                Path(model.parent, f"{model.stem}.{Format.TOPOLOGY}")
+                for model in models
                 ]
 
             # get the MD5 hash of each model
-            ens_dic[i] = [
-                self.get_md5(mol.file_name)
-                for mol in molecule
-                ]
+            ens_dic[i] = [self.get_md5(model) for model in models]
             origi_ens_dic[i] = [
-                self.get_ensemble_origin(mol.file_name)
-                for mol in molecule
+                self.get_ensemble_origin(model) for model in models
             ]
-            # nice variable name, isn't it? :-)
             # molecule parameters are shared among models of the same molecule
             parameters_for_this_molecule = mol_params[mol_params_get()]
 
-            for task_id, model in enumerate(splited_models):
+            for task_id, model in enumerate(models):
                 self.log(f"Sanitizing molecule {model.name}")
                 models_dic[i].append(model)
 
                 if self.params["ligand_top_fname"]:
                     custom_top = self.params["ligand_top_fname"]
                     self.log(f"Using custom topology {custom_top}")
-                    libpdb.sanitize(
-                        model,
-                        overwrite=True,
-                        custom_topology=custom_top,
-                    )
-
-                else:
-                    libpdb.sanitize(model, overwrite=True)
 
                 # Prepare generation of topologies jobs
                 topocg_input = generate_topology(

--- a/src/haddock/modules/topology/topocg/__init__.py
+++ b/src/haddock/modules/topology/topocg/__init__.py
@@ -5,7 +5,7 @@ parameters and topologies (``.psf``) for each of the input structures.
 
 It will:
 - Convert an all atom model to a Martini coarse-grained model
-- Detect missing atoms 
+- Detect missing atoms
 - Re-build them when missing
 - Build and write out topologies (``.psf``) and coordinates (``.pdb``) files
 - Write out a restrain file to convert back the CG model to all atoms
@@ -30,12 +30,12 @@ from haddock.libs.libcns import (
     load_workflow_params,
     prepare_output,
     prepare_single_input,
-    )
+)
 from haddock.libs.libaa2cg import (
     martinize,
     gen_cg_filename,
     gen_cg_tbl_backmapping_fname,
-    )
+)
 from haddock.libs.libontology import Format, PDBFile, TopologyFile
 from haddock.libs.libsubprocess import CNSJob
 from haddock.modules import get_engine
@@ -235,13 +235,11 @@ class HaddockModule(BaseCNSModule):
             psf_files[i] = [
                 Path(model.parent, f"{model.stem}.{Format.TOPOLOGY}")
                 for model in models
-                ]
+            ]
 
             # get the MD5 hash of each model
             ens_dic[i] = [self.get_md5(model) for model in models]
-            origi_ens_dic[i] = [
-                self.get_ensemble_origin(model) for model in models
-            ]
+            origi_ens_dic[i] = [self.get_ensemble_origin(model) for model in models]
             # molecule parameters are shared among models of the same molecule
             parameters_for_this_molecule = mol_params[mol_params_get()]
 
@@ -263,7 +261,7 @@ class HaddockModule(BaseCNSModule):
                     default_params_path=self.toppar_path,
                     write_to_disk=self.params["debug"],
                     force_field=force_field,
-                    shape=shape_dic[i]
+                    shape=shape_dic[i],
                 )
                 self.log("Topology CNS input created")
 
@@ -314,17 +312,17 @@ class HaddockModule(BaseCNSModule):
                         self.path.resolve().parent,
                         origin_name_model,
                         force_field=force_field,
-                        )
+                    )
                     processed_topology = gen_cg_filename(
                         self.path.resolve().parent,
                         origin_name_model,
                         force_field=force_field,
                         ext=Format.TOPOLOGY,
-                        )
+                    )
                     processed_cgtoaa_tbl = gen_cg_tbl_backmapping_fname(
                         self.path.resolve().parent,
                         origin_name_model,
-                        ).resolve()
+                    ).resolve()
                 else:
                     processed_pdb = Path(f"{origin_name_model}.{Format.PDB}")
                     processed_topology = Path(f"{origin_name_model}.{Format.TOPOLOGY}")
@@ -348,7 +346,9 @@ class HaddockModule(BaseCNSModule):
 
         # Remove temporary `*_cg.pdb` files if not in debug mode
         if not self.params["debug"]:
-            for tmp_cg in Path(self.path.resolve().parent).glob(f"{gen_cg_filename('', '*')}"):
+            for tmp_cg in Path(self.path.resolve().parent).glob(
+                f"{gen_cg_filename('', '*')}"
+            ):
                 os.remove(tmp_cg)
 
         # Save module information

--- a/tests/test_module_topocg.py
+++ b/tests/test_module_topocg.py
@@ -62,7 +62,7 @@ def test_generate_topology(topocg, protein):
     """Test generate_topology function."""
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", PDBConstructionWarning)
-        force_field=topocg.params["cgffversion"]
+        force_field = topocg.params["cgffversion"]
         observed_inp_out = generate_topology(
             input_pdb=protein,
             output_path=topocg.path,
@@ -74,10 +74,12 @@ def test_generate_topology(topocg, protein):
         )
 
     assert observed_inp_out == Path(protein.name).with_suffix(f".{Format.CNS_INPUT}")
-    
+
     # Confirm the expected output file exists
     expected_filename = topocg.path.resolve() / f"{protein.stem}_cg.pdb"
-    assert expected_filename.exists(), f"Expected CG PDB file not found: {expected_filename}"
+    assert expected_filename.exists(), (
+        f"Expected CG PDB file not found: {expected_filename}"
+    )
 
     # Check that backmapping tbl file has been created
     tbl_backmapping_fpath = topocg.path.resolve() / f"{protein.stem}_cg_to_aa.tbl"

--- a/tests/test_module_topocg.py
+++ b/tests/test_module_topocg.py
@@ -1,5 +1,6 @@
 """Specific tests for topocg."""
 
+import shutil
 import tempfile
 from math import isnan
 from pathlib import Path
@@ -8,8 +9,10 @@ from Bio.PDB.PDBExceptions import PDBConstructionWarning
 
 import pytest
 
+import haddock.modules.topology.topocg as topocg_mod
 from haddock.gear.yaml2cfg import read_from_yaml_config
-from haddock.libs.libontology import Format
+from haddock.libs import libpdb
+from haddock.libs.libontology import Format, PDBFile
 from haddock.modules.topology.topocg import DEFAULT_CONFIG as topocg_params
 from haddock.modules.topology.topocg import HaddockModule as Topocg
 from haddock.modules.topology.topocg import generate_topology
@@ -88,6 +91,84 @@ def test_generate_topology(topocg, protein):
 
     # Check for CG-specific atom/residue names (e.g., "BB" for backbone bead)
     assert "BB" in contents, "CG markers not found in output PDB."
+
+
+def test_run_uses_presplit_models_without_splitting(monkeypatch, protein):
+    """Models from the previous (topoaa) step are already split.
+
+    ``_run`` must consume them directly and must not re-split the ensemble
+    (the redundant ``libpdb.split_ensemble`` call that was removed).
+    """
+    with tempfile.TemporaryDirectory() as tempdir:
+        root = Path(tempdir)
+        prev_dir = root / "1_topoaa"
+        cwd = root / "2_topocg"
+        prev_dir.mkdir()
+        cwd.mkdir()
+
+        # Two individual (already-split) models with their aa topologies,
+        # mimicking the output of the previous topoaa step.
+        prev_output = {}
+        expected_inputs = []
+        for idx in range(2):
+            pdb_name = f"mol_{idx + 1}.pdb"
+            shutil.copy(protein, prev_dir / pdb_name)
+            (prev_dir / f"mol_{idx + 1}.{Format.TOPOLOGY}").write_text("")
+            pdbfile = PDBFile(file_name=pdb_name, path=str(prev_dir))
+            prev_output[idx] = pdbfile
+            expected_inputs.append(pdbfile.rel_path)
+
+        monkeypatch.chdir(cwd)
+        module = Topocg(order=1, path=Path("."), initial_params=topocg_params)
+        module.envvars = {}
+
+        class _FakePreviousIO:
+            output = [prev_output]
+
+        module.previous_io = _FakePreviousIO()
+
+        # Guard against regressions: splitting must never happen here.
+        def _no_split(*args, **kwargs):
+            raise AssertionError("topocg should not call split_ensemble")
+
+        monkeypatch.setattr(libpdb, "split_ensemble", _no_split)
+
+        # Capture the model paths handed to topology generation instead of
+        # running CNS, and avoid the DSSP/martinize machinery.
+        captured_inputs = []
+
+        def _fake_generate_topology(input_pdb, *args, **kwargs):
+            captured_inputs.append(Path(input_pdb))
+            return Path(f"{Path(input_pdb).stem}.{Format.CNS_INPUT}")
+
+        monkeypatch.setattr(topocg_mod, "generate_topology", _fake_generate_topology)
+
+        # Neutralise the CNS engine.
+        class _FakeEngine:
+            def __init__(self, jobs):
+                self.jobs = jobs
+
+            def run(self):
+                return None
+
+        monkeypatch.setattr(topocg_mod, "get_engine", lambda *a, **k: _FakeEngine)
+
+        # Skip the disk-dependent export step, just capture its input.
+        exported = {}
+
+        def _fake_export(self, faulty_tolerance=0.0):
+            exported["models"] = self.output_models
+
+        monkeypatch.setattr(Topocg, "export_io_models", _fake_export)
+
+        module._run()
+
+    # The presplit model paths were used verbatim (no split, no renaming).
+    assert captured_inputs == expected_inputs
+    # One CNS job per input model was created.
+    assert len(module.output_models) == 1
+    assert len(module.output_models[0]) == 2
+    assert exported["models"] is module.output_models
 
 
 def test_get_md5(topocg, ensemble_header_w_md5, protein):


### PR DESCRIPTION
## What does this PR do and why?

The molecule sanitisation and ensemble splitting steps were removed from topocg as unnecessary (and problematic steps with ligands). topocg receives its molecules from topoaa which has already sanitised and split ensembles.

## How was this tested?

By running the CG workflow on BM5 entry 1AZS which was original causing problems.
Previously the topocg step was editing the PDB in the topoaa directory and removing the ligand.
Now the ligand is correctly preserved and the file in untouched.

## AI assistance

## Checklist

- [X] Tests cover the new and/or changed code
- [ ] Documentation updated if needed (also in the [haddock3 user-manual](https://github.com/haddocking/haddock3-user-manual)
- [X] `CHANGELOG.md` updated for user-facing changes

## Related issues

#1638
