### PR TITLE
clarify `libcluster.add_cluster_info` behaviour

### DIFF
--- a/src/haddock/libs/libclust.py
+++ b/src/haddock/libs/libclust.py
@@ -257,21 +257,24 @@ def add_cluster_info(
     sorted_score: List[Tuple[int, float]], clt_dic: dict[int, List[PDBFile]]
 ) -> List[PDBFile]:
     """
-    Add cluster information to the models.
+    Rank clusters and models, then attach a cluster ID and rank info to each model.
 
     Parameters
     ----------
     sorted_score : :obj:`list`
         List of tuples with the cluster ID and the average score, sorted by
-        the average score.
+        the average score. ex: ``[(1, -341.2), (2, -347.5)]``
 
     clt_dic : :obj:`dict`
         Dictionary with the clusters.
+        ex: ``{1: [PDBFile, PDBFile, ...], 2: [PDBFile, PDBFile, ...]}``
+
 
     Returns
     -------
     output_models : :obj:`list`
-        List of models with the cluster information.
+        List of models with the cluster information attached, ordered by cluster rank,
+        then by model rank within each cluster.
     """
     # Add this info to the models
     output_models = []

--- a/src/haddock/libs/libclust.py
+++ b/src/haddock/libs/libclust.py
@@ -278,6 +278,7 @@ def add_cluster_info(
     """
     # Add this info to the models
     output_models = []
+    log.warning("Reordering by cluster rank and model rank")
     for cluster_rank, _e in enumerate(sorted_score, start=1):
         cluster_id, _ = _e
         # sort the models by score

--- a/src/haddock/libs/libclust.py
+++ b/src/haddock/libs/libclust.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 import numpy as np
 from scipy.spatial.distance import squareform
+from typing import List, Tuple
 
 from haddock import log
 from haddock.core.typing import FilePath, Optional, ParamDictT, Union
@@ -252,13 +253,15 @@ def rank_clusters(clt_dic, threshold):
     return score_dic, sorted_score_dic
 
 
-def add_cluster_info(sorted_score_dic, clt_dic):
+def add_cluster_info(
+    sorted_score: List[Tuple[int, float]], clt_dic: dict[int, List[PDBFile]]
+) -> List[PDBFile]:
     """
     Add cluster information to the models.
 
     Parameters
     ----------
-    sorted_score_dic : :obj:`list`
+    sorted_score : :obj:`list`
         List of tuples with the cluster ID and the average score, sorted by
         the average score.
 
@@ -272,7 +275,7 @@ def add_cluster_info(sorted_score_dic, clt_dic):
     """
     # Add this info to the models
     output_models = []
-    for cluster_rank, _e in enumerate(sorted_score_dic, start=1):
+    for cluster_rank, _e in enumerate(sorted_score, start=1):
         cluster_id, _ = _e
         # sort the models by score
         clt_dic[cluster_id].sort()

--- a/src/haddock/libs/libclust.py
+++ b/src/haddock/libs/libclust.py
@@ -11,24 +11,23 @@ Main functions
 import os
 from pathlib import Path
 
-from haddock import log
-from haddock.core.typing import FilePath, Union, ParamDictT, Optional
-from haddock.libs.libontology import PDBFile
-from haddock.libs.libplots import heatmap_plotly
-
 import numpy as np
 from scipy.spatial.distance import squareform
 
+from haddock import log
+from haddock.core.typing import FilePath, Optional, ParamDictT, Union
+from haddock.libs.libontology import PDBFile
+from haddock.libs.libplots import heatmap_plotly
 
 MAX_NB_ENTRY_HTML_MATRIX = 3100
 
 
-def write_structure_list(input_models: list[PDBFile],
-                         clustered_models: list[PDBFile],
-                         out_fname: FilePath) -> None:
+def write_structure_list(
+    input_models: list[PDBFile], clustered_models: list[PDBFile], out_fname: FilePath
+) -> None:
     """
     Get the list of unclustered structures.
-    
+
     Parameters
     ----------
     input_models : list
@@ -37,7 +36,7 @@ def write_structure_list(input_models: list[PDBFile],
         list of clustered models
     """
     output_fname = Path(out_fname)
-    output_str = f'rank\tmodel_name\tscore\tcluster_id{os.linesep}'
+    output_str = f"rank\tmodel_name\tscore\tcluster_id{os.linesep}"
     structure_list: list[PDBFile] = []
     # checking which input models have not been clustered
     for model in input_models:
@@ -50,27 +49,26 @@ def write_structure_list(input_models: list[PDBFile],
     # adding models to output string
     for mdl_rank, mdl in enumerate(structure_list, start=1):
         output_str += (
-            f'{mdl_rank}\t{mdl.file_name}\t{mdl.score:.2f}\t{mdl.clt_id}'
-            f'{os.linesep}'
-            )
+            f"{mdl_rank}\t{mdl.file_name}\t{mdl.score:.2f}\t{mdl.clt_id}{os.linesep}"
+        )
     output_str += os.linesep
-    log.info(f'Saving structure list to {out_fname}')
-    with open(output_fname, 'w') as out_fh:
+    log.info(f"Saving structure list to {out_fname}")
+    with open(output_fname, "w") as out_fh:
         out_fh.write(output_str)
 
 
 def plot_cluster_matrix(
-        matrix_path: Union[Path, FilePath, str],
-        final_order_idx: list[int],
-        labels: list[str],
-        dttype: str = '',
-        diag_fill: Union[int, float] = 1,
-        color_scale: str = "Blues",
-        reverse: bool = False,
-        output_fname: Union[str, Path, FilePath] = 'clust_matrix',
-        matrix_cluster_dt: Optional[list[list[list[int]]]] = None,
-        cluster_limits: Optional[list[dict[str, float]]] = None,
-        ) -> Optional[str]:
+    matrix_path: Union[Path, FilePath, str],
+    final_order_idx: list[int],
+    labels: list[str],
+    dttype: str = "",
+    diag_fill: Union[int, float] = 1,
+    color_scale: str = "Blues",
+    reverse: bool = False,
+    output_fname: Union[str, Path, FilePath] = "clust_matrix",
+    matrix_cluster_dt: Optional[list[list[list[int]]]] = None,
+    cluster_limits: Optional[list[dict[str, float]]] = None,
+) -> Optional[str]:
     """Plot a plotly heatmap of a matrix file.
 
     Parameters
@@ -132,33 +130,33 @@ def plot_cluster_matrix(
 
     # Check if must reverse the colorscale
     if reverse:
-        if color_scale[-2:] == '_r':
+        if color_scale[-2:] == "_r":
             color_scale = color_scale[:-2]
         else:
-            color_scale += '_r'
+            color_scale += "_r"
 
     # Define hovering tempalte string
     if matrix_cluster_dt:
         hovertemplate = (
-            f'                                {dttype}: %{{z}} <br>'
-            f' Model1: %{{x}}    ClusterID: %{{customdata[0]}} <br>'
-            f' Model2: %{{y}}    ClusterID: %{{customdata[1]}} '
-            '<extra></extra>'
-            )
+            f"                                {dttype}: %{{z}} <br>"
+            f" Model1: %{{x}}    ClusterID: %{{customdata[0]}} <br>"
+            f" Model2: %{{y}}    ClusterID: %{{customdata[1]}} "
+            "<extra></extra>"
+        )
     else:
         hovertemplate = (
-            f'                       {dttype}: %{{z}} <br>'
-            f' Model1: %{{x}} <br>'
-            f' Model2: %{{y}} '
-            '<extra></extra>'
-            )
+            f"                       {dttype}: %{{z}} <br>"
+            f" Model1: %{{x}} <br>"
+            f" Model2: %{{y}} "
+            "<extra></extra>"
+        )
 
     # Generate file name
     output_fname_ext = f"{output_fname}.html"
     # Draw heatmap
     heatmap_plotly(
         submat,
-        labels={'color': dttype},
+        labels={"color": dttype},
         xlabels=labels,
         ylabels=labels,
         color_scale=color_scale,
@@ -167,14 +165,14 @@ def plot_cluster_matrix(
         hovertemplate=hovertemplate,
         customdata=matrix_cluster_dt,
         delineation_traces=cluster_limits,
-        )
+    )
     # Return generated filepath
     return output_fname_ext
 
 
 def get_cluster_matrix_plot_clt_dt(
-        cluster_ids: list[int],
-        ) -> tuple[list[list[list[int]]], list[dict[str, float]]]:
+    cluster_ids: list[int],
+) -> tuple[list[list[list[int]]], list[dict[str, float]]]:
     """Generate cluster matrix data for plotly.
 
     Parameters
@@ -186,15 +184,12 @@ def get_cluster_matrix_plot_clt_dt(
     -------
     matrix_cluster_dt: list[list[list[int]]]
         A matrix of cluster ids, used for plotly.
-    
+
     cluster_limits: list[dict[str, float]]]
         Boundaries to draw lines between clusters with plotly.
     """
     # Set custom data
-    matrix_cluster_dt = [
-        [[clix, cliy] for clix in cluster_ids]
-        for cliy in cluster_ids
-        ]
+    matrix_cluster_dt = [[[clix, cliy] for clix in cluster_ids] for cliy in cluster_ids]
     # Build delineation lines
     del_ind = -0.5
     del_posi = []
@@ -210,17 +205,17 @@ def get_cluster_matrix_plot_clt_dt(
             "x1": delpos,
             "y0": -0.5,
             "y1": len(cluster_ids) - 0.5,
-            }
+        }
         for delpos in del_posi
-        ] + [
-            {
-                "y0": delpos,
-                "y1": delpos,
-                "x0": -0.5,
-                "x1": len(cluster_ids) - 0.5,
-                }
-            for delpos in del_posi
-        ]
+    ] + [
+        {
+            "y0": delpos,
+            "y1": delpos,
+            "x0": -0.5,
+            "x1": len(cluster_ids) - 0.5,
+        }
+        for delpos in del_posi
+    ]
     return matrix_cluster_dt, cluster_limits
 
 
@@ -232,15 +227,15 @@ def rank_clusters(clt_dic, threshold):
     ----------
     clt_dic : :obj:`dict`
         Dictionary with the clusters.
-    
+
     threshold : int
         Number of models to consider for the average score.
-    
+
     Returns
     -------
     score_dic : :obj:`dict`
         Dictionary with the cluster ID as key and the average score as value.
-    
+
     sorted_score_dic : :obj:`list`
         List of tuples with the cluster ID and the average score, sorted by
         the average score.
@@ -252,7 +247,7 @@ def rank_clusters(clt_dic, threshold):
         denom = float(min(threshold, len(score_l)))
         top4_score = sum(score_l[:threshold]) / denom
         score_dic[clt_id] = top4_score
-    
+
     sorted_score_dic = sorted(score_dic.items(), key=lambda k: k[1])
     return score_dic, sorted_score_dic
 
@@ -266,10 +261,10 @@ def add_cluster_info(sorted_score_dic, clt_dic):
     sorted_score_dic : :obj:`list`
         List of tuples with the cluster ID and the average score, sorted by
         the average score.
-    
+
     clt_dic : :obj:`dict`
         Dictionary with the clusters.
-    
+
     Returns
     -------
     output_models : :obj:`list`
@@ -282,8 +277,7 @@ def add_cluster_info(sorted_score_dic, clt_dic):
         # sort the models by score
         clt_dic[cluster_id].sort()
         # rank the models
-        for model_ranking, pdb in enumerate(clt_dic[cluster_id],
-                                            start=1):
+        for model_ranking, pdb in enumerate(clt_dic[cluster_id], start=1):
             pdb.clt_id = int(cluster_id)
             pdb.clt_rank = cluster_rank
             pdb.clt_model_rank = model_ranking
@@ -292,8 +286,8 @@ def add_cluster_info(sorted_score_dic, clt_dic):
 
 
 def clustrmsd_tolerance_params(
-        parameters: ParamDictT,
-        ) -> tuple[str, Union[int, float]]:
+    parameters: ParamDictT,
+) -> tuple[str, Union[int, float]]:
     """Provide parameters of interest for clust rmsd.
 
     Parameters

--- a/src/haddock/modules/analysis/clustfcc/__init__.py
+++ b/src/haddock/modules/analysis/clustfcc/__init__.py
@@ -9,7 +9,9 @@ For more details about this clustering method, please check
 Proteins: Struct. Funct. Bioinform.
 80, 1810–1817 (2012)*
 
-
+Note that the output models are reordered by cluster rank and the rank within each
+cluster; this means that the order of output models of this cluster will be different
+than the input - this may be relevant for modules executed downstream.
 
 For more details about this module, please `refer to the haddock3 user manual
 <https://www.bonvinlab.org/haddock3-user-manual/modules/analysis.html#clustfcc-module>`_

--- a/src/haddock/modules/analysis/clustfcc/__init__.py
+++ b/src/haddock/modules/analysis/clustfcc/__init__.py
@@ -9,6 +9,8 @@ For more details about this clustering method, please check
 Proteins: Struct. Funct. Bioinform.
 80, 1810–1817 (2012)*
 
+
+
 For more details about this module, please `refer to the haddock3 user manual
 <https://www.bonvinlab.org/haddock3-user-manual/modules/analysis.html#clustfcc-module>`_
 """
@@ -26,14 +28,14 @@ from haddock.libs.libclust import (
     plot_cluster_matrix,
     rank_clusters,
     write_structure_list,
-    )
+)
 from haddock.libs.libfcc import (
-    calculate_pairwise_matrix,
     Cluster,
     Element,
-    parse_contact_file,
+    calculate_pairwise_matrix,
     create_elements,
-    )
+    parse_contact_file,
+)
 from haddock.libs.libsubprocess import JobInputFirst
 from haddock.modules import BaseHaddockModule, get_engine
 from haddock.modules.analysis import get_analysis_exec_mode
@@ -42,8 +44,7 @@ from haddock.modules.analysis.clustfcc.clustfcc import (
     iterate_clustering,
     write_clusters,
     write_clustfcc_file,
-    )
-
+)
 
 RECIPE_PATH = Path(__file__).resolve().parent
 DEFAULT_CONFIG = Path(RECIPE_PATH, MODULE_DEFAULT_YAML)
@@ -69,7 +70,7 @@ class HaddockModule(BaseHaddockModule):
         if not CONTACT_FCC_EXEC.exists():
             raise ModuleError(
                 f"CONTACT FCC execultable not found at: {CONTACT_FCC_EXEC}"
-                )
+            )
 
     def _run(self) -> None:
         """Execute module."""
@@ -111,9 +112,7 @@ class HaddockModule(BaseHaddockModule):
         # Check if any contact file could not be retrieved
         if not_found:
             # No contacts were calculated, we cannot cluster
-            self.finish_with_error(
-                f"Several files were not generated: {not_found}"
-                )
+            self.finish_with_error(f"Several files were not generated: {not_found}")
 
         log.info("Calculating the FCC matrix")
         parsed_contacts = parse_contact_file(
@@ -168,8 +167,9 @@ class HaddockModule(BaseHaddockModule):
 
             # ranking clusters
             _scores, sorted_score_dic = rank_clusters(
-                clt_dic, self.params["min_population"],
-                )
+                clt_dic,
+                self.params["min_population"],
+            )
 
             # Add this info to the models
             self.output_models = add_cluster_info(sorted_score_dic, clt_dic)

--- a/src/haddock/modules/analysis/clustrmsd/__init__.py
+++ b/src/haddock/modules/analysis/clustrmsd/__init__.py
@@ -30,6 +30,7 @@ matrix.
 For more details about this module, please `refer to the haddock3 user manual
 <https://www.bonvinlab.org/haddock3-user-manual/modules/analysis.html#clustrmsd-module>`_
 """
+
 from pathlib import Path
 
 from haddock import log
@@ -42,7 +43,7 @@ from haddock.libs.libclust import (
     plot_cluster_matrix,
     rank_clusters,
     write_structure_list,
-    )
+)
 from haddock.libs.libontology import ModuleIO
 from haddock.modules import BaseHaddockModule
 from haddock.modules.analysis.clustrmsd.clustrmsd import (
@@ -54,7 +55,7 @@ from haddock.modules.analysis.clustrmsd.clustrmsd import (
     read_matrix,
     write_clusters,
     write_clustrmsd_file,
-    )
+)
 
 RECIPE_PATH = Path(__file__).resolve().parent
 DEFAULT_CONFIG = Path(RECIPE_PATH, MODULE_DEFAULT_YAML)
@@ -66,11 +67,11 @@ class HaddockModule(BaseHaddockModule):
     name = RECIPE_PATH.name
 
     def __init__(
-            self,
-            order: int,
-            path: Path,
-            initial_params: Union[Path, str] = DEFAULT_CONFIG,
-            ) -> None:
+        self,
+        order: int,
+        path: Path,
+        initial_params: Union[Path, str] = DEFAULT_CONFIG,
+    ) -> None:
         super().__init__(order, path, initial_params)
 
         self.matrix_json = self._load_previous_io("rmsd_matrix.json")
@@ -96,31 +97,31 @@ class HaddockModule(BaseHaddockModule):
         # adjust the parameters
         tolerance_param_name, tolerance = clustrmsd_tolerance_params(
             self.params,
-            )
-        
+        )
+
         log.info(
             f"Clustering with {tolerance_param_name} = {tolerance}, "
             f"and criterion {self.params['criterion']}"
-            )
-        
+        )
+
         cluster_arr = get_clusters(
             dendrogram,
             tolerance,
             self.params["criterion"],
-            )
+        )
 
         # when crit == distance, apply clustering min_population
-        if self.params['criterion'] == "distance":
+        if self.params["criterion"] == "distance":
             cluster_arr, min_population = iterate_min_population(
                 cluster_arr,
-                self.params['min_population'],
-                )
-            self.params['min_population'] = min_population
-        
+                self.params["min_population"],
+            )
+            self.params["min_population"] = min_population
+
         clusters, cluster_arr = order_clusters(cluster_arr)
         log.info(f"clusters = {clusters}")
-        
-        out_filename = Path('cluster.out')
+
+        out_filename = Path("cluster.out")
         clt_dic, cluster_centers = write_clusters(
             clusters,
             cluster_arr,
@@ -128,23 +129,23 @@ class HaddockModule(BaseHaddockModule):
             rmsd_matrix,
             out_filename,
             centers=True,
-            )
+        )
 
         # ranking clusters
         score_dic, sorted_score_dic = rank_clusters(
             clt_dic,
-            self.params['min_population'],
-            )
+            self.params["min_population"],
+        )
 
         self.output_models = add_cluster_info(sorted_score_dic, clt_dic)
-        
+
         # Write unclustered structures
         write_structure_list(
             models,
             self.output_models,
             out_fname="clustrmsd.tsv",
-            )  # type: ignore
-        
+        )  # type: ignore
+
         write_clustrmsd_file(
             clusters,
             clt_dic,
@@ -152,35 +153,35 @@ class HaddockModule(BaseHaddockModule):
             score_dic,
             sorted_score_dic,
             self.params,
-            )
+        )
 
         # Draw the matrix
-        if self.params['plot_matrix']:
+        if self.params["plot_matrix"]:
             # Obtain final models indices
             final_order_idx, labels, cluster_ids = [], [], []
             for pdb in self.output_models:
                 final_order_idx.append(models.index(pdb))
-                labels.append(pdb.file_name.replace('.pdb', ''))
+                labels.append(pdb.file_name.replace(".pdb", ""))
                 cluster_ids.append(pdb.clt_id)
             # Get custom cluster data
             matrix_cluster_dt, cluster_limits = get_cluster_matrix_plot_clt_dt(
                 cluster_ids
-                )
+            )
 
             # Define output filename
-            html_matrix_basepath = 'rmsd_matrix'
+            html_matrix_basepath = "rmsd_matrix"
             # Plot matrix
             html_matrixpath = plot_cluster_matrix(
                 get_matrix_path(self.matrix_json.input[0]),
                 final_order_idx,
                 labels,
-                dttype='RMSD(Å)',
+                dttype="RMSD(Å)",
                 reverse=True,
                 diag_fill=0,
                 output_fname=html_matrix_basepath,
                 matrix_cluster_dt=matrix_cluster_dt,
                 cluster_limits=cluster_limits,
-                )
+            )
             if html_matrixpath:
                 log.info(f"Plotting matrix in {html_matrixpath}")
             else:

--- a/src/haddock/modules/analysis/clustrmsd/__init__.py
+++ b/src/haddock/modules/analysis/clustrmsd/__init__.py
@@ -25,6 +25,10 @@ workflow through the `rmsd_matrix.json` file, thus allowing to execute several
 `clustrmsd` modules (possibly with different parameters) on the same RMSD
 matrix.
 
+Note that the output models are reordered by cluster rank and the rank within each
+cluster; this means that the order of output models of this cluster will be different
+than the input - this may be relevant for modules executed downstream.
+
 .. _scipy routines: https://docs.scipy.org/doc/scipy/reference/cluster.hierarchy.html
 
 For more details about this module, please `refer to the haddock3 user manual

--- a/src/haddock/modules/analysis/clustrmsd/__init__.py
+++ b/src/haddock/modules/analysis/clustrmsd/__init__.py
@@ -20,10 +20,13 @@ Four parameters can be defined in this context:
 * `min_population` : set the minimum number of models that should be present
   in a cluster to consider it. If criterion is `maxclust`, the value is ignored.
 
-This module passes the path to the RMSD matrix is to the next step of the
-workflow through the `rmsd_matrix.json` file, thus allowing to execute several
-`clustrmsd` modules (possibly with different parameters) on the same RMSD
-matrix.
+This module passes the path to the RMSD matrix to the next step of the
+workflow through the `rmsd_matrix.json` file. Note that this does **not**
+mean several `clustrmsd` modules can be chained (possibly with different
+parameters) on the same RMSD matrix within a single continuous workflow run
+- doing so leads to a mismatched model-cluster mapping. To re-cluster an
+already computed matrix with different parameters without recomputing it,
+use `haddock3-re` or the `--restart` option instead.
 
 Note that the output models are reordered by cluster rank and the rank within each
 cluster; this means that the order of output models of this cluster will be different

--- a/tests/test_libclust.py
+++ b/tests/test_libclust.py
@@ -1,15 +1,19 @@
 """Test the libclust library."""
+
 import os
-from pathlib import Path
-import pytest
 import random
 import tempfile
+from pathlib import Path
+from typing import cast
+
+import pytest
 
 from haddock.libs.libclust import (
     MAX_NB_ENTRY_HTML_MATRIX,
+    add_cluster_info,
     plot_cluster_matrix,
     write_structure_list,
-    )
+)
 from haddock.libs.libontology import PDBFile
 
 from . import golden_data
@@ -20,16 +24,12 @@ def protprot_input_models():
     """Prot-prot input."""
     return [
         PDBFile(
-            Path(golden_data, "protprot_complex_1.pdb"),
-            path=golden_data,
-            score=-42
-            ),
+            Path(golden_data, "protprot_complex_1.pdb"), path=golden_data, score=-42
+        ),
         PDBFile(
-            Path(golden_data, "protprot_complex_2.pdb"),
-            path=golden_data,
-            score=-17
-            )
-        ]
+            Path(golden_data, "protprot_complex_2.pdb"), path=golden_data, score=-17
+        ),
+    ]
 
 
 @pytest.fixture
@@ -38,7 +38,7 @@ def big_distance_matrix_data():
     bigmatrix = []
     for i in range(1, MAX_NB_ENTRY_HTML_MATRIX + 1):
         for j in range(i + 1, MAX_NB_ENTRY_HTML_MATRIX + 2):
-            bigmatrix.append(f'{i}\t{j}\t{random.random():.2f}')
+            bigmatrix.append(f"{i}\t{j}\t{random.random():.2f}")
     return bigmatrix
 
 
@@ -49,7 +49,7 @@ def small_distance_matrix_data():
     matrix = []
     for i in range(1, small):
         for j in range(i + 1, small + 1):
-            matrix.append(f'{i}\t{j}\t{random.random():.2f}')
+            matrix.append(f"{i}\t{j}\t{random.random():.2f}")
     return matrix
 
 
@@ -62,11 +62,11 @@ def test_write_structure_list(protprot_input_models):
     write_structure_list(protprot_input_models, clustered_models, cl_fname)
     observed_file_content = open(cl_fname, "r").read()
     expected_file_content = (
-        f'rank\tmodel_name\tscore\tcluster_id{os.linesep}'
-        f'1\tprotprot_complex_1.pdb\t-42.00\t1{os.linesep}'
-        f'2\tprotprot_complex_2.pdb\t-17.00\t-{os.linesep}'
-        f'{os.linesep}'
-        )
+        f"rank\tmodel_name\tscore\tcluster_id{os.linesep}"
+        f"1\tprotprot_complex_1.pdb\t-42.00\t1{os.linesep}"
+        f"2\tprotprot_complex_2.pdb\t-17.00\t-{os.linesep}"
+        f"{os.linesep}"
+    )
     assert observed_file_content == expected_file_content
     os.unlink(cl_fname)
 
@@ -75,9 +75,9 @@ def test_plot_cluster_matrix_big(big_distance_matrix_data):
     """Test test_plot_cluster_matrix_big function with big matrix."""
     with tempfile.TemporaryDirectory(dir=".") as tmpdir:
         # Write matrix
-        matrix_path = f'{tmpdir}bigmatrix.mat'
-        with open(matrix_path, 'w') as f:
-            f.write('\n'.join(big_distance_matrix_data))
+        matrix_path = f"{tmpdir}bigmatrix.mat"
+        with open(matrix_path, "w") as f:
+            f.write("\n".join(big_distance_matrix_data))
         # Run function
         figure_path = plot_cluster_matrix(
             matrix_path,
@@ -88,7 +88,7 @@ def test_plot_cluster_matrix_big(big_distance_matrix_data):
             color_scale="Blues",
             reverse=False,
             output_fname="clust_matrix_test_big",
-            )
+        )
         # Check output
         assert figure_path is None
         assert not Path("clust_matrix_test_big.html").exists()
@@ -99,23 +99,60 @@ def test_plot_cluster_matrix(small_distance_matrix_data):
     """Test test_plot_cluster_matrix_big function with small matrix."""
     with tempfile.TemporaryDirectory(dir=".") as tmpdir:
         # Write matrix
-        matrix_path = f'{tmpdir}smallmatrix.mat'
-        with open(matrix_path, 'w') as f:
-            f.write('\n'.join(small_distance_matrix_data))
+        matrix_path = f"{tmpdir}smallmatrix.mat"
+        with open(matrix_path, "w") as f:
+            f.write("\n".join(small_distance_matrix_data))
         # Run function
         figure_path = plot_cluster_matrix(
             matrix_path,
             list(range(10)),
             [str(i + 1) for i in range(10)],
-            dttype='random',
+            dttype="random",
             diag_fill=0.5,
             color_scale="Blues",
             reverse=True,
-            output_fname='clust_matrix_test_small',
-            )
+            output_fname="clust_matrix_test_small",
+        )
         # Check output
         assert os.path.exists(figure_path)
         assert Path(figure_path).stat().st_size != 0
-        assert Path(figure_path).suffix == '.html'
+        assert Path(figure_path).suffix == ".html"
         Path(figure_path).unlink(missing_ok=False)
         Path(matrix_path).unlink(missing_ok=False)
+
+
+def test_add_cluster_info(protprot_input_models):
+    # create cluster information
+    # [(cluster_id, average-score)]
+    input_l = [(1, +1.0), (2, -1.0)]
+
+    # Create some PDBs
+    input_pdbs = [
+        PDBFile(file_name=f"{i}.pdb", score=float(random.randint(-500, 0)))
+        for i in range(10)
+    ]
+
+    # Make sure the PDBFiles are not created with any cluster information
+    for p in input_pdbs:
+        assert p.clt_id is None
+        assert p.clt_rank is None
+        assert p.clt_model_rank is None
+
+    # split so we get two sets of models
+    mid = len(input_pdbs) // 2
+    pdbs_cluster_1 = input_pdbs[mid:]
+    pdbs_cluster_2 = input_pdbs[:mid]
+
+    observed = add_cluster_info(input_l, clt_dic={1: pdbs_cluster_1, 2: pdbs_cluster_2})
+
+    # assert that the cluster information was added to the models
+    for p in observed:
+        assert p.clt_id is not None
+        assert p.clt_rank is not None
+        assert p.clt_model_rank is not None
+
+    # assert the order has changed
+    assert observed[0] != input_pdbs[0]
+
+    # check they were properly sorted
+    assert cast(float, observed[0].score) < cast(float, observed[-1].score)


### PR DESCRIPTION
> Before submitting, read the [contributing guidelines](CONTRIBUTING.md) and the [AI policy](AI-POLICY.md).

## What does this PR do and why?
<!-- Please explain what you did in this PR -->

The modules use `libclust.add_cluster_info` to append cluster data to a group of `PDBFile`s, however this functions does more things than its described in its docstring. Not only it will add the cluster data but it will also re-order it's output both by cluster ranking and model ranking within each cluster. This is the desired behaviour but it was not properly documented.

This PR changes the module description of both `clustfcc` and `clustrmsd` to make this clear and I also added type signatures to `libcluster.add_cluster_info` and a test since it was uncovered.

## How was this tested?
<!-- Explain how the changes were verified -->

Added new test

## AI assistance
<!-- Did AI tools play a meaningful role in this PR? If so, note what they helped with and how you verified the output. Leave blank if not applicable. -->

None

## Checklist

- [x] Tests cover the new and/or changed code
- [x] Documentation updated if needed (also in the [haddock3 user-manual](https://github.com/haddocking/haddock3-user-manual)
- ~[ ] `CHANGELOG.md` updated for user-facing changes~

## Related issues
<!-- Link any relevant GitHub issues or user-manual PRs -->

#1650

## Notes for reviewers
<!-- Anything that needs special attention, known limitations, or follow-up work -->

It a bit messy because of the re-formatting, the important commits were these: https://github.com/haddocking/haddock3/pull/1653/changes/9c4303e1ec4647c43f24a62fc60f351195721dfe, https://github.com/haddocking/haddock3/pull/1653/changes/2acd722225d975ae97090b2b4e74e4307770e29b, https://github.com/haddocking/haddock3/pull/1653/changes/9dc8613d6d678ed7cd9402778fcb1a5a064cb926, https://github.com/haddocking/haddock3/pull/1653/changes/25f5b84bccb695ae1c83fd57dfdeb2ce6c7d3f1a
