### PR TITLE
Restrict scheduler task error handling

### DIFF
--- a/src/haddock/core/exceptions.py
+++ b/src/haddock/core/exceptions.py
@@ -10,6 +10,12 @@ class HaddockError(Exception):
     pass
 
 
+class HaddockTaskExecutionError(HaddockError):
+    """Expected error while executing a scheduled HADDOCK task."""
+
+    pass
+
+
 class ConfigurationError(HaddockError):
     """Error in the configuration file."""
 
@@ -34,7 +40,7 @@ class JobRunningError(HaddockError):
     pass
 
 
-class CNSRunningError(HaddockError):
+class CNSRunningError(HaddockTaskExecutionError):
     """CNS run error."""
 
     pass

--- a/src/haddock/libs/libparallel.py
+++ b/src/haddock/libs/libparallel.py
@@ -4,6 +4,7 @@ import math
 from multiprocessing import Process, Queue
 
 from haddock import log
+from haddock.core.exceptions import HaddockTaskExecutionError
 from haddock.core.typing import (
     AnyT,
     FilePath,
@@ -88,7 +89,7 @@ class Worker(Process):
             r = None
             try:
                 r = task.run()
-            except Exception as e:
+            except HaddockTaskExecutionError as e:
                 log.warning(f"Exception in task execution: {e}")
 
             results.append(r)

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,10 +1,20 @@
 """Test exceptions module."""
 import pytest
 
-from haddock.core.exceptions import CNSRunningError
+from haddock.core.exceptions import (
+    CNSRunningError,
+    HaddockError,
+    HaddockTaskExecutionError,
+)
 
 
 def test_cns_error():
     """Test CNS error."""
     with pytest.raises(CNSRunningError):
         raise CNSRunningError(b'something')
+
+
+def test_cns_error_is_a_task_execution_error():
+    """CNS failures can be tolerated by task schedulers."""
+    assert issubclass(CNSRunningError, HaddockTaskExecutionError)
+    assert issubclass(HaddockTaskExecutionError, HaddockError)

--- a/tests/test_libparallel.py
+++ b/tests/test_libparallel.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 
+from haddock.core.exceptions import HaddockTaskExecutionError
 from haddock.libs.libparallel import (
     GenericTask,
     Scheduler,
@@ -50,7 +51,12 @@ class TaskWithException:
         pass
 
     def run(self):
-        raise ValueError("Test error")
+        raise HaddockTaskExecutionError("Test error")
+
+
+class TaskWithUnexpectedException:
+    def run(self):
+        raise ValueError("Unexpected test error")
 
 
 @pytest.fixture
@@ -166,6 +172,12 @@ def test_scheduler_with_exception(scheduler_with_exception):
     assert scheduler_with_exception.results[0] == 2
     assert scheduler_with_exception.results[1] is None
     assert scheduler_with_exception.results[2] == 4
+
+
+def test_worker_propagates_unexpected_exception():
+    worker = Worker(tasks=[TaskWithUnexpectedException()], results=Queue())
+    with pytest.raises(ValueError, match="Unexpected test error"):
+        worker.run()
 
 
 def test_generic_task_init():


### PR DESCRIPTION
> Before submitting, read the [contributing guidelines](CONTRIBUTING.md) and the [AI policy](AI-POLICY.md).

## What does this PR do and why?
The libparallel scheduler catches exceptions and counts them toward tolerance. However, it catches ALL exceptions, not just the ones that are CNS/task related. This PR defines a proper exception class for that, and makes the scheduler catch only those.

## How was this tested?
Unit tests by the AI. 

## AI assistance
Implementation by Codex 5.6 Sol under my direction. I inspected every line by hand. 

## Checklist

- [X] Tests cover the new and/or changed code
- [ ] Documentation updated if needed (also in the [haddock3 user-manual](https://github.com/haddocking/haddock3-user-manual)
- [ ] `CHANGELOG.md` updated for user-facing changes
