### PR TITLE
Add .dockerignore to reduce Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,216 @@
+# Mirrored from .gitignore
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+.DS_Store
+
+# vim
+tags
+.vim
+
+# VSCode
+.vscode
+
+# Binaries
+src/haddock/bin/cns
+src/haddock/bin/contact_fcc
+src/haddock/bin/fast-rmsdmatrix
+src/haddock/bin/haddock-restraints
+
+# ignore generated data of the examples
+examples/*/run*
+examples/*/capriscoring-test/*
+examples/thirdparty/*/run*
+
+# ignore generated data for docs
+haddock3-docs/
+docs/src/
+log
+end-to-end_tests/ab-grid
+end-to-end_tests/prot-grid
+
+# Docker-specific
+# Git history and metadata
+.git/
+.gitignore
+
+# Environment files — never bake secrets into the image
+.env
+.env.*
+!.env.example
+
+# Documentation
+*.md
+docs/
+LICENSE
+CHANGELOG*
+
+# CI/CD configuration
+.github/
+.gitlab/
+
+# Docker tooling
+docker-compose.yml
+docker-compose*.yml
+.dockerignore
+
+# Development tooling
+Makefile
+.editorconfig
+
+# Test suites and coverage
+tests/
+test/
+spec/
+__tests__/
+coverage/
+.pytest_cache/
+.nyc_output/
+
+# Language runtime caches
+node_modules/
+__pycache__/
+*.pyc
+.venv/
+venv/
+vendor/
+
+# Build artefacts
+dist/
+build/
+target/
+out/
+
+# IDE and OS files
+.idea/
+.vscode/
+.DS_Store
+*.swp
+*.log


### PR DESCRIPTION
Add a `.dockerignore` file so that `docker build` only copies what the image actually needs.

Without `.dockerignore`, every `COPY . .` in the Dockerfile sends the full working tree to the Docker daemon — including `.git/`, test suites, docs, IDE config, and build artifacts. This bloats the build context (and therefore build time and layer size) unnecessarily.

The file mirrors patterns already present in `.gitignore` (byte-compiled files, virtual envs, dist artefacts, notebooks checkpoints, etc.) and adds Docker-specific exclusions for development tooling, CI config, documentation, and test directories that have no place in a production image.

No Python source files are touched, so CI only triggers the `docker-build` job.

This change was generated by [Autar](https://autar.ai) and reviewed by a human before submission.
