### PR TITLE
Added mpi and grid execution modes to general default.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- 2026-09-09: Adding missing execution modes to default.yaml - Issue #1690
 - 2026-09-02: Fixed identical seed per sampling_factor replica in flexref, mdref and emref - Issue #1685
 - 2026-08-05: Harmonised running mode of test config files - Issue #1655
 - 2026-08-10: Added missing improper for HYP - Issue #1662

--- a/src/haddock/modules/__init__.py
+++ b/src/haddock/modules/__init__.py
@@ -399,7 +399,7 @@ class BaseHaddockModule(ABC):
                 self._params[param] = EmptyPath()
 
 
-EngineMode = Literal["batch", "local", "mpi"]
+EngineMode = Literal["batch", "local", "mpi", "grid"]
 
 
 def get_engine(

--- a/src/haddock/modules/defaults.yaml
+++ b/src/haddock/modules/defaults.yaml
@@ -41,11 +41,15 @@ mode:
   choices:
     - local
     - batch
+    - mpi
+    - grid
   title: Mode of execution
-  short: Mode of execution of the jobs, either local or using a batch system.
-  long: Mode of execution of the jobs, either local or using a batch system.
-    Currently slurm and torque are supported. For the batch mode the queue command must be
-    specified in the queue parameter.
+  short: Mode of execution of the jobs, either local, or using a batch system, MPI or the grid.
+  long: Mode of execution of the jobs. With local the jobs run as concurrent processes on the
+    current machine. With batch they are submitted to a batch system; currently slurm and torque
+    are supported and the queue command must be specified in the queue parameter. With mpi they
+    are distributed over MPI, which requires the mpi optional dependencies to be installed. With
+    grid they are submitted to the DIRAC grid, falling back to local if the grid is unreachable.
   group: "execution"
   explevel: easy
 batch_type:


### PR DESCRIPTION
## What does this PR do and why?

The default.yaml file in `src/haddock/modules/` defined the exectution modes. It was missing the mpi and grid modes.
This PR corrects that.

## AI assistance

Claude actually identified the issue when analysing the code.

## Checklist

- [X] Tests cover the new and/or changed code
- [ ] Documentation updated if needed (also in the [haddock3 user-manual](https://github.com/haddocking/haddock3-user-manual)
- [X] `CHANGELOG.md` updated for user-facing changes

## Related issues

#1690

## Notes for reviewers

Note that this default.yaml file is currently not checked when assessing the validity of a workflow toml file. As such mpi and grid modes were accepted. This will be handled separately.